### PR TITLE
SSH2: don't count data length against window size

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2986,7 +2986,7 @@ class Net_SSH2
 
             extract(unpack('Ctype/Nchannel', $this->_string_shift($response, 5)));
 
-            $this->window_size_server_to_client[$channel]-= strlen($response) + 4;
+            $this->window_size_server_to_client[$channel]-= strlen($response);
 
             // resize the window, if appropriate
             if ($this->window_size_server_to_client[$channel] < 0) {
@@ -3284,7 +3284,7 @@ class Net_SSH2
         $max_size = min(
             $this->packet_size_client_to_server[$client_channel],
             $this->window_size_client_to_server[$client_channel]
-        ) - 4;
+        );
         while (strlen($data) > $max_size) {
             if (!$this->window_size_client_to_server[$client_channel]) {
                 $this->bitmap^= NET_SSH2_MASK_WINDOW_ADJUST;
@@ -3294,7 +3294,7 @@ class Net_SSH2
                 $max_size = min(
                     $this->packet_size_client_to_server[$client_channel],
                     $this->window_size_client_to_server[$client_channel]
-                ) - 4;
+                );
             }
 
             $temp = $this->_string_shift($data, $max_size);
@@ -3305,20 +3305,20 @@ class Net_SSH2
                 $temp
             );
 
-            $this->window_size_client_to_server[$client_channel]-= strlen($temp) + 4;
+            $this->window_size_client_to_server[$client_channel]-= strlen($temp);
 
             if (!$this->_send_binary_packet($packet)) {
                 return false;
             }
         }
 
-        if (strlen($data) >= $this->window_size_client_to_server[$client_channel] - 4) {
+        if (strlen($data) >= $this->window_size_client_to_server[$client_channel]) {
             $this->bitmap^= NET_SSH2_MASK_WINDOW_ADJUST;
             $this->_get_channel_packet(-1);
             $this->bitmap^= NET_SSH2_MASK_WINDOW_ADJUST;
         }
 
-        $this->window_size_client_to_server[$client_channel]-= strlen($data) + 4;
+        $this->window_size_client_to_server[$client_channel]-= strlen($data);
 
         return $this->_send_binary_packet(pack('CN2a*',
             NET_SSH2_MSG_CHANNEL_DATA,


### PR DESCRIPTION
it is my hope that the issues 8c9e7a890e5755ee27fca66590ff5d2fa0616e56 and ccb1c3e2bdefd41cb3a7a21876eb0f5cd055c601 sought to resolve were fixed 9f8d8a7bf6c92d49f71dcadf585c898fcccd5c0d and 7a2c7a414c08d28f0700c7f6f8686a9e0e246a44.

Unfortunately, I don't think unit tests are really going to be feasible unless someone knows how to control how OpenSSH decides what window size to use (I don't).
