### PR TITLE
Properly skip SFTPLargeFileTest when environment variables not defined.

### DIFF
--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -43,8 +43,10 @@ class Functional_Net_SFTPLargeFileTest extends PhpseclibFunctionalTestCase
 
     public function tearDown()
     {
-        $this->sftp->chdir($this->getEnv('SSH_HOME'));
-        $this->sftp->delete($this->scratchDir);
+        if ($this->sftp) {
+            $this->sftp->chdir($this->getEnv('SSH_HOME'));
+            $this->sftp->delete($this->scratchDir);
+        }
         parent::tearDown();
     }
 


### PR DESCRIPTION
Fixes PHP Fatal error:  Call to a member function chdir() on a non-object in tests/Functional/Net/SFTPLargeFileTest.php on line 46
