### PR TITLE
SSH2: Add hmac-sha2-512.

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1164,6 +1164,7 @@ class Net_SSH2
 
         $mac_algorithms = array(
             // from <http://www.ietf.org/rfc/rfc6668.txt>:
+            'hmac-sha2-512',// OPTIONAL        HMAC-SHA512 (digest length = key length = 64)
             'hmac-sha2-256',// RECOMMENDED     HMAC-SHA256 (digest length = key length = 32)
 
             'hmac-sha1-96', // RECOMMENDED     first 96 bits of HMAC-SHA1 (digest length = 12, key length = 20)
@@ -1699,6 +1700,10 @@ class Net_SSH2
                 $this->hmac_create = new Crypt_Hash('sha256');
                 $createKeyLength = 32;
                 break;
+            case 'hmac-sha2-512':
+                $this->hmac_create = new Crypt_Hash('sha512');
+                $createKeyLength = 64;
+                break;
             case 'hmac-sha1':
                 $this->hmac_create = new Crypt_Hash('sha1');
                 $createKeyLength = 20;
@@ -1729,6 +1734,11 @@ class Net_SSH2
                 $this->hmac_check = new Crypt_Hash('sha256');
                 $checkKeyLength = 32;
                 $this->hmac_size = 32;
+                break;
+            case 'hmac-sha2-512':
+                $this->hmac_check = new Crypt_Hash('sha512');
+                $checkKeyLength = 64;
+                $this->hmac_size = 64;
                 break;
             case 'hmac-sha1':
                 $this->hmac_check = new Crypt_Hash('sha1');


### PR DESCRIPTION
Replaces #423 
Follows #429

I'll have hmac-sha2-512 at the top until this actually passes.
