### PR TITLE
Unit tests: changing the mode with runkit causes issues with static vars

### DIFF
--- a/tests/PhpseclibFunctionalTestCase.php
+++ b/tests/PhpseclibFunctionalTestCase.php
@@ -9,10 +9,12 @@ abstract class PhpseclibFunctionalTestCase extends PhpseclibTestCase
 {
     static public function setUpBeforeClass()
     {
-        self::ensureConstant('MATH_BIGINTEGER_MODE', MATH_BIGINTEGER_MODE_GMP);
-        self::ensureConstant('CRYPT_HASH_MODE', CRYPT_HASH_MODE_HASH);
-        self::reRequireFile('Math/BigInteger.php');
-        self::reRequireFile('Crypt/Hash.php');
+        if (extension_loaded('runkit')) {
+            self::ensureConstant('MATH_BIGINTEGER_MODE', MATH_BIGINTEGER_MODE_GMP);
+            self::ensureConstant('CRYPT_HASH_MODE', CRYPT_HASH_MODE_HASH);
+            self::reRequireFile('Math/BigInteger.php');
+            self::reRequireFile('Crypt/Hash.php');
+        }
         parent::setUpBeforeClass();
     }
 


### PR DESCRIPTION
Fixes https://github.com/phpseclib/phpseclib/issues/437
