### PR TITLE
Add hmac-sha2-256 MAC support

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1163,7 +1163,9 @@ class Net_SSH2
         }
 
         $mac_algorithms = array(
-            'hmac-sha2-256',// RECOMMENDED HMAC-SHA256 (digest length = key length = 32)
+            // from <http://www.ietf.org/rfc/rfc6668.txt>:
+            'hmac-sha2-256',// RECOMMENDED     HMAC-SHA256 (digest length = key length = 32)
+            
             'hmac-sha1-96', // RECOMMENDED     first 96 bits of HMAC-SHA1 (digest length = 12, key length = 20)
             'hmac-sha1',    // REQUIRED        HMAC-SHA1 (digest length = key length = 20)
             'hmac-md5-96',  // OPTIONAL        first 96 bits of HMAC-MD5 (digest length = 12, key length = 16)


### PR DESCRIPTION
This small patch adds hmac-sha2-256 support separately as requested in #423.

Some security standards now recommend to disable MD5 and SHA1, and use SHA2 instead. This change was tested using SHA2 against RHEL6's OpenSSH v5.3p1 and Solaris 11. And was also tested with RHEL5's OpenSSH 4.3p2 which doesn't include SHA2.
