### PR TITLE
misplaced quote mark

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3138,7 +3138,7 @@ class Net_SSH2 {
                 $hex = substr(
                            preg_replace(
                                '#(.)#es',
-                               '"' . $boundary . '" . str_pad(dechex(ord(substr("\\1", -1))), 2, "0", STR_PAD_LEFT)',
+                               '"' . $boundary . '"' . str_pad(dechex(ord(substr("\\1", -1))), 2, "0", STR_PAD_LEFT),
                                $fragment),
                            strlen($boundary)
                        );


### PR DESCRIPTION
just passing by and it looked like a ' got on the wrong side of an expression. Is this correct?
