### PR TITLE
Do not Autoload when checking for inverse class_exists. Fails with autol...

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -762,7 +762,7 @@ class Net_SSH2 {
     {
         // Include Math_BigInteger
         // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
-        if (!class_exists('Math_BigInteger')) {
+        if (!class_exists('Math_BigInteger', false)) {
             require_once('Math/BigInteger.php');
         }
 
@@ -770,7 +770,7 @@ class Net_SSH2 {
             require_once('Crypt/Random.php');
         }
 
-        if (!class_exists('Crypt_Hash')) {
+        if (!class_exists('Crypt_Hash', false)) {
             require_once('Crypt/Hash.php');
         }
 
@@ -1352,14 +1352,14 @@ class Net_SSH2 {
 
         switch ($encrypt) {
             case '3des-cbc':
-                if (!class_exists('Crypt_TripleDES')) {
+                if (!class_exists('Crypt_TripleDES', false)) {
                     require_once('Crypt/TripleDES.php');
                 }
                 $this->encrypt = new Crypt_TripleDES();
                 // $this->encrypt_block_size = 64 / 8 == the default
                 break;
             case '3des-ctr':
-                if (!class_exists('Crypt_TripleDES')) {
+                if (!class_exists('Crypt_TripleDES', false)) {
                     require_once('Crypt/TripleDES.php');
                 }
                 $this->encrypt = new Crypt_TripleDES(CRYPT_DES_MODE_CTR);
@@ -1368,7 +1368,7 @@ class Net_SSH2 {
             case 'aes256-cbc':
             case 'aes192-cbc':
             case 'aes128-cbc':
-                if (!class_exists('Crypt_Rijndael')) {
+                if (!class_exists('Crypt_Rijndael', false)) {
                     require_once('Crypt/Rijndael.php');
                 }
                 $this->encrypt = new Crypt_Rijndael();
@@ -1377,21 +1377,21 @@ class Net_SSH2 {
             case 'aes256-ctr':
             case 'aes192-ctr':
             case 'aes128-ctr':
-                if (!class_exists('Crypt_Rijndael')) {
+                if (!class_exists('Crypt_Rijndael', false)) {
                     require_once('Crypt/Rijndael.php');
                 }
                 $this->encrypt = new Crypt_Rijndael(CRYPT_RIJNDAEL_MODE_CTR);
                 $this->encrypt_block_size = 16; // eg. 128 / 8
                 break;
             case 'blowfish-cbc':
-                if (!class_exists('Crypt_Blowfish')) {
+                if (!class_exists('Crypt_Blowfish', false)) {
                     require_once('Crypt/Blowfish.php');
                 }
                 $this->encrypt = new Crypt_Blowfish();
                 $this->encrypt_block_size = 8;
                 break;
             case 'blowfish-ctr':
-                if (!class_exists('Crypt_Blowfish')) {
+                if (!class_exists('Crypt_Blowfish', false)) {
                     require_once('Crypt/Blowfish.php');
                 }
                 $this->encrypt = new Crypt_Blowfish(CRYPT_BLOWFISH_MODE_CTR);
@@ -1401,7 +1401,7 @@ class Net_SSH2 {
             case 'twofish192-cbc':
             case 'twofish256-cbc':
             case 'twofish-cbc':
-                if (!class_exists('Crypt_Twofish')) {
+                if (!class_exists('Crypt_Twofish', false)) {
                     require_once('Crypt/Twofish.php');
                 }
                 $this->encrypt = new Crypt_Twofish();
@@ -1410,7 +1410,7 @@ class Net_SSH2 {
             case 'twofish128-ctr':
             case 'twofish192-ctr':
             case 'twofish256-ctr':
-                if (!class_exists('Crypt_Twofish')) {
+                if (!class_exists('Crypt_Twofish', false)) {
                     require_once('Crypt/Twofish.php');
                 }
                 $this->encrypt = new Crypt_Twofish(CRYPT_TWOFISH_MODE_CTR);
@@ -1419,7 +1419,7 @@ class Net_SSH2 {
             case 'arcfour':
             case 'arcfour128':
             case 'arcfour256':
-                if (!class_exists('Crypt_RC4')) {
+                if (!class_exists('Crypt_RC4', false)) {
                     require_once('Crypt/RC4.php');
                 }
                 $this->encrypt = new Crypt_RC4();
@@ -1430,13 +1430,13 @@ class Net_SSH2 {
 
         switch ($decrypt) {
             case '3des-cbc':
-                if (!class_exists('Crypt_TripleDES')) {
+                if (!class_exists('Crypt_TripleDES', false)) {
                     require_once('Crypt/TripleDES.php');
                 }
                 $this->decrypt = new Crypt_TripleDES();
                 break;
             case '3des-ctr':
-                if (!class_exists('Crypt_TripleDES')) {
+                if (!class_exists('Crypt_TripleDES', false)) {
                     require_once('Crypt/TripleDES.php');
                 }
                 $this->decrypt = new Crypt_TripleDES(CRYPT_DES_MODE_CTR);
@@ -1444,7 +1444,7 @@ class Net_SSH2 {
             case 'aes256-cbc':
             case 'aes192-cbc':
             case 'aes128-cbc':
-                if (!class_exists('Crypt_Rijndael')) {
+                if (!class_exists('Crypt_Rijndael', false)) {
                     require_once('Crypt/Rijndael.php');
                 }
                 $this->decrypt = new Crypt_Rijndael();
@@ -1453,21 +1453,21 @@ class Net_SSH2 {
             case 'aes256-ctr':
             case 'aes192-ctr':
             case 'aes128-ctr':
-                if (!class_exists('Crypt_Rijndael')) {
+                if (!class_exists('Crypt_Rijndael', false)) {
                     require_once('Crypt/Rijndael.php');
                 }
                 $this->decrypt = new Crypt_Rijndael(CRYPT_RIJNDAEL_MODE_CTR);
                 $this->decrypt_block_size = 16;
                 break;
             case 'blowfish-cbc':
-                if (!class_exists('Crypt_Blowfish')) {
+                if (!class_exists('Crypt_Blowfish', false)) {
                     require_once('Crypt/Blowfish.php');
                 }
                 $this->decrypt = new Crypt_Blowfish();
                 $this->decrypt_block_size = 8;
                 break;
             case 'blowfish-ctr':
-                if (!class_exists('Crypt_Blowfish')) {
+                if (!class_exists('Crypt_Blowfish', false)) {
                     require_once('Crypt/Blowfish.php');
                 }
                 $this->decrypt = new Crypt_Blowfish(CRYPT_BLOWFISH_MODE_CTR);
@@ -1477,7 +1477,7 @@ class Net_SSH2 {
             case 'twofish192-cbc':
             case 'twofish256-cbc':
             case 'twofish-cbc':
-                if (!class_exists('Crypt_Twofish')) {
+                if (!class_exists('Crypt_Twofish', false)) {
                     require_once('Crypt/Twofish.php');
                 }
                 $this->decrypt = new Crypt_Twofish();
@@ -1486,7 +1486,7 @@ class Net_SSH2 {
             case 'twofish128-ctr':
             case 'twofish192-ctr':
             case 'twofish256-ctr':
-                if (!class_exists('Crypt_Twofish')) {
+                if (!class_exists('Crypt_Twofish', false)) {
                     require_once('Crypt/Twofish.php');
                 }
                 $this->decrypt = new Crypt_Twofish(CRYPT_TWOFISH_MODE_CTR);
@@ -1495,7 +1495,7 @@ class Net_SSH2 {
             case 'arcfour':
             case 'arcfour128':
             case 'arcfour256':
-                if (!class_exists('Crypt_RC4')) {
+                if (!class_exists('Crypt_RC4', false)) {
                     require_once('Crypt/RC4.php');
                 }
                 $this->decrypt = new Crypt_RC4();


### PR DESCRIPTION
Do not Autoload when checking for inverse class_exists. Fails with autoload in some cases. According to the php documentation: http://php.net/manual/en/function.class-exists.php

bool class_exists ( string $class_name [, bool $autoload = true ] )

We do not want to autoload this class, we want the autoloader from symphony to do that for us. This causes some strange problems when used in combination with other libraries.
