### PR TITLE
Error: "Constant CRYPT_RSA_MODE already defined"

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -532,7 +532,7 @@ class Crypt_RSA
                             define('MATH_BIGINTEGER_OPENSSL_DISABLE', true);
                     }
                     break;
-                case true:
+                default:
                     define('CRYPT_RSA_MODE', CRYPT_RSA_MODE_INTERNAL);
             }
         }


### PR DESCRIPTION
It happens if defined(MATH_BIGINTEGER_OPENSSL_DISABLE) && !function_exists('openssl_pkey_get_details')
