### PR TITLE
SSH2: ignore exit_status channel requests

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2918,12 +2918,9 @@ class Net_SSH2
                         case 'exit-status':
                             extract(unpack('Cfalse/Nexit_status', $this->_string_shift($response, 5)));
                             $this->exit_status = $exit_status;
-                            // "The channel needs to be closed with SSH_MSG_CHANNEL_CLOSE after this message."
-                            // -- http://tools.ietf.org/html/rfc4254#section-6.10
-                            $this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_EOF, $this->server_channels[$client_channel]));
-                            $this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_CLOSE, $this->server_channels[$channel]));
 
-                            $this->channel_status[$channel] = NET_SSH2_MSG_CHANNEL_EOF;
+                            // "The client MAY ignore these messages."
+                            // -- http://tools.ietf.org/html/rfc4254#section-6.10
 
                             break;
                         default:


### PR DESCRIPTION
Fixes #258 I think.

First, both logs show that an exit-status channel request was sent to the client from the server. The client (phpseclib) then closed the connection. The server still sent some info, however, before finally closing the connection off.

Ultimately, I think this problem, in turn, stems from an RFC ([RFC4254](http://tools.ietf.org/html/rfc4254#section-6.10)) that imho is unnecessary vague at some points. Quoting it...

```
   When the command running at the other end terminates, the following
   message can be sent to return the exit status of the command.
   Returning the status is RECOMMENDED.  No acknowledgement is sent for
   this message.  The channel needs to be closed with
   SSH_MSG_CHANNEL_CLOSE after this message.

   The client MAY ignore these messages.

      byte      SSH_MSG_CHANNEL_REQUEST
      uint32    recipient channel
      string    "exit-status"
      boolean   FALSE
      uint32    exit_status
```

It says the channel needs to be closed but it doesn't say by whom. phpseclib had been doing the closing but now I'm wondering if the subtext (since "the client MAY ignore these messages") is that it's the server that should be doing the closing and not the client.

That's what this commit does. Also, assuming this hypothesis is correct I've opened up an errata on RFC4254 concerning this matter. Maybe this'll get my name in that RFC :D

I was able to duplicate the problem described in #258 by uploading a file containing the letter a 1024 \* 1024 times and this fix fixed it for me.
