### PR TITLE
using absolute location for requires

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -34,10 +34,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -233,7 +233,7 @@ class Net_SFTP extends Net_SSH2 {
      * Directory Cache
      *
      * Rather than always having to open a directory and close it immediately there after to see if a file is a directory or
-     * rather than always 
+     * rather than always
      *
      * @see Net_SFTP::_save_dir()
      * @see Net_SFTP::_remove_dir()
@@ -334,7 +334,7 @@ class Net_SFTP extends Net_SSH2 {
             0x00000004 => 'NET_SFTP_ATTR_PERMISSIONS',
             0x00000008 => 'NET_SFTP_ATTR_ACCESSTIME',
             // 0x80000000 will yield a floating point on 32-bit systems and converting floating points to integers
-            // yields inconsistent behavior depending on how php is compiled.  so we left shift -1 (which, in 
+            // yields inconsistent behavior depending on how php is compiled.  so we left shift -1 (which, in
             // two's compliment, consists of all 1 bits) by 31.  on 64-bit systems this'll yield 0xFFFFFFFF80000000.
             // that's not a problem, however, and 'anded' and a 32-bit number, as all the leading 1 bits are ignored.
               -1 << 31 => 'NET_SFTP_ATTR_EXTENDED'
@@ -1199,7 +1199,7 @@ class Net_SFTP extends Net_SSH2 {
         }
 
         /*
-         "Because some systems must use separate system calls to set various attributes, it is possible that a failure 
+         "Because some systems must use separate system calls to set various attributes, it is possible that a failure
           response will be returned, but yet some of the attributes may be have been successfully modified.  If possible,
           servers SHOULD avoid this situation; however, clients MUST be aware that this is possible."
 
@@ -1309,7 +1309,7 @@ class Net_SFTP extends Net_SSH2 {
         }
 
         $dir = $this->_realpath($dir);
-        // by not providing any permissions, hopefully the server will use the logged in users umask - their 
+        // by not providing any permissions, hopefully the server will use the logged in users umask - their
         // default permissions.
         $attr = $mode == -1 ? "\0\0\0\0" : pack('N2', NET_SFTP_ATTR_PERMISSIONS, $mode & 07777);
 
@@ -1407,7 +1407,7 @@ class Net_SFTP extends Net_SSH2 {
      * So, for example, if you set $data to 'filename.ext' and then do Net_SFTP::get(), you will get a file, twelve bytes
      * long, containing 'filename.ext' as its contents.
      *
-     * Setting $mode to NET_SFTP_LOCAL_FILE will change the above behavior.  With NET_SFTP_LOCAL_FILE, $remote_file will 
+     * Setting $mode to NET_SFTP_LOCAL_FILE will change the above behavior.  With NET_SFTP_LOCAL_FILE, $remote_file will
      * contain as many bytes as filename.ext does on your local filesystem.  If your filename.ext is 1MB then that is how
      * large $remote_file will be, as well.
      *
@@ -2030,7 +2030,7 @@ class Net_SFTP extends Net_SSH2 {
         $stop = strtok(microtime(), ' ') + strtok('');
 
         if (defined('NET_SFTP_LOGGING')) {
-            $packet_type = '-> ' . $this->packet_types[$type] . 
+            $packet_type = '-> ' . $this->packet_types[$type] .
                            ' (' . round($stop - $start, 4) . 's)';
             if (NET_SFTP_LOGGING == NET_SFTP_LOG_REALTIME) {
                 echo "<pre>\r\n" . $this->_format_log(array($data), array($packet_type)) . "\r\n</pre>\r\n";
@@ -2106,7 +2106,7 @@ class Net_SFTP extends Net_SSH2 {
         $packet = $this->_string_shift($this->packet_buffer, $length);
 
         if (defined('NET_SFTP_LOGGING')) {
-            $packet_type = '<- ' . $this->packet_types[$this->packet_type] . 
+            $packet_type = '<- ' . $this->packet_types[$this->packet_type] .
                            ' (' . round($stop - $start, 4) . 's)';
             if (NET_SFTP_LOGGING == NET_SFTP_LOG_REALTIME) {
                 echo "<pre>\r\n" . $this->_format_log(array($packet), array($packet_type)) . "\r\n</pre>\r\n";

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -743,15 +743,15 @@ class Net_SSH2 {
         // Include Math_BigInteger
         // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
         if (!class_exists('Math_BigInteger')) {
-            require_once(__DIR__ . '/../Math/BigInteger.php');
+            require_once(dirname(__FILE__) . '/../Math/BigInteger.php');
         }
 
         if (!function_exists('crypt_random_string')) {
-            require_once(__DIR__ . '/../Crypt/Random.php');
+            require_once(dirname(__FILE__) . '/../Crypt/Random.php');
         }
 
         if (!class_exists('Crypt_Hash')) {
-            require_once(__DIR__ . '/../Crypt/Hash.php');
+            require_once(dirname(__FILE__) . '/../Crypt/Hash.php');
         }
 
         $this->last_packet = strtok(microtime(), ' ') + strtok(''); // == microtime(true) in PHP5
@@ -1297,14 +1297,14 @@ class Net_SSH2 {
         switch ($encrypt) {
             case '3des-cbc':
                 if (!class_exists('Crypt_TripleDES')) {
-                    require_once(__DIR__ . '/../Crypt/TripleDES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/TripleDES.php');
                 }
                 $this->encrypt = new Crypt_TripleDES();
                 // $this->encrypt_block_size = 64 / 8 == the default
                 break;
             case '3des-ctr':
                 if (!class_exists('Crypt_TripleDES')) {
-                    require_once(__DIR__ . '/../Crypt/TripleDES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/TripleDES.php');
                 }
                 $this->encrypt = new Crypt_TripleDES(CRYPT_DES_MODE_CTR);
                 // $this->encrypt_block_size = 64 / 8 == the default
@@ -1313,7 +1313,7 @@ class Net_SSH2 {
             case 'aes192-cbc':
             case 'aes128-cbc':
                 if (!class_exists('Crypt_AES')) {
-                    require_once(__DIR__ . '/../Crypt/AES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/AES.php');
                 }
                 $this->encrypt = new Crypt_AES();
                 $this->encrypt_block_size = 16; // eg. 128 / 8
@@ -1322,21 +1322,21 @@ class Net_SSH2 {
             case 'aes192-ctr':
             case 'aes128-ctr':
                 if (!class_exists('Crypt_AES')) {
-                    require_once(__DIR__ . '/../Crypt/AES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/AES.php');
                 }
                 $this->encrypt = new Crypt_AES(CRYPT_AES_MODE_CTR);
                 $this->encrypt_block_size = 16; // eg. 128 / 8
                 break;
             case 'blowfish-cbc':
                 if (!class_exists('Crypt_Blowfish')) {
-                    require_once(__DIR__ . '/../Crypt/Blowfish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Blowfish.php');
                 }
                 $this->encrypt = new Crypt_Blowfish();
                 $this->encrypt_block_size = 8;
                 break;
             case 'blowfish-ctr':
                 if (!class_exists('Crypt_Blowfish')) {
-                    require_once(__DIR__ . '/../Crypt/Blowfish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Blowfish.php');
                 }
                 $this->encrypt = new Crypt_Blowfish(CRYPT_BLOWFISH_MODE_CTR);
                 $this->encrypt_block_size = 8;
@@ -1346,7 +1346,7 @@ class Net_SSH2 {
             case 'twofish256-cbc':
             case 'twofish-cbc':
                 if (!class_exists('Crypt_Twofish')) {
-                    require_once(__DIR__ . '/../Crypt/Twofish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Twofish.php');
                 }
                 $this->encrypt = new Crypt_Twofish();
                 $this->encrypt_block_size = 16;
@@ -1355,7 +1355,7 @@ class Net_SSH2 {
             case 'twofish192-ctr':
             case 'twofish256-ctr':
                 if (!class_exists('Crypt_Twofish')) {
-                    require_once(__DIR__ . '/../Crypt/Twofish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Twofish.php');
                 }
                 $this->encrypt = new Crypt_Twofish(CRYPT_TWOFISH_MODE_CTR);
                 $this->encrypt_block_size = 16;
@@ -1364,7 +1364,7 @@ class Net_SSH2 {
             case 'arcfour128':
             case 'arcfour256':
                 if (!class_exists('Crypt_RC4')) {
-                    require_once(__DIR__ . '/../Crypt/RC4.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/RC4.php');
                 }
                 $this->encrypt = new Crypt_RC4();
                 break;
@@ -1375,13 +1375,13 @@ class Net_SSH2 {
         switch ($decrypt) {
             case '3des-cbc':
                 if (!class_exists('Crypt_TripleDES')) {
-                    require_once(__DIR__ . '/../Crypt/TripleDES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/TripleDES.php');
                 }
                 $this->decrypt = new Crypt_TripleDES();
                 break;
             case '3des-ctr':
                 if (!class_exists('Crypt_TripleDES')) {
-                    require_once(__DIR__ . '/../Crypt/TripleDES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/TripleDES.php');
                 }
                 $this->decrypt = new Crypt_TripleDES(CRYPT_DES_MODE_CTR);
                 break;
@@ -1389,7 +1389,7 @@ class Net_SSH2 {
             case 'aes192-cbc':
             case 'aes128-cbc':
                 if (!class_exists('Crypt_AES')) {
-                    require_once(__DIR__ . '/../Crypt/AES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/AES.php');
                 }
                 $this->decrypt = new Crypt_AES();
                 $this->decrypt_block_size = 16;
@@ -1398,21 +1398,21 @@ class Net_SSH2 {
             case 'aes192-ctr':
             case 'aes128-ctr':
                 if (!class_exists('Crypt_AES')) {
-                    require_once(__DIR__ . '/../Crypt/AES.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/AES.php');
                 }
                 $this->decrypt = new Crypt_AES(CRYPT_AES_MODE_CTR);
                 $this->decrypt_block_size = 16;
                 break;
             case 'blowfish-cbc':
                 if (!class_exists('Crypt_Blowfish')) {
-                    require_once(__DIR__ . '/../Crypt/Blowfish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Blowfish.php');
                 }
                 $this->decrypt = new Crypt_Blowfish();
                 $this->decrypt_block_size = 8;
                 break;
             case 'blowfish-ctr':
                 if (!class_exists('Crypt_Blowfish')) {
-                    require_once(__DIR__ . '/../Crypt/Blowfish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Blowfish.php');
                 }
                 $this->decrypt = new Crypt_Blowfish(CRYPT_BLOWFISH_MODE_CTR);
                 $this->decrypt_block_size = 8;
@@ -1422,7 +1422,7 @@ class Net_SSH2 {
             case 'twofish256-cbc':
             case 'twofish-cbc':
                 if (!class_exists('Crypt_Twofish')) {
-                    require_once(__DIR__ . '/../Crypt/Twofish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Twofish.php');
                 }
                 $this->decrypt = new Crypt_Twofish();
                 $this->decrypt_block_size = 16;
@@ -1431,7 +1431,7 @@ class Net_SSH2 {
             case 'twofish192-ctr':
             case 'twofish256-ctr':
                 if (!class_exists('Crypt_Twofish')) {
-                    require_once(__DIR__ . '/../Crypt/Twofish.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/Twofish.php');
                 }
                 $this->decrypt = new Crypt_Twofish(CRYPT_TWOFISH_MODE_CTR);
                 $this->decrypt_block_size = 16;
@@ -1440,7 +1440,7 @@ class Net_SSH2 {
             case 'arcfour128':
             case 'arcfour256':
                 if (!class_exists('Crypt_RC4')) {
-                    require_once(__DIR__ . '/../Crypt/RC4.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/RC4.php');
                 }
                 $this->decrypt = new Crypt_RC4();
                 break;
@@ -3299,7 +3299,7 @@ class Net_SSH2 {
                 $signature = $this->_string_shift($signature, $temp['length']);
 
                 if (!class_exists('Crypt_RSA')) {
-                    require_once(__DIR__ . '/../Crypt/RSA.php');
+                    require_once(dirname(__FILE__) . '/../Crypt/RSA.php');
                 }
 
                 $rsa = new Crypt_RSA();


### PR DESCRIPTION
- I found that when I was accessing this through a script it would use the Net folder
  as the starting point.  For example, when it required 'Crypt/Random.php', it would try to require  
  'Net/Crypt/Random.php.  This tells it to use the exact location correctly, regardless of where it's being called from
- also deleting EOL spaces
