### PR TITLE
Use _MODE instead of the incorrect _ENGINE.

### DIFF
--- a/tests/Unit/Crypt/AES/InternalTest.php
+++ b/tests/Unit/Crypt/AES/InternalTest.php
@@ -11,7 +11,7 @@ class Unit_Crypt_AES_InternalTest extends Unit_Crypt_AES_TestCase
     {
         parent::setUpBeforeClass();
 
-        self::ensureConstant('CRYPT_AES_ENGINE', Crypt_AES::ENGINE_INTERNAL);
-        self::ensureConstant('CRYPT_RIJNDAEL_ENGINE', Crypt_Rijndael::ENGINE_INTERNAL);
+        self::ensureConstant('CRYPT_AES_MODE', Crypt_AES::ENGINE_INTERNAL);
+        self::ensureConstant('CRYPT_RIJNDAEL_MODE', Crypt_Rijndael::ENGINE_INTERNAL);
     }
 }

--- a/tests/Unit/Crypt/AES/McryptTest.php
+++ b/tests/Unit/Crypt/AES/McryptTest.php
@@ -15,7 +15,7 @@ class Unit_Crypt_AES_McryptTest extends Unit_Crypt_AES_TestCase
 
         parent::setUpBeforeClass();
 
-        self::ensureConstant('CRYPT_AES_ENGINE', Crypt_AES::ENGINE_MCRYPT);
-        self::ensureConstant('CRYPT_RIJNDAEL_ENGINE', Crypt_Rijndael::ENGINE_MCRYPT);
+        self::ensureConstant('CRYPT_AES_MODE', Crypt_AES::ENGINE_MCRYPT);
+        self::ensureConstant('CRYPT_RIJNDAEL_MODE', Crypt_Rijndael::ENGINE_MCRYPT);
     }
 }


### PR DESCRIPTION
Partially reverts 0305a4827ccdb14b4746d6539e8813e214cd047e.
