### PR TITLE
SFTP: Removed dead code

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1506,8 +1506,6 @@ class Net_SFTP extends Net_SSH2 {
                 return false;
         }
 
-        $initialize = true;
-
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-8.2.3
         if ($mode & NET_SFTP_LOCAL_FILE) {
             if (!is_file($data)) {


### PR DESCRIPTION
variable: $initialize = true, ironically - is initialized but never used.
Feel free to deny if this is reserved for future implementation(s).
