### PR TITLE
PHP_Compat is required when the PHP version below 4.3.3 (not above or eq...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "suggest": {
         "ext-mcrypt": "Install the Mcrypt extension in order to speed up a wide variety of cryptographic operations.",
         "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-        "pear-pear/PHP_Compat": "Install PHP_Compat to get phpseclib working on PHP >= 4.3.3."
+        "pear-pear/PHP_Compat": "Install PHP_Compat to get phpseclib working on PHP < 4.3.3."
     },
     "include-path": ["phpseclib/"],
     "autoload": {


### PR DESCRIPTION
...ual).

Caused by 98fb4936115f0295711713fae744d33e1e85cc78
