### PR TITLE
fixed $GLOBALS to $_GLOBALS

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -149,7 +149,7 @@ function crypt_random_string($length)
             serialize($_POST) .
             serialize($_GET) .
             serialize($_COOKIE) .
-            serialize($GLOBALS) .
+            serialize($_GLOBALS) .
             serialize($_SESSION) .
             serialize($_OLD_SESSION)
         ));


### PR DESCRIPTION
Shouldn't it be $_GLOBALS ? This change fixed a bug in a case I was calling new NET_SSH2() in a class method.
