### PR TITLE
Add "Installing Dependencies" and "Contributing" sections to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AES, Blowfish, Twofish, SSH-1, SSH-2, SFTP, and X.509
 <img src="http://phpseclib.sourceforge.net/pear-icon.png" alt="PEAR Channel" width="16" height="16">
 PEAR Channel: [phpseclib.sourceforge.net](http://phpseclib.sourceforge.net/pear.htm)
 
-## Installing Dependencies
+## Installing Development Dependencies
 
 Dependencies are managed via Composer.
 
@@ -36,7 +36,7 @@ Dependencies are managed via Composer.
 
 1. Fork the Project
 
-2. Install Dependencies
+2. Install Development Dependencies
 
 3. Create a Feature Branch
 


### PR DESCRIPTION
Revival of #189

Check https://github.com/bantu/phpseclib/tree/readme-update to see this in action.
No idea why https://github.com/bantu/phpseclib/blob/readme-update/README.md displays differently.

cc @mpscholten
