### PR TITLE
SSH2: make $mac_algorithms non-static

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1140,7 +1140,7 @@ class Net_SSH2
             $encryption_algorithms = array_values($encryption_algorithms);
         }
 
-        static $mac_algorithms = array(
+        $mac_algorithms = array(
             'hmac-sha1-96', // RECOMMENDED     first 96 bits of HMAC-SHA1 (digest length = 12, key length = 20)
             'hmac-sha1',    // REQUIRED        HMAC-SHA1 (digest length = key length = 20)
             'hmac-md5-96',  // OPTIONAL        first 96 bits of HMAC-MD5 (digest length = 12, key length = 16)


### PR DESCRIPTION
none of the other statically defined variables have the potential
to change as multiple Net_SSH2 objects are created but this one does.

ie. if you connect to one SSH-2.0-SSHD server then no subsequent server
will use hmac-sha1-96 even if it could
