### PR TITLE
Net_SFTP_Stream: Use default SFTP port, if no port specified

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -153,7 +153,7 @@ class Net_SFTP_Stream {
      */
     function _parse_path($path)
     {
-        extract(parse_url($path));
+        extract(parse_url($path) + array('port' => 22));
 
         if (!isset($host)) {
             return false;


### PR DESCRIPTION
If someone uses the `sftp://` wrapper and doesn't specify the port, it should default to 22.
