### PR TITLE
Add missing Unit prefix to class Math_BigInteger_InternalTest.

### DIFF
--- a/tests/Unit/Math/BigInteger/InternalTest.php
+++ b/tests/Unit/Math/BigInteger/InternalTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-class Math_BigInteger_InternalTest extends Unit_Math_BigInteger_TestCase
+class Unit_Math_BigInteger_InternalTest extends Unit_Math_BigInteger_TestCase
 {
     static public function setUpBeforeClass()
     {


### PR DESCRIPTION
Found via https://github.com/phpseclib/phpseclib/issues/437#issuecomment-50738012
