### PR TITLE
Base CodeSniffer ruleset on PEAR ruleset.

### DIFF
--- a/tests/code_sniffer_ruleset.xml
+++ b/tests/code_sniffer_ruleset.xml
@@ -3,6 +3,50 @@
 
  <description>phpseclib coding standard</description>
 
+ <!-- We are using the PEAR standard as a base -->
+ <rule ref="PEAR"/>
+
+ <!-- Temporary exceptions to the PEAR standard follow -->
+
+ <rule ref="Generic.ControlStructures.InlineControlStructure.Discouraged"><severity>0</severity></rule>
+ <rule ref="Generic.Files.LineLength.TooLong"><severity>0</severity></rule>
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma"><severity>0</severity></rule>
+ <rule ref="Generic.PHP.LowerCaseConstant.Found"><severity>0</severity></rule>
+ <rule ref="PEAR.NamingConventions.ValidFunctionName.FunctionNoCapital"><severity>0</severity></rule>
+ <rule ref="PEAR.NamingConventions.ValidFunctionName.NotCamelCaps"><severity>0</severity></rule>
+ <rule ref="PEAR.Classes.ClassDeclaration.OpenBraceNewLine"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.ClassComment.InvalidVersion"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.ClassComment.MissingTag"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.ClassComment.WrongTagOrder"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FileComment.EmptyCopyright"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FileComment.InvalidVersion"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FileComment.TagIndent"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.ExtraParamComment"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.MissingReturn"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.MissingParamComment"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.MissingParamName"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.MissingParamTag"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.ParameterCommentsNotAligned"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.ParameterNamesNotAligned"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.ParamNameNoMatch"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.SpacingAfterParams"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.SpacingBeforeParams"><severity>0</severity></rule>
+ <rule ref="PEAR.Commenting.FunctionComment.SpacingBeforeTags"><severity>0</severity></rule>
+ <rule ref="PEAR.ControlStructures.ControlSignature"><severity>0</severity></rule>
+ <rule ref="PEAR.Files.IncludingFile.BracketsNotRequired"><severity>0</severity></rule>
+ <rule ref="PEAR.Files.IncludingFile.UseIncludeOnce"><severity>0</severity></rule>
+ <rule ref="PEAR.Formatting.MultiLineAssignment.EqualSignLine"><severity>0</severity></rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"><severity>0</severity></rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine"><severity>0</severity></rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.Indent"><severity>0</severity></rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket"><severity>0</severity></rule>
+ <rule ref="PEAR.WhiteSpace.ScopeClosingBrace.BreakIdent"><severity>0</severity></rule>
+ <rule ref="PEAR.WhiteSpace.ScopeClosingBrace.Indent"><severity>0</severity></rule>
+ <rule ref="PEAR.WhiteSpace.ScopeClosingBrace.Line"><severity>0</severity></rule>
+ <rule ref="PEAR.WhiteSpace.ScopeIndent.Incorrect"><severity>0</severity></rule>
+
+ <!-- Useful additional rules follow -->
+
  <!-- "for (; bar; )" should be "while (bar)" instead -->
  <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop" />
 
@@ -11,24 +55,6 @@
 
  <!-- All code files MUST use only UTF-8 without BOM. -->
  <rule ref="Generic.Files.ByteOrderMark" />
-
- <!-- All code files MUST use the Unix LF (linefeed) line ending. -->
- <rule ref="Generic.Files.LineEndings" />
-
- <!-- Class constants MUST be declared in all upper case with underscore separators. -->
- <rule ref="Generic.NamingConventions.UpperCaseConstantName" />
-
- <!-- Only <?php, no short tags. -->
- <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound" />
-
- <!-- PHP keywords MUST be in lower case. -->
- <rule ref="Generic.PHP.LowerCaseKeyword" />
-
- <!-- Spaces MUST be used for indentation -->
- <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
-
- <!-- Method arguments with default values MUST go at the end of the argument list. -->
- <rule ref="PEAR.Functions.ValidDefaultValue" />
 
  <!-- In the argument list, there MUST NOT be a space before each comma,
       and there MUST be one space after each comma. -->


### PR DESCRIPTION
After this patch is merged we can fix and remove the temporary exceptions one-by-one.
