### PR TITLE
Switch to using calculated absolution path for requires.

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -67,7 +67,7 @@
  * Include Crypt_Rijndael
  */
 if (!class_exists('Crypt_Rijndael')) {
-    require_once 'Rijndael.php';
+    require_once dirname( __FILE__ ).'/Rijndael.php';
 }
 
 /**#@+

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -398,7 +398,7 @@ class Crypt_DES {
                 }
 
                 if (!class_exists('Crypt_Hash')) {
-                    require_once('Crypt/Hash.php');
+                    require_once(dirname( __FILE__ ).'/Hash.php');
                 }
 
                 $i = 1;

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -560,7 +560,7 @@ class Crypt_Hash {
     function _sha512($m)
     {
         if (!class_exists('Math_BigInteger')) {
-            require_once('Math/BigInteger.php');
+            require_once(dirname( __FILE__ ).'/../Math/BigInteger.php');
         }
 
         static $init384, $init512, $k;

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -267,7 +267,7 @@ class Crypt_RC4 {
                 }
 
                 if (!class_exists('Crypt_Hash')) {
-                    require_once('Crypt/Hash.php');
+                    require_once(dirname( __FILE__ ).'/../Crypt/Hash.php');
                 }
 
                 $i = 1;

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -72,17 +72,17 @@
 /**
  * Include Math_BigInteger
  */
-require_once('Math/BigInteger.php');
+require_once(dirname( __FILE__ )'/../Math/BigInteger.php');
 
 /**
  * Include Crypt_Random
  */
-require_once('Crypt/Random.php');
+require_once(dirname( __FILE__ )'/Random.php');
 
 /**
  * Include Crypt_Hash
  */
-require_once('Crypt/Hash.php');
+require_once(dirname( __FILE__ )'/Hash.php');
 
 /**#@+
  * @access public
@@ -697,7 +697,7 @@ class Crypt_RSA {
                     $private.= $this->_random(16 - (strlen($private) & 15));
                     $source.= pack('Na*', strlen($private), $private);
                     if (!class_exists('Crypt_AES')) {
-                        require_once('Crypt/AES.php');
+                        require_once(dirname( __FILE__ )'/AES.php');
                     }
                     $sequence = 0;
                     $symkey = '';
@@ -718,7 +718,7 @@ class Crypt_RSA {
                 $key.= 'Private-Lines: ' . ((strlen($private) + 32) >> 6) . "\r\n";
                 $key.= chunk_split($private, 64);
                 if (!class_exists('Crypt_Hash')) {
-                    require_once('Crypt/Hash.php');
+                    require_once(dirname( __FILE__ )'/Hash.php');
                 }
                 $hash = new Crypt_Hash('sha1');
                 $hash->setKey(pack('H*', sha1($hashkey)));
@@ -758,7 +758,7 @@ class Crypt_RSA {
                     $symkey = pack('H*', md5($this->password . $iv)); // symkey is short for symmetric key
                     $symkey.= substr(pack('H*', md5($symkey . $this->password . $iv)), 0, 8);
                     if (!class_exists('Crypt_TripleDES')) {
-                        require_once('Crypt/TripleDES.php');
+                        require_once(dirname( __FILE__ )'/TripleDES.php');
                     }
                     $des = new Crypt_TripleDES();
                     $des->setKey($symkey);
@@ -913,26 +913,26 @@ class Crypt_RSA {
                     switch ($matches[1]) {
                         case 'AES-128-CBC':
                             if (!class_exists('Crypt_AES')) {
-                                require_once('Crypt/AES.php');
+                                require_once(dirname( __FILE__ )'/AES.php');
                             }
                             $symkey = substr($symkey, 0, 16);
                             $crypto = new Crypt_AES();
                             break;
                         case 'DES-EDE3-CFB':
                             if (!class_exists('Crypt_TripleDES')) {
-                                require_once('Crypt/TripleDES.php');
+                                require_once(dirname( __FILE__ )'/TripleDES.php');
                             }
                             $crypto = new Crypt_TripleDES(CRYPT_DES_MODE_CFB);
                             break;
                         case 'DES-EDE3-CBC':
                             if (!class_exists('Crypt_TripleDES')) {
-                                require_once('Crypt/TripleDES.php');
+                                require_once(dirname( __FILE__ )'/TripleDES.php');
                             }
                             $crypto = new Crypt_TripleDES();
                             break;
                         case 'DES-CBC':
                             if (!class_exists('Crypt_DES')) {
-                                require_once('Crypt/DES.php');
+                                require_once(dirname( __FILE__ )'/DES.php');
                             }
                             $crypto = new Crypt_DES();
                             break;
@@ -1137,7 +1137,7 @@ class Crypt_RSA {
                 switch ($encryption) {
                     case 'aes256-cbc':
                         if (!class_exists('Crypt_AES')) {
-                            require_once('Crypt/AES.php');
+                            require_once(dirname( __FILE__ )'/AES.php');
                         }
                         $symkey = '';
                         $sequence = 0;

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -610,7 +610,7 @@ class Crypt_Rijndael {
                 }
 
                 if (!class_exists('Crypt_Hash')) {
-                    require_once('Crypt/Hash.php');
+                    require_once(dirname( __FILE__ ).'/../Crypt/Hash.php');
                 }
 
                 $i = 1;

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -58,7 +58,7 @@
  * Include Crypt_DES
  */
 if (!class_exists('Crypt_DES')) {
-    require_once('DES.php');
+    require_once(dirname( __FILE__ )'/DES.php');
 }
 
 /**
@@ -394,7 +394,7 @@ class Crypt_TripleDES {
                 }
 
                 if (!class_exists('Crypt_Hash')) {
-                    require_once('Crypt/Hash.php');
+                    require_once(dirname( __FILE__ )'/Hash.php');
                 }
 
                 $i = 1;

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -44,7 +44,7 @@
 /**
  * Include Math_BigInteger
  */
-require_once('Math/BigInteger.php');
+require_once(dirname( __FILE__ )'/../Math/BigInteger.php');
 
 /**#@+
  * Tag Classes

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -48,7 +48,7 @@
  * Include File_ASN1
  */
 if (!class_exists('File_ASN1')) {
-    require_once('File/ASN1.php');
+    require_once(dirname( __FILE__ )'/ASN1.php');
 }
 
 /**
@@ -1664,7 +1664,7 @@ class File_X509 {
         switch ($publicKeyAlgorithm) {
             case 'rsaEncryption':
                 if (!class_exists('Crypt_RSA')) {
-                    require_once('Crypt/RSA.php');
+                    require_once(dirname( __FILE__ )'/../Crypt/RSA.php');
                 }
                 $rsa = new Crypt_RSA();
                 $rsa->loadKey($publicKey);
@@ -2029,7 +2029,7 @@ class File_X509 {
         switch ($this->currentCert['tbsCertificate']['subjectPublicKeyInfo']['algorithm']['algorithm']) {
             case 'rsaEncryption':
                 if (!class_exists('Crypt_RSA')) {
-                    require_once('Crypt/RSA.php');
+                    require_once(dirname( __FILE__ )'/../Crypt/RSA.php');
                 }
                 $publicKey = new Crypt_RSA();
                 $publicKey->loadKey($key);
@@ -2080,7 +2080,7 @@ class File_X509 {
         switch ($algorithm) {
             case 'rsaEncryption':
                 if (!class_exists('Crypt_RSA')) {
-                    require_once('Crypt/RSA.php');
+                    require_once(dirname( __FILE__ )'/../Crypt/RSA.php');
                 }
                 $this->publicKey = new Crypt_RSA();
                 $this->publicKey->loadKey($key);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -58,7 +58,7 @@
  * Include Net_SSH2
  */
 if (!class_exists('Net_SSH2')) {
-    require_once('Net/SSH2.php');
+    require_once(dirname( __FILE__ )'/SSH2.php');
 }
 
 /**#@+

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -72,40 +72,40 @@
  * Used to do RSA encryption.
  */
 if (!class_exists('Math_BigInteger')) {
-    require_once('Math/BigInteger.php');
+    require_once(dirname( __FILE__ )'/../Math/BigInteger.php');
 }
 
 /**
  * Include Crypt_Null
  */
-//require_once('Crypt/Null.php');
+//require_once(dirname( __FILE__ )'/../Crypt/Null.php');
 
 /**
  * Include Crypt_DES
  */
 if (!class_exists('Crypt_DES')) {
-    require_once('Crypt/DES.php');
+    require_once(dirname( __FILE__ )'/../Crypt/DES.php');
 }
 
 /**
  * Include Crypt_TripleDES
  */
 if (!class_exists('Crypt_TripleDES')) {
-    require_once('Crypt/TripleDES.php');
+    require_once(dirname( __FILE__ )'/../Crypt/TripleDES.php');
 }
 
 /**
  * Include Crypt_RC4
  */
 if (!class_exists('Crypt_RC4')) {
-    require_once('Crypt/RC4.php');
+    require_once(dirname( __FILE__ )'/../Crypt/RC4.php');
 }
 
 /**
  * Include Crypt_Random
  */
 if (!class_exists('Crypt_Random')) {
-    require_once('Crypt/Random.php');
+    require_once(dirname( __FILE__ )'/../Crypt/Random.php');
 }
 
 /**#@+
@@ -1184,7 +1184,7 @@ class Net_SSH1 {
     {
         /*
         if (!class_exists('Crypt_RSA')) {
-            require_once('Crypt/RSA.php');
+            require_once(dirname( __FILE__ )'/../Crypt/RSA.php');
         }
 
         $rsa = new Crypt_RSA();

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -74,42 +74,42 @@
  * Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
  */
 if (!class_exists('Math_BigInteger')) {
-    require_once('Math/BigInteger.php');
+    require_once(dirname( __FILE__ )'/../Math/BigInteger.php');
 }
 
 /**
  * Include Crypt_Random
  */
 if (!class_exists('Crypt_Random')) {
-    require_once('Crypt/Random.php');
+    require_once(dirname( __FILE__ )'/../Crypt/Random.php');
 }
 
 /**
  * Include Crypt_Hash
  */
 if (!class_exists('Crypt_Hash')) {
-    require_once('Crypt/Hash.php');
+    require_once(dirname( __FILE__ )'/../Crypt/Hash.php');
 }
 
 /**
  * Include Crypt_TripleDES
  */
 if (!class_exists('Crypt_TripleDES')) {
-    require_once('Crypt/TripleDES.php');
+    require_once(dirname( __FILE__ )'/../Crypt/TripleDES.php');
 }
 
 /**
  * Include Crypt_RC4
  */
 if (!class_exists('Crypt_RC4')) {
-    require_once('Crypt/RC4.php');
+    require_once(dirname( __FILE__ )'/../Crypt/RC4.php');
 }
 
 /**
  * Include Crypt_AES
  */
 if (!class_exists('Crypt_AES')) {
-    require_once('Crypt/AES.php');
+    require_once(dirname( __FILE__ )'/../Crypt/AES.php');
 }
 
 /**#@+
@@ -2803,7 +2803,7 @@ class Net_SSH2 {
                 $signature = $this->_string_shift($signature, $temp['length']);
 
                 if (!class_exists('Crypt_RSA')) {
-                    require_once('Crypt/RSA.php');
+                    require_once(dirname( __FILE__ )'/../Crypt/RSA.php');
                 }
 
                 $rsa = new Crypt_RSA();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,16 +5,9 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-// Set up include path accordingly. This is especially required because some
-// class files of phpseclib require() other dependencies.
-set_include_path(implode(PATH_SEPARATOR, array(
-	dirname(__FILE__) . '/../phpseclib/',
-	get_include_path(),
-)));
-
 function phpseclib_autoload($class)
 {
-	$file = str_replace('_', '/', $class) . '.php';
+	$file = dirname( dirname( __FILE__ ) )."/phpseclib/".str_replace('_', '/', $class) . '.php';
 
 	require $file;
 }


### PR DESCRIPTION
While there will be a small overhead added for this change it helps remove errors that can happen if `set_include_path` isn't set. In my case we didn't want to use `set_include_path` for libraries because it increase the number of `stat` calls done by PHP during the require of any other relative path.

This patch should be fully backwards compatible with people using `set_include_path`.
