### PR TITLE
RC2: Optimizations, inline-crypt bug fix

### DIFF
--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -10,7 +10,7 @@
  *
  * Useful resources are as follows:
  *
- *  - {@link @link http://tools.ietf.org/html/rfc2268}
+ *  - {@link http://tools.ietf.org/html/rfc2268}
  *
  * Here's a short example of how to use this library:
  * <code>
@@ -21,11 +21,7 @@
  *
  *    $rc2->setKey('abcdefgh');
  *
- *    $size = 10 * 1024;
- *    $plaintext = '';
- *    for ($i = 0; $i < $size; $i++) {
- *        $plaintext.= 'a';
- *    }
+ *    $plaintext = str_repeat('a', 1024);
  *
  *    echo $rc2->decrypt($rc2->encrypt($plaintext));
  * ?>
@@ -62,7 +58,7 @@
  * Base cipher class
  */
 if (!class_exists('Crypt_Base')) {
-    require_once 'Base.php';
+    require_once('Base.php');
 }
 
 /**#@+
@@ -71,12 +67,36 @@ if (!class_exists('Crypt_Base')) {
  * @see Crypt_RC2::decrypt()
  */
 /**
- * Define specific block modes for compatibility.
+ * Encrypt / decrypt using the Counter mode.
+ *
+ * Set to -1 since that's what Crypt/Random.php uses to index the CTR mode.
+ *
+ * @link http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Counter_.28CTR.29
  */
 define('CRYPT_RC2_MODE_CTR', CRYPT_MODE_CTR);
+/**
+ * Encrypt / decrypt using the Electronic Code Book mode.
+ *
+ * @link http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Electronic_codebook_.28ECB.29
+ */
 define('CRYPT_RC2_MODE_ECB', CRYPT_MODE_ECB);
+/**
+ * Encrypt / decrypt using the Code Book Chaining mode.
+ *
+ * @link http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Cipher-block_chaining_.28CBC.29
+ */
 define('CRYPT_RC2_MODE_CBC', CRYPT_MODE_CBC);
+/**
+ * Encrypt / decrypt using the Cipher Feedback mode.
+ *
+ * @link http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Cipher_feedback_.28CFB.29
+ */
 define('CRYPT_RC2_MODE_CFB', CRYPT_MODE_CFB);
+/**
+ * Encrypt / decrypt using the Cipher Feedback mode.
+ *
+ * @link http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Output_feedback_.28OFB.29
+ */
 define('CRYPT_RC2_MODE_OFB', CRYPT_MODE_OFB);
 /**#@-*/
 
@@ -97,7 +117,7 @@ define('CRYPT_RC2_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
 /**
  * Pure-PHP implementation of RC2.
  *
- * @version 0.1.0
+ * @version 0.1.1
  * @access  public
  * @package Crypt_RC2
  */
@@ -119,7 +139,7 @@ class Crypt_RC2 extends Crypt_Base {
      * @var String
      * @access private
      */
-    var $key = "\0\0\0\0\0\0\0\0";
+    var $key = "\0";
 
     /**
      * The default password key_size used by setPassword()
@@ -129,7 +149,7 @@ class Crypt_RC2 extends Crypt_Base {
      * @var Integer
      * @access private
      */
-    var $password_key_size = 8;
+    var $password_key_size = 128; // = 1024 bits
 
     /**
      * The namespace used by the cipher for its constants.
@@ -159,15 +179,6 @@ class Crypt_RC2 extends Crypt_Base {
     var $cfb_init_len = 500;
 
     /**
-     * max possible size of $key
-     *
-     * @see Crypt_RC2::setKey()
-     * @var String
-     * @access private
-     */
-    var $key_size_max = 128;
-
-    /**
      * The Key Schedule
      *
      * @see Crypt_RC2::_setupKey()
@@ -177,15 +188,48 @@ class Crypt_RC2 extends Crypt_Base {
     var $keys;
 
     /**
-     * Key expansion randomization table and its inverse.
+     * Key expansion randomization table.
+     * The inverse table (invpitable) will be calculated at run time.
      *
      * @see Crypt_RC2::Crypt_RC2()
      * @see Crypt_RC2::setKey()
      * @var Array
      * @access private
      */
-    var $pitable;
-    var $invpitable;
+    var $pitable = array(
+        0xD9, 0x78, 0xF9, 0xC4, 0x19, 0xDD, 0xB5, 0xED,
+        0x28, 0xE9, 0xFD, 0x79, 0x4A, 0xA0, 0xD8, 0x9D,
+        0xC6, 0x7E, 0x37, 0x83, 0x2B, 0x76, 0x53, 0x8E,
+        0x62, 0x4C, 0x64, 0x88, 0x44, 0x8B, 0xFB, 0xA2,
+        0x17, 0x9A, 0x59, 0xF5, 0x87, 0xB3, 0x4F, 0x13,
+        0x61, 0x45, 0x6D, 0x8D, 0x09, 0x81, 0x7D, 0x32,
+        0xBD, 0x8F, 0x40, 0xEB, 0x86, 0xB7, 0x7B, 0x0B,
+        0xF0, 0x95, 0x21, 0x22, 0x5C, 0x6B, 0x4E, 0x82,
+        0x54, 0xD6, 0x65, 0x93, 0xCE, 0x60, 0xB2, 0x1C,
+        0x73, 0x56, 0xC0, 0x14, 0xA7, 0x8C, 0xF1, 0xDC,
+        0x12, 0x75, 0xCA, 0x1F, 0x3B, 0xBE, 0xE4, 0xD1,
+        0x42, 0x3D, 0xD4, 0x30, 0xA3, 0x3C, 0xB6, 0x26,
+        0x6F, 0xBF, 0x0E, 0xDA, 0x46, 0x69, 0x07, 0x57,
+        0x27, 0xF2, 0x1D, 0x9B, 0xBC, 0x94, 0x43, 0x03,
+        0xF8, 0x11, 0xC7, 0xF6, 0x90, 0xEF, 0x3E, 0xE7,
+        0x06, 0xC3, 0xD5, 0x2F, 0xC8, 0x66, 0x1E, 0xD7,
+        0x08, 0xE8, 0xEA, 0xDE, 0x80, 0x52, 0xEE, 0xF7,
+        0x84, 0xAA, 0x72, 0xAC, 0x35, 0x4D, 0x6A, 0x2A,
+        0x96, 0x1A, 0xD2, 0x71, 0x5A, 0x15, 0x49, 0x74,
+        0x4B, 0x9F, 0xD0, 0x5E, 0x04, 0x18, 0xA4, 0xEC,
+        0xC2, 0xE0, 0x41, 0x6E, 0x0F, 0x51, 0xCB, 0xCC,
+        0x24, 0x91, 0xAF, 0x50, 0xA1, 0xF4, 0x70, 0x39,
+        0x99, 0x7C, 0x3A, 0x85, 0x23, 0xB8, 0xB4, 0x7A,
+        0xFC, 0x02, 0x36, 0x5B, 0x25, 0x55, 0x97, 0x31,
+        0x2D, 0x5D, 0xFA, 0x98, 0xE3, 0x8A, 0x92, 0xAE,
+        0x05, 0xDF, 0x29, 0x10, 0x67, 0x6C, 0xBA, 0xC9,
+        0xD3, 0x00, 0xE6, 0xCF, 0xE1, 0x9E, 0xA8, 0x2C,
+        0x63, 0x16, 0x01, 0x3F, 0x58, 0xE2, 0x89, 0xA9,
+        0x0D, 0x38, 0x34, 0x1B, 0xAB, 0x33, 0xFF, 0xB0,
+        0xBB, 0x48, 0x0C, 0x5F, 0xB9, 0xB1, 0xCD, 0x2E,
+        0xC5, 0xF3, 0xDB, 0x47, 0xE5, 0xA5, 0x9C, 0x77,
+        0x0A, 0xA6, 0x20, 0x68, 0xFE, 0x7F, 0xC1, 0xAD
+    );
 
     /**
      * Default Constructor.
@@ -194,66 +238,26 @@ class Crypt_RC2 extends Crypt_Base {
      *
      * $mode could be:
      *
-     * - CRYPT_MODE_ECB
+     * - CRYPT_RC2_MODE_ECB
      *
-     * - CRYPT_MODE_CBC
+     * - CRYPT_RC2_MODE_CBC
      *
-     * - CRYPT_MODE_CTR
+     * - CRYPT_RC2_MODE_CTR
      *
-     * - CRYPT_MODE_CFB
+     * - CRYPT_RC2_MODE_CFB
      *
-     * - CRYPT_MODE_OFB
+     * - CRYPT_RC2_MODE_OFB
      *
-     * If not explictly set, CRYPT_MODE_CBC will be used.
+     * If not explictly set, CRYPT_RC2_MODE_CBC will be used.
      *
      * @see Crypt_Base::Crypt_Base()
      * @param optional Integer $mode
      * @access public
      */
-    function Crypt_RC2($mode = CRYPT_MODE_CBC)
+    function Crypt_RC2($mode = CRYPT_RC2_MODE_CBC)
     {
         parent::Crypt_Base($mode);
-        $pitable = array(
-            0xD9, 0x78, 0xF9, 0xC4, 0x19, 0xDD, 0xB5, 0xED,
-            0x28, 0xE9, 0xFD, 0x79, 0x4A, 0xA0, 0xD8, 0x9D,
-            0xC6, 0x7E, 0x37, 0x83, 0x2B, 0x76, 0x53, 0x8E,
-            0x62, 0x4C, 0x64, 0x88, 0x44, 0x8B, 0xFB, 0xA2,
-            0x17, 0x9A, 0x59, 0xF5, 0x87, 0xB3, 0x4F, 0x13,
-            0x61, 0x45, 0x6D, 0x8D, 0x09, 0x81, 0x7D, 0x32,
-            0xBD, 0x8F, 0x40, 0xEB, 0x86, 0xB7, 0x7B, 0x0B,
-            0xF0, 0x95, 0x21, 0x22, 0x5C, 0x6B, 0x4E, 0x82,
-            0x54, 0xD6, 0x65, 0x93, 0xCE, 0x60, 0xB2, 0x1C,
-            0x73, 0x56, 0xC0, 0x14, 0xA7, 0x8C, 0xF1, 0xDC,
-            0x12, 0x75, 0xCA, 0x1F, 0x3B, 0xBE, 0xE4, 0xD1,
-            0x42, 0x3D, 0xD4, 0x30, 0xA3, 0x3C, 0xB6, 0x26,
-            0x6F, 0xBF, 0x0E, 0xDA, 0x46, 0x69, 0x07, 0x57,
-            0x27, 0xF2, 0x1D, 0x9B, 0xBC, 0x94, 0x43, 0x03,
-            0xF8, 0x11, 0xC7, 0xF6, 0x90, 0xEF, 0x3E, 0xE7,
-            0x06, 0xC3, 0xD5, 0x2F, 0xC8, 0x66, 0x1E, 0xD7,
-            0x08, 0xE8, 0xEA, 0xDE, 0x80, 0x52, 0xEE, 0xF7,
-            0x84, 0xAA, 0x72, 0xAC, 0x35, 0x4D, 0x6A, 0x2A,
-            0x96, 0x1A, 0xD2, 0x71, 0x5A, 0x15, 0x49, 0x74,
-            0x4B, 0x9F, 0xD0, 0x5E, 0x04, 0x18, 0xA4, 0xEC,
-            0xC2, 0xE0, 0x41, 0x6E, 0x0F, 0x51, 0xCB, 0xCC,
-            0x24, 0x91, 0xAF, 0x50, 0xA1, 0xF4, 0x70, 0x39,
-            0x99, 0x7C, 0x3A, 0x85, 0x23, 0xB8, 0xB4, 0x7A,
-            0xFC, 0x02, 0x36, 0x5B, 0x25, 0x55, 0x97, 0x31,
-            0x2D, 0x5D, 0xFA, 0x98, 0xE3, 0x8A, 0x92, 0xAE,
-            0x05, 0xDF, 0x29, 0x10, 0x67, 0x6C, 0xBA, 0xC9,
-            0xD3, 0x00, 0xE6, 0xCF, 0xE1, 0x9E, 0xA8, 0x2C,
-            0x63, 0x16, 0x01, 0x3F, 0x58, 0xE2, 0x89, 0xA9,
-            0x0D, 0x38, 0x34, 0x1B, 0xAB, 0x33, 0xFF, 0xB0,
-            0xBB, 0x48, 0x0C, 0x5F, 0xB9, 0xB1, 0xCD, 0x2E,
-            0xC5, 0xF3, 0xDB, 0x47, 0xE5, 0xA5, 0x9C, 0x77,
-            0x0A, 0xA6, 0x20, 0x68, 0xFE, 0x7F, 0xC1, 0xAD
-        );
-        $this->invpitable = array_flip($pitable);
-
-        // Avoid a later modulus operation.
-        $this->pitable = array_merge($pitable, $pitable);
-
         $this->setKey('');
-        $this->setIV('');
     }
 
     /**
@@ -275,7 +279,7 @@ class Crypt_RC2 extends Crypt_Base {
     function setKey($key, $t1 = 1024)
     {
         // Key length should be 1..128.
-        $key = strlen($key)? substr($key, 0, 128): "\x00";
+        $key = strlen($key) ? substr($key, 0, 128): "\x00";
         $t = strlen($key);
 
         // The mcrypt RC2 implementation only supports effective key length
@@ -284,13 +288,16 @@ class Crypt_RC2 extends Crypt_Base {
         // inverse pitable mapping to the first byte before submitting it
         // to mcrypt.
 
+        // Setting up the [inv]pitable
+        $invpitable = array_flip($this->pitable);
+        $pitable = array_merge($this->pitable, $this->pitable);// Avoid a later modulus operation.
+
         // Key expansion.
         $l = array_values(unpack('C*', $key));
         $t8 = ($t1 + 7) >> 3;
         $tm = 0xFF >> (8 * $t8 - $t1);
 
         // Expand key.
-        $pitable = $this->pitable;
         for ($i = $t; $i < 128; $i++) {
             $l[$i] = $pitable[$l[$i - 1] + $l[$i - $t]];
         }
@@ -301,23 +308,9 @@ class Crypt_RC2 extends Crypt_Base {
         }
 
         // Prepare the key for mcrypt.
-        $l[0] = $this->invpitable[$l[0]];
+        $l[0] = $invpitable[$l[0]];
         array_unshift($l, 'C*');
         parent::setKey(call_user_func_array('pack', $l));
-    }
-
-    /**
-     * Sets the initialization vector. (optional)
-     *
-     * SetIV is not required when CRYPT_MODE_ECB is being used.
-     * If not explictly set, it'll be assumed to be all zero's.
-     *
-     * @access public
-     * @param String $iv
-     */
-    function setIV($iv)
-    {
-        parent::setIV(str_pad(substr($iv, 0, 8), 8, "\x00"));
     }
 
     /**
@@ -419,7 +412,7 @@ class Crypt_RC2 extends Crypt_Base {
     function _setupKey()
     {
         $l = unpack('Ca/Cb/v*', $this->key);
-        $l[0] = $this->pitable[$l['a']] | ($l['b'] << 8);
+        array_unshift($l, $this->pitable[$l['a']] | ($l['b'] << 8));
         unset($l['a']);
         unset($l['b']);
         $this->keys = $l;
@@ -434,19 +427,35 @@ class Crypt_RC2 extends Crypt_Base {
     function _setupInlineCrypt()
     {
         $lambda_functions = &Crypt_RC2::_getLambdaFunctions();
-        $code_hash = "Crypt_RC2, {$this->mode}";
+
+        // The first 10 generated $lambda_functions will use the $keys hardcoded as integers
+        // for the mixing rounds, for better inline crypt performance [~20% faster].
+        // But for memory reason we have to limit those ultra-optimized $lambda_functions to an amount of 10.
+        $keys = $this->keys;
+        if (count($lambda_functions) >= 10) {
+            foreach ($this->keys as $k => $v) {
+                $keys[$k] = '$keys[' . $k . ']';
+            }
+        }
+
+        $code_hash = md5(str_pad("Crypt_RC2, {$this->mode}, ", 32, "\0") . implode(',', $keys));
 
         // Is there a re-usable $lambda_functions in there?
         // If not, we have to create it.
         if (!isset($lambda_functions[$code_hash])) {
             // Init code for both, encrypt and decrypt.
-            $init_crypt = '
-                list($r0, $r1, $r2, $r3) = array_values(unpack("v*", $text));
-                $keys = $self->keys;';
+            $init_crypt = '$keys = $self->keys;';
+
+            // $in is the current 8 bytes block which has to be en/decrypt
+            $encrypt_block = $decrypt_block = '
+                $in = unpack("v4", $in);
+                $r0 = $in[1];
+                $r1 = $in[2];
+                $r2 = $in[3];
+                $r3 = $in[4];
+            ';
 
             // Create code for encryption.
-            $encrypt_block = '';
-
             $limit = 20;
             $actions = array($limit => 44, 44 => 64);
             $j = 0;
@@ -454,16 +463,16 @@ class Crypt_RC2 extends Crypt_Base {
             for (;;) {
                 // Mixing round.
                 $encrypt_block .= '
-                    $r0 = (($r0 + $keys[' . $j++ . '] +
+                    $r0 = (($r0 + ' . $keys[$j++] . ' +
                            ((($r1 ^ $r2) & $r3) ^ $r1)) & 0xFFFF) << 1;
                     $r0 |= $r0 >> 16;
-                    $r1 = (($r1 + $keys[' . $j++ . '] +
+                    $r1 = (($r1 + ' . $keys[$j++] . ' +
                            ((($r2 ^ $r3) & $r0) ^ $r2)) & 0xFFFF) << 2;
                     $r1 |= $r1 >> 16;
-                    $r2 = (($r2 + $keys[' . $j++ . '] +
+                    $r2 = (($r2 + ' . $keys[$j++] . ' +
                            ((($r3 ^ $r0) & $r1) ^ $r3)) & 0xFFFF) << 3;
                     $r2 |= $r2 >> 16;
-                    $r3 = (($r3 + $keys[' . $j++ . '] +
+                    $r3 = (($r3 + ' . $keys[$j++] . ' +
                            ((($r0 ^ $r1) & $r2) ^ $r0)) & 0xFFFF) << 5;
                     $r3 |= $r3 >> 16;';
 
@@ -482,11 +491,9 @@ class Crypt_RC2 extends Crypt_Base {
                 }
             }
 
-            $encrypt_block .= '
-                return pack("vvvv", $r0, $r1, $r2, $r3);';
+            $encrypt_block .= '$in = pack("v4", $r0, $r1, $r2, $r3);';
 
             // Create code for decryption.
-            $decrypt_block = '';
             $limit = 44;
             $actions = array($limit => 20, 20 => 0);
             $j = 64;
@@ -495,16 +502,16 @@ class Crypt_RC2 extends Crypt_Base {
                 // R-mixing round.
                 $decrypt_block .= '
                     $r3 = ($r3 | ($r3 << 16)) >> 5;
-                    $r3 = ($r3 - $keys[' . --$j . '] -
+                    $r3 = ($r3 - ' . $keys[--$j] . ' -
                            ((($r0 ^ $r1) & $r2) ^ $r0)) & 0xFFFF;
                     $r2 = ($r2 | ($r2 << 16)) >> 3;
-                    $r2 = ($r2 - $keys[' . --$j . '] -
+                    $r2 = ($r2 - ' . $keys[--$j] . ' -
                            ((($r3 ^ $r0) & $r1) ^ $r3)) & 0xFFFF;
                     $r1 = ($r1 | ($r1 << 16)) >> 2;
-                    $r1 = ($r1 - $keys[' . --$j . '] -
+                    $r1 = ($r1 - ' . $keys[--$j] . ' -
                            ((($r2 ^ $r3) & $r0) ^ $r2)) & 0xFFFF;
                     $r0 = ($r0 | ($r0 << 16)) >> 1;
-                    $r0 = ($r0 - $keys[' . --$j . '] -
+                    $r0 = ($r0 - ' . $keys[--$j] . ' -
                            ((($r1 ^ $r2) & $r3) ^ $r1)) & 0xFFFF;';
 
                 if ($j == $limit) {
@@ -522,8 +529,7 @@ class Crypt_RC2 extends Crypt_Base {
                 }
             }
 
-            $decrypt_block .= '
-                return pack("vvvv", $r0, $r1, $r2, $r3);';
+            $decrypt_block .= '$in = pack("v4", $r0, $r1, $r2, $r3);';
 
             // Creates the inline-crypt function
             $lambda_functions[$code_hash] = $this->_createInlineCryptFunction(


### PR DESCRIPTION
Hi Patrick... great work!  re: https://github.com/phpseclib/phpseclib/commit/b247ad174375dbdc323a85a2e2f82d10c3b225c7

i made some changes in _setupInlineCrypt(). Speeding it up to additional ~20% and fixing a "code-layout" bug in there.

Also i made some other changes arround (typo, memory optimization, phpdoc, CS). See the inline github comments.

For `setKey($key, $t1 = 1024)`
Do you think it's possible - if it makes sense - to remove the second parameter and add a public method like "setEffectiveKeyLength()" ... as we do it similar in Rijndael with setKeyLength()
I ask this only, trying to be syncron with the other ciphers setKey() arguments and object handlings (as good as possible :-) )

Greetings
Hans-Jürgen :-)
