### PR TITLE
Add mcrypt extension to require-dev in composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Dependencies are managed via Composer.
     php composer.phar install --dev
     ```
 
+3. Install any PHP extensions prompted by composer.
+
 ## Contributing
 
 1. Fork the Project

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     "require-dev": {
         "phing/phing": "2.7.*",
         "phpunit/phpunit": "4.0.*",
-        "squizlabs/php_codesniffer": "1.*"
+        "squizlabs/php_codesniffer": "1.*",
+        "ext-mcrypt": "*"
     },
     "suggest": {
         "ext-mcrypt": "Install the Mcrypt extension in order to speed up a wide variety of cryptographic operations.",


### PR DESCRIPTION
If you run the test suite without the `mcrypt` extension installed you get the following failure:

``` bash
$> ./vendor/bin/phpunit 
PHPUnit 4.0.14 by Sebastian Bergmann.

Configuration read from /home/mbfisher/git-projects/phpseclib/phpunit.xml.dist

...............................................................  63 / 217 ( 29%)
................................................SSSSSSSSSSSSSSS 126 / 217 ( 58%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 189 / 217 ( 87%)
SSSSSSSSSS.SSS.SS.SSF.....

Time: 237 ms, Memory: 14.00Mb

There was 1 failure:

1) Net_SSH2Test::testGenerateIdentifier with data set #5 ('SSH-2.0-phpseclib_0.3 (mcrypt, bcmath)', array('mcrypt', 'bcmath'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'SSH-2.0-phpseclib_0.3 (mcrypt, bcmath)'
+'SSH-2.0-phpseclib_0.3 (bcmath)'

/home/mbfisher/git-projects/phpseclib/tests/Net/SSH2Test.php:70

FAILURES!                                             
Tests: 128, Assertions: 151, Failures: 1, Skipped: 95.
```

This commit adds `ext-mcrypt` to the `require-dev` section of `composer.json`, so that composer prompts you to install it.

Could this be the case for other extensions I happen to have installed?

M
