### PR TITLE
Initing eof to false

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -256,6 +256,7 @@ class Net_SFTP_Stream {
 
         $this->size = $this->sftp->size($path);
         $this->mode = preg_replace('#[bt]$#', '', $mode);
+        $this->eof = false;
 
         if ($this->size === false) {
             if ($this->mode[0] == 'r') {


### PR DESCRIPTION
The call _stream_eof() must return a boolean, not null.
Returning null makes PHP believe that the method wasn't implemented.

Fixes #170
