### PR TITLE
Quote shell argument with escapeshellarg()

### DIFF
--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -170,7 +170,7 @@ class Net_SCP
             return false;
         }
 
-        if (!$this->ssh->exec('scp -t "' . $remote_file . '"', false)) { // -t = to
+        if (!$this->ssh->exec('scp -t ' . escapeshellarg($remote_file), false)) { // -t = to
             return false;
         }
 
@@ -244,7 +244,7 @@ class Net_SCP
             return false;
         }
 
-        if (!$this->ssh->exec('scp -f "' . $remote_file . '"', false)) { // -f = from
+        if (!$this->ssh->exec('scp -f ' . escapeshellarg($remote_file), false)) { // -f = from
             return false;
         }
 


### PR DESCRIPTION
Currently, the call to "scp -t" or "scp -f" just uses naive quoting - i.e. a couple of quote marks are thrown in.

But, this can easily be escaped from - if the filename has a quote mark of its own in it, for example.

e.g. if the filename is as follows, then bad things will happen:

 ";rm -rf /;

Instead, escapeshellarg should be used, to make sure it gets escaped properly.
