### PR TITLE
Drop version tags from doc blocks.

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -126,7 +126,6 @@ define('CRYPT_AES_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  *
  * @package Crypt_AES
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_AES extends Crypt_Rijndael

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -49,7 +49,6 @@
  * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
  * @copyright MMVII Jim Wigginton
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
- * @version   1.0.1
  * @link      http://phpseclib.sourceforge.net
  */
 
@@ -117,7 +116,6 @@ define('CRYPT_MODE_MCRYPT', 2);
  * @package Crypt_Base
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
- * @version 1.0.0
  * @access  public
  */
 class Crypt_Base

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -50,7 +50,6 @@
  * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
  * @copyright MMVII Jim Wigginton
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
- * @version   1.0
  * @link      http://phpseclib.sourceforge.net
  */
 
@@ -122,7 +121,6 @@ define('CRYPT_BLOWFISH_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  * @package Crypt_Blowfish
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
- * @version 1.0
  * @access  public
  */
 class Crypt_Blowfish extends Crypt_Base

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -140,7 +140,6 @@ define('CRYPT_DES_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  *
  * @package Crypt_DES
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_DES extends Crypt_Base

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -77,7 +77,6 @@ define('CRYPT_HASH_MODE_HASH',     3);
  *
  * @package Crypt_Hash
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_Hash

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -117,7 +117,6 @@ define('CRYPT_RC2_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  * Pure-PHP implementation of RC2.
  *
  * @package Crypt_RC2
- * @version 0.1.1
  * @access  public
  */
 class Crypt_RC2 extends Crypt_Base

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -96,7 +96,6 @@ define('CRYPT_RC4_DECRYPT', 1);
  *
  * @package Crypt_RC4
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_RC4 extends Crypt_Base

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -241,7 +241,6 @@ define('CRYPT_RSA_PUBLIC_FORMAT_PKCS1', 7);
  *
  * @package Crypt_RSA
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_RSA

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -137,7 +137,6 @@ define('CRYPT_RIJNDAEL_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  *
  * @package Crypt_Rijndael
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_Rijndael extends Crypt_Base

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -78,7 +78,6 @@ define('CRYPT_DES_MODE_CBC3', CRYPT_DES_MODE_CBC);
  *
  * @package Crypt_TripleDES
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Crypt_TripleDES extends Crypt_DES

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -50,7 +50,6 @@
  * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
  * @copyright MMVII Jim Wigginton
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
- * @version   1.0
  * @link      http://phpseclib.sourceforge.net
  */
 
@@ -122,7 +121,6 @@ define('CRYPT_TWOFISH_MODE_MCRYPT', CRYPT_MODE_MCRYPT);
  * @package Crypt_Twofish
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
- * @version 1.0
  * @access  public
  */
 class Crypt_Twofish extends Crypt_Base

--- a/phpseclib/File/ANSI.php
+++ b/phpseclib/File/ANSI.php
@@ -41,7 +41,6 @@
  *
  * @package File_ANSI
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.3.0
  * @access  public
  */
 class File_ANSI

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -112,7 +112,6 @@ define('FILE_ASN1_TYPE_ANY',             -2);
  *
  * @package File_ASN1
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.3.0
  * @access  public
  */
 class File_ASN1_Element
@@ -143,7 +142,6 @@ class File_ASN1_Element
  *
  * @package File_ASN1
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.3.0
  * @access  public
  */
 class File_ASN1

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -125,7 +125,6 @@ define('FILE_X509_ATTR_REPLACE', -3); // Clear first, then add a value.
  *
  * @package File_X509
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.3.1
  * @access  public
  */
 class File_X509

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -175,7 +175,6 @@ define('MATH_BIGINTEGER_KARATSUBA_CUTOFF', 25);
  *
  * @package Math_BigInteger
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 1.0.0RC4
  * @access  public
  */
 class Math_BigInteger

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -83,7 +83,6 @@ define('NET_SCP_SSH2',  2);
  *
  * @package Net_SCP
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Net_SCP

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -117,7 +117,6 @@ define('NET_SFTP_RESUME_START',  8);
  *
  * @package Net_SFTP
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Net_SFTP extends Net_SSH2

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -38,7 +38,6 @@
  *
  * @package Net_SFTP_Stream
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.3.2
  * @access  public
  */
 class Net_SFTP_Stream

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -227,7 +227,6 @@ define('NET_SSH1_READ_REGEX', 2);
  *
  * @package Net_SSH1
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Net_SSH1

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -145,7 +145,6 @@ define('NET_SSH2_LOG_MAX_SIZE', 1024 * 1024);
  *
  * @package Net_SSH2
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  public
  */
 class Net_SSH2

--- a/phpseclib/System/SSH_Agent.php
+++ b/phpseclib/System/SSH_Agent.php
@@ -77,7 +77,6 @@ define('SYSTEM_SSH_AGENT_SIGN_RESPONSE', 14);
  *
  * @package System_SSH_Agent
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  internal
  */
 class System_SSH_Agent_Identity
@@ -214,7 +213,6 @@ class System_SSH_Agent_Identity
  *
  * @package System_SSH_Agent
  * @author  Jim Wigginton <terrafrost@php.net>
- * @version 0.1.0
  * @access  internal
  */
 class System_SSH_Agent


### PR DESCRIPTION
Fixes #285

`find phpseclib -type f -name "*.php" -exec sed -i '/@version/d' {} \;`
