### PR TITLE
SSH2: make isConnected return true if even if we're not logged in

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2658,7 +2658,7 @@ class Net_SSH2
      */
     function isConnected()
     {
-        return $this->bitmap & NET_SSH2_MASK_LOGIN;
+        return $this->bitmap & NET_SSH2_MASK_CONNECTED;
     }
 
     /**


### PR DESCRIPTION
Fixes #411 

When `isConnected()` was first implemented multi-factor authentication was not supported and the connection was made in the constructor, neither of which are no longer the case.

Also, if you want to know if someone was successfully logged in you can already use the login() method anyway. isConnected()'s purpose was never that so much as it was to tell you if you were still connected after each successive command executed. ie. whether the server had disconnected you. It still does that even with this change - all this change does is give isConnected() one additional use-case where it might be desirable to use.
