### PR TITLE
Added a branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
         "files": [
             "phpseclib/Crypt/Random.php"
         ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3-dev"
+        }
     }
 }


### PR DESCRIPTION
This will allow people to require `0.3@dev` as opposed to `dev-master` in their `composer.json` requirements.
