### PR TITLE
fix certificate validity encoding

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -162,7 +162,7 @@ class File_ASN1
      * @access private
      * @link http://php.net/class.datetime
      */
-    var $format = 'D, d M y H:i:s O';
+    var $format = 'D, d M Y H:i:s O';
 
     /**
      * Default date format


### PR DESCRIPTION
RFC 3280 requires in section
- 4.1.2.5 Validity
- 5.1.2.4 This Update
- 5.1.2.5 Next Update
- 5.1.2.6 Revoked Certificates
  that dates are to be encoded as utcTime iff they are before 2050 and
  as generalTime otherwise.

Currently, phpseclib does not respect this by always choosing generalTime.
Further, the format used interally to represent dates only keeps two digits,
so dates in 2050 and later cannot be represented in this format.

This patch fixes this by
1. changing the interal format to be capable of unambiguously representing
   dates in 2050 or later (i.e. use four digits to represent the year),
2. choosing between utcTime and generalTime accordingly.

Without this patch, openssl_x509_parse complains:
  Warning:  openssl_x509_parse(): illegal ASN1 data type for timestamp
