### PR TITLE
BigInteger: accommodate GMP change in PHP 5.6

### DIFF
--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -329,9 +329,12 @@ class Math_BigInteger
 
         switch ( MATH_BIGINTEGER_MODE ) {
             case MATH_BIGINTEGER_MODE_GMP:
-                if (is_resource($x) && get_resource_type($x) == 'GMP integer') {
-                    $this->value = $x;
-                    return;
+                switch (true) {
+                    case is_resource($x) && get_resource_type($x) == 'GMP integer':
+                    // PHP 5.6 switched GMP from using resources to objects
+                    case is_object($x) && get_class($x) == 'GMP':
+                        $this->value = $x;
+                        return;
                 }
                 $this->value = gmp_init(0);
                 break;


### PR DESCRIPTION
There were more PHP 5.6 changes than just this but all of the other changes are BC with the way BigInteger is using GMP and do not yield any significant speedup as can be verified using https://github.com/terrafrost/phpseclib/tree/gmp-overload-exp

More info on the PHP 5.6 changes:

https://wiki.php.net/rfc/operator_overloading_gmp
