### PR TITLE
SFTP_Stream: Fixed typo in _parse_path

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -174,7 +174,7 @@ class Net_SFTP_Stream {
             }
             $this->sftp = $$host;
         } else {
-            if (isset($this->contenxt)) {
+            if (isset($this->context)) {
                 $context = stream_context_get_options($this->context);
             }
             if (isset($context['sftp']['session'])) {


### PR DESCRIPTION
typo: isset($this->contenxt)
should be $this->context
