### PR TITLE
SSH2: rm unused constant

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2079,7 +2079,6 @@ class Net_SSH2
 
                 if (!count($responses) && $num_prompts) {
                     $this->last_interactive_response = $orig;
-                    $this->bitmap |= NET_SSH_MASK_LOGIN_INTERACTIVE;
                     return false;
                 }
 


### PR DESCRIPTION
Fixes #467.

The constant doesn't need to be defined since the `strlen($this->last_interactive_response)` check in `_login_helper` serves the same purpose that `NET_SSH_MASK_LOGIN_INTERACTIVE` was intended to serve
