### PR TITLE
RSA: slight adjustment to CRYPT_RSA_PUBLIC_FORMAT_PKCS1_RAW format

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -2173,12 +2173,12 @@ class File_X509
         switch ($algorithm) {
             case 'rsaEncryption':
                 return
-                    "-----BEGIN PUBLIC KEY-----\r\n" .
+                    "-----BEGIN RSA PUBLIC KEY-----\r\n" .
                     // subjectPublicKey is stored as a bit string in X.509 certs.  the first byte of a bit string represents how many bits
                     // in the last byte should be ignored.  the following only supports non-zero stuff but as none of the X.509 certs Firefox
                     // uses as a cert authority actually use a non-zero bit I think it's safe to assume that none do.
                     chunk_split(base64_encode(substr(base64_decode($key), 1)), 64) .
-                    '-----END PUBLIC KEY-----';
+                    '-----END RSA PUBLIC KEY-----';
             default:
                 return $key;
         }


### PR DESCRIPTION
CRYPT_RSA_PUBLIC_FORMAT_PKCS1_RAW and CRYPT_RSA_PUBLIC_FORMAT_PKCS1
produce two very similar looking keys but they are not the same.
As dissection OpenSSL's asn1parse would reveal CRYPT_RSA_PUBLIC_FORMAT_PKCS1
has the fact that it is an RSA key embedded within it whereas
CRYPT_RSA_PUBLIC_FORMAT_PKCS1_RAW does not. phpseclib now resolves
this ambiguity in the same way that OpenSSH's ssh-keygen does.

Despite this change CRYPT_RSA_PUBLIC_FORMAT_PKCS1_RAW is still incompatible
with OpenSSL's rsautl (CRYPT_RSA_PUBLIC_FORMAT_PKCS1 is compatible). I guess
this incompatibility isn't just due to the headers but is also due to the
overall structure of the format.
