### PR TITLE
[task/fix-test-autoloader] Fix autoloader to support failing/erroring te...

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,14 +9,34 @@
 // class files of phpseclib require() other dependencies.
 set_include_path(implode(PATH_SEPARATOR, array(
 	dirname(__FILE__) . '/../phpseclib/',
+	dirname(__FILE__) . '/',
 	get_include_path(),
 )));
+
+function phpseclib_is_includable($suffix)
+{
+	foreach (explode(PATH_SEPARATOR, get_include_path()) as $prefix)
+	{
+		$ds = substr($prefix, -1) == DIRECTORY_SEPARATOR ? '' : DIRECTORY_SEPARATOR;
+		$file = $prefix . $ds . $suffix;
+
+		if (file_exists($file))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
 
 function phpseclib_autoload($class)
 {
 	$file = str_replace('_', '/', $class) . '.php';
 
-	require $file;
+	if (phpseclib_is_includable($file))
+	{
+		require $file;
+	}
 }
 
 spl_autoload_register('phpseclib_autoload');


### PR DESCRIPTION
...sts.

Before showing error output PHPUnit 3.7.x calls class_exists() on some PHPUnit
Extension class names that may not exist. Calling class_exists() already
triggers the autoload function in which require() then obviously fails.

We now check whether a file is includable by simply looping over all possible
include directories.
