### PR TITLE
Check wether CRYPT_RANDOM_IS_WINDOWS is defined before defining it.

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -46,7 +46,7 @@
  *
  * @access private
  */
-if (defined('CRYPT_RANDOM_IS_WINDOWS') === false) {
+if (!defined('CRYPT_RANDOM_IS_WINDOWS')) {
     define('CRYPT_RANDOM_IS_WINDOWS', strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
 }
 


### PR DESCRIPTION
A quick [google](https://www.google.nl/search?q=CRYPT_RANDOM_IS_WINDOWS) shows many people struggling with unit tests and phpseclib where defining this constant leads to an error.
