### PR TITLE
Wrap crypt_random_string in if !function_exists

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -47,7 +47,7 @@
  */
 define('CRYPT_RANDOM_IS_WINDOWS', strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
 
-if (!function_exists('crypt_random_string')):
+if (!function_exists('crypt_random_string')) {
 /**
  * Generate a random string.
  *
@@ -245,4 +245,4 @@ function crypt_random_string($length)
     }
     return substr($result, 0, $length);
 }
-endif;
+}


### PR DESCRIPTION
Composer's "file" autoloader does a require instead of a require_once. This means that if you have two composer autoloaders in your project (common in Laravel 4 projects with workbenches) the function file is loaded twice and you get a fatal error of "cannot redeclare function".

Personally I prefer to wrap this in an if (...): endif; but using brackets is what complies with your codesniffer standards, so I updated to use that instead.

This is really only an issue with modern projects using composer, so if you'd rather I requested towards the PHP5 branch, please let me know.
