### PR TITLE
Fix SSH1 undefined $raw error

### DIFF
--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -1095,6 +1095,7 @@ class SSH1
 
         $padding_length = 8 - ($temp['length'] & 7);
         $length = $temp['length'] + $padding_length;
+        $raw = '';
 
         while ($length > 0) {
             $temp = fread($this->fsock, $length);


### PR DESCRIPTION
This patch just initializes the $raw variable in the SSH1::_get_binary_packet method so PHP doesn't throw errors.
