### PR TITLE
Alias the php5 branch as 2.0.x for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3-dev"
+            "dev-php5": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
I don't know how long it will be until the master switches to target 1.0, so for now, it would be cool to alias the php5 branch to 2.0.
