### PR TITLE
Tests for Net_SSH2::isConnected() and more

### DIFF
--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -32,6 +32,36 @@ class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
 
     /**
     * @depends testConstructor
+    * @group github408
+    * @group github412
+    */
+    public function testPreLogin($ssh)
+    {
+        $this->assertFalse(
+            $ssh->isConnected(),
+            'Failed asserting that SSH2 is not connected after construction.'
+        );
+
+        $this->assertNotEmpty(
+            $ssh->getServerPublicHostKey(),
+            'Failed asserting that a non-empty public host key was fetched.'
+        );
+
+        $this->assertTrue(
+            $ssh->isConnected(),
+            'Failed asserting that SSH2 is connected after public key fetch.'
+        );
+
+        $this->assertNotEmpty(
+            $ssh->getServerIdentification(),
+            'Failed asserting that the server identifier was set after connect.'
+        );
+
+        return $ssh;
+    }
+
+    /**
+    * @depends testPreLogin
     */
     public function testPasswordLogin($ssh)
     {


### PR DESCRIPTION
Follows #412
Reproduces #408 (invalid size) for me locally.
