### PR TITLE
Fix SSH2 when autoloaded from Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             "File": "phpseclib/",
             "Math": "phpseclib/",
             "Net": "phpseclib/"
-        }
+        },
+        "files": [
+            "phpseclib/Crypt/Random.php"
+        ]
     }
 }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -80,11 +80,7 @@ if (!class_exists('Math_BigInteger')) {
 /**
  * Include Crypt_Random
  */
-// the class_exists() will only be called if the crypt_random_string function hasn't been defined and
-// will trigger a call to __autoload() if you're wanting to auto-load classes
-// call function_exists() a second time to stop the require_once from being called outside
-// of the auto loader
-if (!function_exists('crypt_random_string') && !class_exists('Crypt_Random') && !function_exists('crypt_random_string')) {
+if (!function_exists('crypt_random_string')) {
     require_once('Crypt/Random.php');
 }
 


### PR DESCRIPTION
Using `class_exists('Crypt_Random')` to autoload the file does not work as expected using Composer autoloading.

Composer throws an exception like `The Composer autoloader expected class "Crypt_Random" to be defined in file <file>` when it does not find that class defined in the file.

This fixes that.
