### PR TITLE
Refactored Net_SSH2::$identifier and added unit tests

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -958,7 +958,7 @@ class Net_SSH2
 
     /**
      * Generates the SSH identifier
-     * You should overwrite this method in your own class if you want to use an other identifier
+     * You should overwrite this method in your own class if you want to use another identifier
      *
      * @access protected
      * @return String

--- a/tests/Net/SSH2Test.php
+++ b/tests/Net/SSH2Test.php
@@ -65,13 +65,13 @@ class Net_SSH2Test extends PhpseclibTestCase
     public function testGenerateIdentifier($expected, array $requiredExtensions)
     {
         $notAllowed = array('gmp', 'bcmath', 'mcrypt', 'gmp');
-        foreach($notAllowed as $nowAllowedExtension) {
-            if(in_array($nowAllowedExtension, $requiredExtensions)) {
+        foreach($notAllowed as $notAllowedExtension) {
+            if(in_array($notAllowedExtension, $requiredExtensions)) {
                 continue;
             }
 
-            if(extension_loaded($nowAllowedExtension)) {
-                $this->markTestSkipped('Extension ' . $nowAllowedExtension . ' is not allowed for this data-set');
+            if(extension_loaded($notAllowedExtension)) {
+                $this->markTestSkipped('Extension ' . $notAllowedExtension . ' is not allowed for this data-set');
             }
         }
 


### PR DESCRIPTION
Currently there's no way to set the SSH-Identifier, this pull request tries to give you the posibility to do this. Now you can use `class MySSH extend Net_SSH2 { function _generate_identifier() { return 'MySSH'; } }` to overwrite this var

 This new way of generating the identifier made it testable, so I added some unit tests.
