### PR TITLE
[topic/40730] Use strlen() instead of count() in function _equals() of C...

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1791,7 +1791,7 @@ class Crypt_RSA {
      */
     function _equals($x, $y)
     {
-        if (count($x) != count($y)) {
+        if (strlen($x) != strlen($y)) {
             return false;
         }
 


### PR DESCRIPTION
...rypt_RSA.

It appears that count() always returns int(1) on strings. Thus, this check is
pointless as is. strlen() was meant here and is actually required to prevent
E_NOTICEs from invalid array accesses using $y[$i].

As per http://www.frostjedi.com/phpbb/viewtopic.php?f=46&t=40730
