### PR TITLE
Add callback to SFTP.php

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1784,6 +1784,7 @@ class Net_SFTP extends Net_SSH2
      * @param optional Integer $mode
      * @param optional Integer $start
      * @param optional Integer $local_start
+     * @param optional Callable $callback
      * @return Boolean
      * @access public
      * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - Net_SFTP::setMode().

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1788,7 +1788,7 @@ class Net_SFTP extends Net_SSH2
      * @access public
      * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - Net_SFTP::setMode().
      */
-    function put($remote_file, $data, $mode = NET_SFTP_STRING, $start = -1, $local_start = -1)
+    function put($remote_file, $data, $mode = NET_SFTP_STRING, $start = -1, $local_start = -1, $callback = null)
     {
         if (!($this->bitmap & NET_SSH2_MASK_LOGIN)) {
             return false;
@@ -1885,6 +1885,9 @@ class Net_SFTP extends Net_SSH2
                 return false;
             }
             $sent+= strlen($temp);
+            if (is_callable($callback)) {
+                call_user_func($callback, $sent);
+            }
 
             $i++;
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1784,7 +1784,7 @@ class Net_SFTP extends Net_SSH2
      * @param optional Integer $mode
      * @param optional Integer $start
      * @param optional Integer $local_start
-     * @param optional Callable $callback
+     * @param optional callable|null $callback
      * @return Boolean
      * @access public
      * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - Net_SFTP::setMode().


### PR DESCRIPTION
Currently, Net_SCP::put() has a callback parameter, allowing the consumer to monitor/log/report progress (or whatever they please).

This patch adds the same feature, working in the same way, to Net_SFTP::put()