### PR TITLE
Avoid calling fclose(false)

### DIFF
--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -195,7 +195,6 @@ class Net_SCP
 
             $fp = @fopen($data, 'rb');
             if (!$fp) {
-                fclose($fp);
                 return false;
             }
             $size = filesize($data);


### PR DESCRIPTION
The previous code would always call fclose(false) if the file was not successfully opened - resulting in a PHP notice.
