### PR TITLE
SSH2: make it so callback functions can make exec() return early

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2355,7 +2355,7 @@ class Net_SSH2
             return true;
         }
 
-        $this->window_size_server_to_client[NET_SSH2_CHANNEL_SHELL] = 0x7FFFFFFF;
+        $this->window_size_server_to_client[NET_SSH2_CHANNEL_SHELL] = $this->window_size;
         $packet_size = 0x4000;
 
         $packet = pack('CNa*N3',


### PR DESCRIPTION
One of the problems with http://phpseclib.sourceforge.net/ssh/examples.html#callback is that it can't make exec() return early. ie. with that code sample it'll just loop endlessly. With this change you could make the callback function return true after that function has been called 10x times and then the exec() function would return control to the program.
