### PR TITLE
Making Net_SFTP::chdir capable of handling the empty string.

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -635,8 +635,12 @@ class Net_SFTP extends Net_SSH2 {
             return false;
         }
 
-        // Suffix a slash
-        if (!$dir || $dir[strlen($dir) - 1] != '/') {
+        if ($dir === '') {
+            $dir = './';
+        }
+
+        // Suffix a slash if needed
+        if ($dir[strlen($dir) - 1] != '/') {
             $dir.= '/';
         }
 


### PR DESCRIPTION
Fixing a ugly notice when using the empty string as parameter for chdir:
  Notice: Uninitialized string offset: -1 in Net/SFTP.php line 617
