### PR TITLE
Added test for Net_SSH2::_format_log()

### DIFF
--- a/tests/Net/SSH2Test.php
+++ b/tests/Net/SSH2Test.php
@@ -29,9 +29,9 @@ class Net_SSH2Test extends PhpseclibTestCase
      */
     public function testFormatLog(array $message_log, array $message_number_log, $expected)
     {
-        $ssh = $this->getMockBuilder('Net_SSH1')
+        $ssh = $this->getMockBuilder('Net_SSH2')
             ->disableOriginalConstructor()
-            ->setMethods(null)
+            ->setMethods(array('__destruct'))
             ->getMock();
 
         $result = $ssh->_format_log($message_log, $message_number_log);


### PR DESCRIPTION
This test is required for proving #205. Fix depends on how we will solve #212.

Also this code is against dry, maybe we should discuss about moving the `Net_SSH1::_format_log` and `Net_SSH2::_format_log` to a own class like `Net_SSH_LogFormatter`? Then we can write just one test instead of two. @terrafrost what do you think, what's the best way to solve this?
