### PR TITLE
Set the default timezone in tests bootstrap file.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+date_default_timezone_set('UTC');
+
 // Set up include path accordingly. This is especially required because some
 // class files of phpseclib require() other dependencies.
 set_include_path(implode(PATH_SEPARATOR, array(


### PR DESCRIPTION
Silences

> phpinfo(): It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.

warnings/errors.
