### PR TITLE
SFTP: Replace incorrect comment about filesize. There is no 4 GiB limit.

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2473,11 +2473,12 @@ class Net_SFTP extends Net_SSH2
         foreach ($this->attributes as $key => $value) {
             switch ($flags & $key) {
                 case NET_SFTP_ATTR_SIZE: // 0x00000001
-                    // size is represented by a 64-bit integer, so we perhaps ought to be doing the following:
-                    // $attr['size'] = new Math_BigInteger($this->_string_shift($response, 8), 256);
-                    // of course, you shouldn't be using Net_SFTP to transfer files that are in excess of 4GB
-                    // (0xFFFFFFFF bytes), anyway.  as such, we'll just represent all file sizes that are bigger than
-                    // 4GB as being 4GB.
+                    // The size attribute is defined as an unsigned 64-bit integer.
+                    // The following will use floats on 32-bit platforms, if necessary.
+                    // As can be seen in the BigInteger class, floats are generally
+                    // IEEE 754 binary64 "double precision" on such platforms and
+                    // as such can represent integers of at least 2^50 without loss
+                    // of precision. Interpreted in filesize, 2^50 bytes = 1024 TiB.
                     extract(unpack('Nupper/Nsize', $this->_string_shift($response, 8)));
                     $attr['size'] = $upper ? 4294967296 * $upper : 0;
                     $attr['size']+= $size < 0 ? ($size & 0x7FFFFFFF) + 0x80000000 : $size;


### PR DESCRIPTION
- There is no 2 or 4 GiB limit. It has been removed by 2c80ac8acad6d4b0c486d4e5db63ac6e27b3e4ea (which was followed by 0f5b3ea41613545869dc2546b691e4e686796591).
- The BigInteger comment is suboptimal. As we have seen, we can use floats for the time being.

I am not sure there are any problems with the actual statements below, but here is an alternative version which may or may not have more desirable properties: `$attr['size'] = hexdec(bin2hex($this->_string_shift($response, 8)));`
