### PR TITLE
Always correctly link to the constructor of Crypt_Base.

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -109,7 +109,7 @@ define('CRYPT_AES_MODE_OFB', CRYPT_MODE_OFB);
 
 /**#@+
  * @access private
- * @see Crypt_AES::Crypt_AES()
+ * @see Crypt_Base::Crypt_Base()
  */
 /**
  * Toggles the internal implementation

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -103,7 +103,7 @@ define('CRYPT_BLOWFISH_MODE_OFB', CRYPT_MODE_OFB);
 
 /**#@+
  * @access private
- * @see Crypt_Blowfish::Crypt_Blowfish()
+ * @see Crypt_Base::Crypt_Base()
  */
 /**
  * Toggles the internal implementation

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -123,7 +123,7 @@ define('CRYPT_DES_MODE_OFB', CRYPT_MODE_OFB);
 
 /**#@+
  * @access private
- * @see Crypt_DES::Crypt_DES()
+ * @see Crypt_Base::Crypt_Base()
  */
 /**
  * Toggles the internal implementation

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -120,7 +120,7 @@ define('CRYPT_RIJNDAEL_MODE_OFB', CRYPT_MODE_OFB);
 
 /**#@+
  * @access private
- * @see Crypt_Rijndael::Crypt_Rijndael()
+ * @see Crypt_Base::Crypt_Base()
  */
 /**
  * Toggles the internal implementation

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -103,7 +103,7 @@ define('CRYPT_TWOFISH_MODE_OFB', CRYPT_MODE_OFB);
 
 /**#@+
  * @access private
- * @see Crypt_Twofish::Crypt_Twofish()
+ * @see Crypt_Base::Crypt_Base()
  */
 /**
  * Toggles the internal implementation


### PR DESCRIPTION
Follows #376
