### PR TITLE
Reenable SSH Functional Test on Travis CI PHP 5.3.3 and below.

### DIFF
--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -14,12 +14,6 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 
     static public function setUpBeforeClass()
     {
-        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '5.3.3', '<=')) {
-            self::markTestIncomplete(
-                'This test hangs on Travis CI on PHP 5.3.3 and below.'
-            );
-        }
-
         parent::setUpBeforeClass();
 
         self::$scratchDir = uniqid('phpseclib-sftp-scratch-');

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -8,16 +8,6 @@
 
 class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
 {
-    public function setUp()
-    {
-        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '5.3.3', '<=')) {
-            $this->markTestIncomplete(
-                'This test hangs on Travis CI on PHP 5.3.3 and below.'
-            );
-        }
-        parent::setUp();
-    }
-
     public function testConstructor()
     {
         $ssh = new Net_SSH2($this->getEnv('SSH_HOSTNAME'));


### PR DESCRIPTION
Fixes #279
Depend on #317