### PR TITLE
fix more ssh channel issues

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3144,14 +3144,15 @@ class Net_SSH2
                 ) - 4;
             }
 
+            $temp = $this->_string_shift($data, $max_size);
             $packet = pack('CN2a*',
                 NET_SSH2_MSG_CHANNEL_DATA,
                 $this->server_channels[$client_channel],
-                $max_size,
-                $this->_string_shift($data, $max_size)
+                strlen($temp),
+                $temp
             );
 
-            $this->window_size_client_to_server[$client_channel]-= $max_size + 4;
+            $this->window_size_client_to_server[$client_channel]-= strlen($temp) + 4;
 
             if (!$this->_send_binary_packet($packet)) {
                 return false;


### PR DESCRIPTION
Fixes #134

In logs that were provided to me phpseclib sent a packet that was 2536 bytes long (excluding the bytes denoting the channel and data length) but the length packet said it was 32764 bytes long (ie. $max_size).

So when $max_size is less than the data being sent and has to be adjusted by a new window adjust message from the server and the adjustment makes $max_Size bigger than the data being sent over problems arise.

SSH's window size has caused issues before. Overall I don't think the SSH specs really explain the window size very well. I opened up an errata on SSH's RFC a while back about the issue.
