### PR TITLE
ASN1: make File_ASN1 accept int primitives and not just Math_BigInteger ...

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -950,7 +950,7 @@ class File_ASN1
             case FILE_ASN1_TYPE_INTEGER:
             case FILE_ASN1_TYPE_ENUMERATED:
                 if (!isset($mapping['mapping'])) {
-                    if (is_int($source)) {
+                    if (is_numeric($source)) {
                         $source = new Math_BigInteger($source);
                     }
                     $value = $source->toBytes(true);


### PR DESCRIPTION
...objects when an integer is expected

The code to convert the regular integer type into the appropriate format could all just be in-line'd when an integer primitive is used but this approach is easier to read.
