### PR TITLE
AES: Fixed CFB decrypt() using MODE_MCRYPT and ContinuousBuffer

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -337,12 +337,11 @@ class Crypt_AES extends Crypt_Rijndael {
                     }
                     $ciphertext.= mcrypt_generic($this->enmcrypt, substr($plaintext, $i, $len - $len % 16));
                     $iv = substr($ciphertext, -16);
-                    $i = strlen($ciphertext);
                     $len%= 16;
                 }
                 if ($len) {
                     $iv = mcrypt_generic($this->ecb, $iv);
-                    $block = substr($iv, $pos) ^ substr($plaintext, $i);
+                    $block = $iv ^ substr($plaintext, -$len);
                     $iv = substr_replace($iv, $block, 0, $len);
                     $ciphertext.= $block;
                     $pos = $len;
@@ -412,7 +411,6 @@ class Crypt_AES extends Crypt_Rijndael {
                     // ie. $i = min($max, $len), $len-= $i, $pos+= $i, $pos%= $blocksize
                     $plaintext = substr($iv, $orig_pos) ^ $ciphertext;
                     $iv = substr_replace($iv, substr($ciphertext, 0, $i), $orig_pos, $i);
-                    $this->debuffer['demcrypt_init'] = true;
                 }
                 if ($len >= 16) {
                     $cb = substr($ciphertext, $i, $len - $len % 16);
@@ -422,8 +420,8 @@ class Crypt_AES extends Crypt_Rijndael {
                 }
                 if ($len) {
                     $iv = mcrypt_generic($this->ecb, $iv);
-                    $plaintext.= substr($iv, $pos) ^ substr($ciphertext, $i);
-                    $iv = substr_replace($iv, substr($ciphertext, $i, $len), 0, $len);
+                    $plaintext.= $iv ^ substr($ciphertext, -$len);
+                    $iv = substr_replace($iv, substr($ciphertext, -$len), 0, $len);
                     $pos = $len;
                 }
 


### PR DESCRIPTION
Hi Terra, just a small bug in the last AES.php commit...

AES: Fixed small bug from commit https://github.com/phpseclib/phpseclib/commit/d94f1b252db66f52c42fcc8d4c6f1a3f10f5ff4e (AES.php in line 425-426)
in CFB decrypt() using CRYPT_AES_MODE_MCRYPT and enableContinuousBuffer()

Example:

``` php
define('CRYPT_AES_MODE',CRYPT_AES_MODE_MCRYPT);

$cipher = new Crypt_AES(CRYPT_AES_MODE_CFB);
$cipher->enableContinuousBuffer();
echo bin2hex($cipher->decrypt('12345678901234567'));
echo "\n";

$cipher = new Crypt_AES(CRYPT_AES_MODE_CFB);
echo bin2hex($cipher->decrypt('12345678901234567'));
```

Output:
57db78e0dabc1b03b17ccb6bf9001e1870ca20d89cebe6b1cecf03b29e9319bc
57db78e0dabc1b03b17ccb6bf9001e1876

Expected:
57db78e0dabc1b03b17ccb6bf9001e1876
57db78e0dabc1b03b17ccb6bf9001e1876

Output after Bugfix:
57db78e0dabc1b03b17ccb6bf9001e1876
57db78e0dabc1b03b17ccb6bf9001e1876
