### PR TITLE
RC4: fixed ContinuousBuffer() using MODE_MCRYPT

### DIFF
--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -192,6 +192,9 @@ class Crypt_RC4 {
                     case defined('MCRYPT_RC4');
                         $this->mode = MCRYPT_RC4;
                 }
+                $this->encryptStream = mcrypt_module_open($this->mode, '', MCRYPT_MODE_STREAM, '');
+                $this->decryptStream = mcrypt_module_open($this->mode, '', MCRYPT_MODE_STREAM, '');
+
         }
     }
 
@@ -349,18 +352,11 @@ class Crypt_RC4 {
         if ( CRYPT_RC4_MODE == CRYPT_RC4_MODE_MCRYPT ) {
             $keyStream = $mode == CRYPT_RC4_ENCRYPT ? 'encryptStream' : 'decryptStream';
 
-            if ($this->$keyStream === false) {
-                $this->$keyStream = mcrypt_module_open($this->mode, '', MCRYPT_MODE_STREAM, '');
-                mcrypt_generic_init($this->$keyStream, $this->key, '');
-            } else if (!$this->continuousBuffer) {
-                mcrypt_generic_init($this->$keyStream, $this->key, '');
+            if ($this->continuousBuffer) {
+                return mcrypt_generic($this->$keyStream, $text);
             }
-            $newText = mcrypt_generic($this->$keyStream, $text);
-            if (!$this->continuousBuffer) {
-                mcrypt_generic_deinit($this->$keyStream);
-            }
-
-            return $newText;
+            mcrypt_generic_init($this->$keyStream, $this->key, '');
+            return mcrypt_generic($this->$keyStream, $text);
         }
 
         if ($this->encryptStream === false) {
@@ -442,6 +438,11 @@ class Crypt_RC4 {
      */
     function enableContinuousBuffer()
     {
+        if ( CRYPT_RC4_MODE == CRYPT_RC4_MODE_MCRYPT ) {
+            mcrypt_generic_init($this->encryptStream, $this->key, '');
+            mcrypt_generic_init($this->decryptStream, $this->key, '');
+        }
+
         $this->continuousBuffer = true;
     }
 
@@ -457,7 +458,7 @@ class Crypt_RC4 {
     {
         if ( CRYPT_RC4_MODE == CRYPT_RC4_MODE_INTERNAL ) {
             $this->encryptIndex = $this->decryptIndex = array(0, 0);
-            $this->setKey($this->key);
+            $this->encryptStream = $this->decryptStream = false;
         }
 
         $this->continuousBuffer = false;
@@ -508,24 +509,10 @@ class Crypt_RC4 {
      */
     function _closeMCrypt()
     {
-        if ( $this->encryptStream !== false ) {
-            if ( $this->continuousBuffer ) {
-                mcrypt_generic_deinit($this->encryptStream);
-            }
-
-            mcrypt_module_close($this->encryptStream);
-
-            $this->encryptStream = false;
-        }
-
-        if ( $this->decryptStream !== false ) {
-            if ( $this->continuousBuffer ) {
-                mcrypt_generic_deinit($this->decryptStream);
-            }
-
-            mcrypt_module_close($this->decryptStream);
-
-            $this->decryptStream = false;
-        }
+        mcrypt_module_close($this->encryptStream);
+        mcrypt_module_close($this->decryptStream);
     }
 }
+
+// vim: ts=4:sw=4:et:
+// vim6: fdl=1:


### PR DESCRIPTION
Hi Terra, as mentioned... here's the bugfix for RC4 using multiple calls to ContinuousBuffer() in MODE_MCRYPT

Example:

``` php
define('CRYPT_RC4_MODE',CRYPT_RC4_MODE_MCRYPT); // CRYPT_RC4_MODE_INTERNAL works fine

$cipher = new Crypt_RC4();
$cipher->enableContinuousBuffer();
$cipher->encrypt('1');
$cipher->disableContinuousBuffer();

$cipher->enableContinuousBuffer();
echo bin2hex($cipher->encrypt('1'))."\n";

$cipher = new Crypt_RC4();
echo bin2hex($cipher->encrypt('1'));
```

Output:
29
ef

Expected:
ef
ef

Output after bugfix:
ef
ef
