### PR TITLE
Fixed totally incorrect docblocks

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -134,7 +134,7 @@ class Crypt_AES extends Crypt_Rijndael
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'AES';
@@ -146,7 +146,7 @@ class Crypt_AES extends Crypt_Rijndael
      *
      * @see Crypt_Rijndael::setBlockLength()
      * @access public
-     * @param Integer $length
+     * @param int $length
      */
     function setBlockLength($length)
     {
@@ -161,7 +161,7 @@ class Crypt_AES extends Crypt_Rijndael
      *
      * @see Crypt_Rijndael:setKeyLength()
      * @access public
-     * @param Integer $length
+     * @param int $length
      */
     function setKeyLength($length)
     {
@@ -183,7 +183,7 @@ class Crypt_AES extends Crypt_Rijndael
      * @see Crypt_Rijndael:setKey()
      * @see setKeyLength()
      * @access public
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -179,7 +179,7 @@ class Crypt_Base
      * Continuous Buffer status
      *
      * @see Crypt_Base::enableContinuousBuffer()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $continuousBuffer = false;
@@ -211,7 +211,7 @@ class Crypt_Base
      * Since mcrypt operates in continuous mode, by default, it'll need to be recreated when in non-continuous mode.
      *
      * @see Crypt_Base::encrypt()
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $enmcrypt;
@@ -223,7 +223,7 @@ class Crypt_Base
      * Since mcrypt operates in continuous mode, by default, it'll need to be recreated when in non-continuous mode.
      *
      * @see Crypt_Base::decrypt()
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $demcrypt;
@@ -233,7 +233,7 @@ class Crypt_Base
      *
      * @see Crypt_Twofish::setKey()
      * @see Crypt_Twofish::setIV()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $enchanged = true;
@@ -243,7 +243,7 @@ class Crypt_Base
      *
      * @see Crypt_Twofish::setKey()
      * @see Crypt_Twofish::setIV()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $dechanged = true;
@@ -262,7 +262,7 @@ class Crypt_Base
      * @see Crypt_Base::encrypt()
      * @see Crypt_Base::decrypt()
      * @see Crypt_Base::_setupMcrypt()
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $ecb;
@@ -295,7 +295,7 @@ class Crypt_Base
      * @see setKey()
      * @see setIV()
      * @see disableContinuousBuffer()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $changed = true;
@@ -304,7 +304,7 @@ class Crypt_Base
      * Padding status
      *
      * @see Crypt_Base::enablePadding()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $padding = true;
@@ -313,7 +313,7 @@ class Crypt_Base
      * Is the mode one that is paddable?
      *
      * @see Crypt_Base::Crypt_Base()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $paddable = false;
@@ -551,7 +551,7 @@ class Crypt_Base
      * @see Crypt/Hash.php
      * @param string $password
      * @param optional string $method
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function setPassword($password, $method = 'pbkdf2')

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -124,7 +124,7 @@ class Crypt_Base
      * The Encryption Mode
      *
      * @see Crypt_Base::Crypt_Base()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $mode;
@@ -132,7 +132,7 @@ class Crypt_Base
     /**
      * The Block Length of the block cipher
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $block_size = 16;
@@ -141,7 +141,7 @@ class Crypt_Base
      * The Key
      *
      * @see Crypt_Base::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
@@ -150,7 +150,7 @@ class Crypt_Base
      * The Initialization Vector
      *
      * @see Crypt_Base::setIV()
-     * @var String
+     * @var string
      * @access private
      */
     var $iv;
@@ -160,7 +160,7 @@ class Crypt_Base
      *
      * @see Crypt_Base::enableContinuousBuffer()
      * @see Crypt_Base::_clearBuffers()
-     * @var String
+     * @var string
      * @access private
      */
     var $encryptIV;
@@ -170,7 +170,7 @@ class Crypt_Base
      *
      * @see Crypt_Base::enableContinuousBuffer()
      * @see Crypt_Base::_clearBuffers()
-     * @var String
+     * @var string
      * @access private
      */
     var $decryptIV;
@@ -284,7 +284,7 @@ class Crypt_Base
      * on its internaly Key-expanding algorithm.
      *
      * @see Crypt_Base::encrypt()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 600;
@@ -334,7 +334,7 @@ class Crypt_Base
      *
      * @see Crypt_Base::encrypt()
      * @see Crypt_Base::decrypt()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $engine;
@@ -347,7 +347,7 @@ class Crypt_Base
      * @link http://www.php.net/mcrypt_module_open
      * @link http://www.php.net/mcrypt_list_algorithms
      * @see Crypt_Base::_setupMcrypt()
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt;
@@ -356,7 +356,7 @@ class Crypt_Base
      * The default password key_size used by setPassword()
      *
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 32;
@@ -365,7 +365,7 @@ class Crypt_Base
      * The default salt used by setPassword()
      *
      * @see Crypt_Base::setPassword()
-     * @var String
+     * @var string
      * @access private
      */
     var $password_default_salt = 'phpseclib/salt';
@@ -388,7 +388,7 @@ class Crypt_Base
      * $aes = new Crypt_AES(CRYPT_MODE_CFB);     // identical
      *
      * @see Crypt_Base::Crypt_Base()
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace;
@@ -440,7 +440,7 @@ class Crypt_Base
      *
      * If not explicitly set, CRYPT_MODE_CBC will be used.
      *
-     * @param optional Integer $mode
+     * @param int $mode (optional)
      * @access public
      */
     function Crypt_Base($mode = CRYPT_MODE_CBC)
@@ -504,7 +504,7 @@ class Crypt_Base
      * Note: Could, but not must, extend by the child Crypt_* class
      *
      * @access public
-     * @param String $iv
+     * @param string $iv
      */
     function setIV($iv)
     {
@@ -529,7 +529,7 @@ class Crypt_Base
      * Note: Could, but not must, extend by the child Crypt_* class
      *
      * @access public
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -549,8 +549,8 @@ class Crypt_Base
      * Note: Could, but not must, extend by the child Crypt_* class
      *
      * @see Crypt/Hash.php
-     * @param String $password
-     * @param optional String $method
+     * @param string $password
+     * @param optional string $method
      * @return Boolean
      * @access public
      */
@@ -649,8 +649,8 @@ class Crypt_Base
      *
      * @see Crypt_Base::decrypt()
      * @access public
-     * @param String $plaintext
-     * @return String $cipertext
+     * @param string $plaintext
+     * @return string $cipertext
      */
     function encrypt($plaintext)
     {
@@ -877,8 +877,8 @@ class Crypt_Base
      *
      * @see Crypt_Base::encrypt()
      * @access public
-     * @param String $ciphertext
-     * @return String $plaintext
+     * @param string $ciphertext
+     * @return string $plaintext
      */
     function decrypt($ciphertext)
     {
@@ -1187,8 +1187,8 @@ class Crypt_Base
      * Note: Must extend by the child Crypt_* class
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -1201,8 +1201,8 @@ class Crypt_Base
      * Note: Must extend by the child Crypt_* class
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {
@@ -1328,9 +1328,9 @@ class Crypt_Base
      * and padding will, hence forth, be enabled.
      *
      * @see Crypt_Base::_unpad()
-     * @param String $text
+     * @param string $text
      * @access private
-     * @return String
+     * @return string
      */
     function _pad($text)
     {
@@ -1357,9 +1357,9 @@ class Crypt_Base
      * and false will be returned.
      *
      * @see Crypt_Base::_pad()
-     * @param String $text
+     * @param string $text
      * @access private
-     * @return String
+     * @return string
      */
     function _unpad($text)
     {
@@ -1398,14 +1398,14 @@ class Crypt_Base
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
+     * @param string $string
+     * @param int $index (optional)
      * @access private
-     * @return String
+     * @return string
      */
     function _stringShift(&$string, $index = 1)
     {
@@ -1422,10 +1422,10 @@ class Crypt_Base
      *
      * @see Crypt_Base::decrypt()
      * @see Crypt_Base::encrypt()
-     * @param String $iv
-     * @param Integer $length
+     * @param string $iv
+     * @param int $length
      * @access private
-     * @return String $xor
+     * @return string $xor
      */
     function _generateXor(&$iv, $length)
     {
@@ -1635,7 +1635,7 @@ class Crypt_Base
      * @see Crypt_Base::decrypt()
      * @param Array $cipher_code
      * @access private
-     * @return String (the name of the created callback function)
+     * @return string (the name of the created callback function)
      */
     function _createInlineCryptFunction($cipher_code)
     {

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -129,7 +129,7 @@ class Crypt_Blowfish extends Crypt_Base
      * Block Length of the cipher
      *
      * @see Crypt_Base::block_size
-     * @var Integer
+     * @var int
      * @access private
      */
     var $block_size = 8;
@@ -139,7 +139,7 @@ class Crypt_Blowfish extends Crypt_Base
      *
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 56;
@@ -148,7 +148,7 @@ class Crypt_Blowfish extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'BLOWFISH';
@@ -157,7 +157,7 @@ class Crypt_Blowfish extends Crypt_Base
      * The mcrypt specific name of the cipher
      *
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'blowfish';
@@ -166,7 +166,7 @@ class Crypt_Blowfish extends Crypt_Base
      * Optimizing value while CFB-encrypting
      *
      * @see Crypt_Base::cfb_init_len
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 500;
@@ -380,7 +380,7 @@ class Crypt_Blowfish extends Crypt_Base
      *
      * @access public
      * @see Crypt_Base::setKey()
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -455,8 +455,8 @@ class Crypt_Blowfish extends Crypt_Base
      * Encrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -491,8 +491,8 @@ class Crypt_Blowfish extends Crypt_Base
      * Decrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -148,7 +148,7 @@ class Crypt_DES extends Crypt_Base
      * Block Length of the cipher
      *
      * @see Crypt_Base::block_size
-     * @var Integer
+     * @var int
      * @access private
      */
     var $block_size = 8;
@@ -158,7 +158,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_Base::key
      * @see setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key = "\0\0\0\0\0\0\0\0";
@@ -168,7 +168,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 8;
@@ -177,7 +177,7 @@ class Crypt_DES extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'DES';
@@ -186,7 +186,7 @@ class Crypt_DES extends Crypt_Base
      * The mcrypt specific name of the cipher
      *
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'des';
@@ -195,7 +195,7 @@ class Crypt_DES extends Crypt_Base
      * Optimizing value while CFB-encrypting
      *
      * @see Crypt_Base::cfb_init_len
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 500;
@@ -207,7 +207,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_DES::_setupKey()
      * @see Crypt_DES::_processBlock()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $des_rounds = 1;
@@ -216,7 +216,7 @@ class Crypt_DES extends Crypt_Base
      * max possible size of $key
      *
      * @see Crypt_DES::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key_size_max = 8;
@@ -674,7 +674,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_Base::setKey()
      * @access public
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -695,8 +695,8 @@ class Crypt_DES extends Crypt_Base
      * @see Crypt_Base::encrypt()
      * @see Crypt_DES::encrypt()
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -710,8 +710,8 @@ class Crypt_DES extends Crypt_Base
      * @see Crypt_Base::decrypt()
      * @see Crypt_DES::decrypt()
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {
@@ -728,9 +728,9 @@ class Crypt_DES extends Crypt_Base
      * @see Crypt_DES::_encryptBlock()
      * @see Crypt_DES::_decryptBlock()
      * @access private
-     * @param String $block
-     * @param Integer $mode
-     * @return String
+     * @param string $block
+     * @param int $mode
+     * @return string
      */
     function _processBlock($block, $mode)
     {

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -85,7 +85,7 @@ class Crypt_Hash
      * Hash Parameter
      *
      * @see Crypt_Hash::setHash()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $hashParam;
@@ -94,7 +94,7 @@ class Crypt_Hash
      * Byte-length of compression blocks / key (Internal HMAC)
      *
      * @see Crypt_Hash::setAlgorithm()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $b;
@@ -103,7 +103,7 @@ class Crypt_Hash
      * Byte-length of hash output (Internal HMAC)
      *
      * @see Crypt_Hash::setHash()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $l = false;
@@ -112,7 +112,7 @@ class Crypt_Hash
      * Hash Algorithm
      *
      * @see Crypt_Hash::setHash()
-     * @var String
+     * @var string
      * @access private
      */
     var $hash;
@@ -121,7 +121,7 @@ class Crypt_Hash
      * Key
      *
      * @see Crypt_Hash::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key = false;
@@ -130,7 +130,7 @@ class Crypt_Hash
      * Outer XOR (Internal HMAC)
      *
      * @see Crypt_Hash::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $opad;
@@ -139,7 +139,7 @@ class Crypt_Hash
      * Inner XOR (Internal HMAC)
      *
      * @see Crypt_Hash::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $ipad;
@@ -147,7 +147,7 @@ class Crypt_Hash
     /**
      * Default Constructor.
      *
-     * @param optional String $hash
+     * @param optional string $hash
      * @return Crypt_Hash
      * @access public
      */
@@ -175,7 +175,7 @@ class Crypt_Hash
      * Keys can be of any length.
      *
      * @access public
-     * @param optional String $key
+     * @param optional string $key
      */
     function setKey($key = false)
     {
@@ -188,7 +188,7 @@ class Crypt_Hash
      * As set by the constructor or by the setHash() method.
      *
      * @access public
-     * @return String
+     * @return string
      */
     function getHash()
     {
@@ -199,7 +199,7 @@ class Crypt_Hash
      * Sets the hash function.
      *
      * @access public
-     * @param String $hash
+     * @param string $hash
      */
     function setHash($hash)
     {
@@ -306,8 +306,8 @@ class Crypt_Hash
      * Compute the HMAC.
      *
      * @access public
-     * @param String $text
-     * @return String
+     * @param string $text
+     * @return string
      */
     function hash($text)
     {
@@ -356,7 +356,7 @@ class Crypt_Hash
      * Returns the hash length (in bytes)
      *
      * @access public
-     * @return Integer
+     * @return int
      */
     function getLength()
     {
@@ -367,7 +367,7 @@ class Crypt_Hash
      * Wrapper for MD5
      *
      * @access private
-     * @param String $m
+     * @param string $m
      */
     function _md5($m)
     {
@@ -378,7 +378,7 @@ class Crypt_Hash
      * Wrapper for SHA1
      *
      * @access private
-     * @param String $m
+     * @param string $m
      */
     function _sha1($m)
     {
@@ -391,7 +391,7 @@ class Crypt_Hash
      * See {@link http://tools.ietf.org/html/rfc1319 RFC1319}.
      *
      * @access private
-     * @param String $m
+     * @param string $m
      */
     function _md2($m)
     {
@@ -467,7 +467,7 @@ class Crypt_Hash
      * See {@link http://en.wikipedia.org/wiki/SHA_hash_functions#SHA-256_.28a_SHA-2_variant.29_pseudocode SHA-256 (a SHA-2 variant) pseudocode - Wikipedia}.
      *
      * @access private
-     * @param String $m
+     * @param string $m
      */
     function _sha256($m)
     {
@@ -572,7 +572,7 @@ class Crypt_Hash
      * Pure-PHP implementation of SHA384 and SHA512
      *
      * @access private
-     * @param String $m
+     * @param string $m
      */
     function _sha512($m)
     {
@@ -755,10 +755,10 @@ class Crypt_Hash
      * Right Rotate
      *
      * @access private
-     * @param Integer $int
-     * @param Integer $amt
+     * @param int $int
+     * @param int $amt
      * @see _sha256()
-     * @return Integer
+     * @return int
      */
     function _rightRotate($int, $amt)
     {
@@ -771,10 +771,10 @@ class Crypt_Hash
      * Right Shift
      *
      * @access private
-     * @param Integer $int
-     * @param Integer $amt
+     * @param int $int
+     * @param int $amt
      * @see _sha256()
-     * @return Integer
+     * @return int
      */
     function _rightShift($int, $amt)
     {
@@ -786,9 +786,9 @@ class Crypt_Hash
      * Not
      *
      * @access private
-     * @param Integer $int
+     * @param int $int
      * @see _sha256()
-     * @return Integer
+     * @return int
      */
     function _not($int)
     {
@@ -801,8 +801,8 @@ class Crypt_Hash
      * _sha256() adds multiple unsigned 32-bit integers.  Since PHP doesn't support unsigned integers and since the
      * possibility of overflow exists, care has to be taken.  Math_BigInteger() could be used but this should be faster.
      *
-     * @param Integer $...
-     * @return Integer
+     * @param int $...
+     * @return int
      * @see _sha256()
      * @access private
      */
@@ -823,13 +823,13 @@ class Crypt_Hash
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
-     * @return String
+     * @param string $string
+     * @param int $index (optional)
+     * @return string
      * @access private
      */
     function _string_shift(&$string, $index = 1)

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -125,7 +125,7 @@ class Crypt_RC2 extends Crypt_Base
      * Block Length of the cipher
      *
      * @see Crypt_Base::block_size
-     * @var Integer
+     * @var int
      * @access private
      */
     var $block_size = 8;
@@ -135,7 +135,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * @see Crypt_Base::key
      * @see setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key = "\0";
@@ -145,7 +145,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 16; // = 128 bits
@@ -154,7 +154,7 @@ class Crypt_RC2 extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'RC2';
@@ -163,7 +163,7 @@ class Crypt_RC2 extends Crypt_Base
      * The mcrypt specific name of the cipher
      *
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'rc2';
@@ -172,7 +172,7 @@ class Crypt_RC2 extends Crypt_Base
      * Optimizing value while CFB-encrypting
      *
      * @see Crypt_Base::cfb_init_len
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 500;
@@ -182,7 +182,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * @see Crypt_RC2::setKeyLength()
      * @see Crypt_RC2::setKey()
-     * @var Integer
+     * @var int
      * @access private
      * @internal Should be in range [1..1024].
      * @internal Changing this value after setting the key has no effect.
@@ -335,7 +335,7 @@ class Crypt_RC2 extends Crypt_Base
      * If not explicitly set, CRYPT_RC2_MODE_CBC will be used.
      *
      * @see Crypt_Base::Crypt_Base()
-     * @param optional Integer $mode
+     * @param int $mode (optional)
      * @access public
      */
     function Crypt_RC2($mode = CRYPT_RC2_MODE_CBC)
@@ -352,7 +352,7 @@ class Crypt_RC2 extends Crypt_Base
      *  Crypt_RC2::setKey() call.
      *
      * @access public
-     * @param Integer $length in bits
+     * @param int $length in bits
      */
     function setKeyLength($length)
     {
@@ -374,8 +374,8 @@ class Crypt_RC2 extends Crypt_Base
      *
      * @see Crypt_Base::setKey()
      * @access public
-     * @param String $key
-     * @param Integer $t1 optional          Effective key length in bits.
+     * @param string $key
+     * @param int $t1 optional          Effective key length in bits.
      */
     function setKey($key, $t1 = 0)
     {
@@ -422,8 +422,8 @@ class Crypt_RC2 extends Crypt_Base
      * @see Crypt_Base::_encryptBlock()
      * @see Crypt_Base::encrypt()
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -467,8 +467,8 @@ class Crypt_RC2 extends Crypt_Base
      * @see Crypt_Base::_decryptBlock()
      * @see Crypt_Base::decrypt()
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -107,7 +107,7 @@ class Crypt_RC4 extends Crypt_Base
      * so we the block_size to 0
      *
      * @see Crypt_Base::block_size
-     * @var Integer
+     * @var int
      * @access private
      */
     var $block_size = 0;
@@ -117,7 +117,7 @@ class Crypt_RC4 extends Crypt_Base
      *
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 128; // = 1024 bits
@@ -126,7 +126,7 @@ class Crypt_RC4 extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'RC4';
@@ -135,7 +135,7 @@ class Crypt_RC4 extends Crypt_Base
      * The mcrypt specific name of the cipher
      *
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'arcfour';
@@ -153,7 +153,7 @@ class Crypt_RC4 extends Crypt_Base
      * The Key
      *
      * @see Crypt_RC4::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key = "\0";
@@ -196,7 +196,7 @@ class Crypt_RC4 extends Crypt_Base
      * {@link http://www.rsa.com/rsalabs/node.asp?id=2009 http://www.rsa.com/rsalabs/node.asp?id=2009}
      * {@link http://en.wikipedia.org/wiki/Related_key_attack http://en.wikipedia.org/wiki/Related_key_attack}
      *
-     * @param String $iv
+     * @param string $iv
      * @see Crypt_RC4::setKey()
      * @access public
      */
@@ -212,7 +212,7 @@ class Crypt_RC4 extends Crypt_Base
      *
      * @access public
      * @see Crypt_Base::setKey()
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -225,8 +225,8 @@ class Crypt_RC4 extends Crypt_Base
      * @see Crypt_Base::decrypt()
      * @see Crypt_RC4::_crypt()
      * @access public
-     * @param String $plaintext
-     * @return String $ciphertext
+     * @param string $plaintext
+     * @return string $ciphertext
      */
     function encrypt($plaintext)
     {
@@ -245,8 +245,8 @@ class Crypt_RC4 extends Crypt_Base
      * @see Crypt_Base::encrypt()
      * @see Crypt_RC4::_crypt()
      * @access public
-     * @param String $ciphertext
-     * @return String $plaintext
+     * @param string $ciphertext
+     * @return string $plaintext
      */
     function decrypt($ciphertext)
     {
@@ -290,9 +290,9 @@ class Crypt_RC4 extends Crypt_Base
      * @see Crypt_RC4::encrypt()
      * @see Crypt_RC4::decrypt()
      * @access private
-     * @param String $text
-     * @param Integer $mode
-     * @return String $text
+     * @param string $text
+     * @param int $mode
+     * @return string $text
      */
     function _crypt($text, $mode)
     {

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1441,7 +1441,7 @@ class Crypt_RSA
      * Called by xml_set_element_handler()
      *
      * @access private
-     * @param Resource $parser
+     * @param resource $parser
      * @param string $name
      * @param Array $attribs
      */
@@ -1482,7 +1482,7 @@ class Crypt_RSA
      * Called by xml_set_element_handler()
      *
      * @access private
-     * @param Resource $parser
+     * @param resource $parser
      * @param string $name
      */
     function _stop_element_handler($parser, $name)
@@ -1499,7 +1499,7 @@ class Crypt_RSA
      * Called by xml_set_character_data_handler()
      *
      * @access private
-     * @param Resource $parser
+     * @param resource $parser
      * @param string $data
      */
     function _data_handler($parser, $data)
@@ -1660,7 +1660,7 @@ class Crypt_RSA
      * @access public
      * @param string $key optional
      * @param int $type optional
-     * @return Boolean
+     * @return bool
      */
     function setPublicKey($key = false, $type = false)
     {
@@ -1720,7 +1720,7 @@ class Crypt_RSA
      * @access public
      * @param string $key optional
      * @param int $type optional
-     * @return Boolean
+     * @return bool
      */
     function setPrivateKey($key = false, $type = false)
     {
@@ -2166,7 +2166,7 @@ class Crypt_RSA
      * @access private
      * @param string $x
      * @param string $y
-     * @return Boolean
+     * @return bool
      */
     function _equals($x, $y)
     {
@@ -2944,7 +2944,7 @@ class Crypt_RSA
      * @access public
      * @param string $message
      * @param string $signature
-     * @return Boolean
+     * @return bool
      */
     function verify($message, $signature)
     {

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -142,11 +142,11 @@ define('CRYPT_RSA_SIGNATURE_PKCS1', 2);
  */
 define('CRYPT_RSA_ASN1_INTEGER',     2);
 /**
- * ASN1 Bit String
+ * ASN1 Bit string
  */
 define('CRYPT_RSA_ASN1_BITSTRING',   3);
 /**
- * ASN1 Octet String
+ * ASN1 Octet string
  */
 define('CRYPT_RSA_ASN1_OCTETSTRING', 4);
 /**
@@ -291,7 +291,7 @@ class Crypt_RSA
     /**
      * Private Key Format
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $privateKeyFormat = CRYPT_RSA_PRIVATE_FORMAT_PKCS1;
@@ -299,7 +299,7 @@ class Crypt_RSA
     /**
      * Public Key Format
      *
-     * @var Integer
+     * @var int
      * @access public
      */
     var $publicKeyFormat = CRYPT_RSA_PUBLIC_FORMAT_PKCS8;
@@ -355,7 +355,7 @@ class Crypt_RSA
     /**
      * Hash name
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $hashName;
@@ -371,7 +371,7 @@ class Crypt_RSA
     /**
      * Length of hash function output
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $hLen;
@@ -379,7 +379,7 @@ class Crypt_RSA
     /**
      * Length of salt
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $sLen;
@@ -395,7 +395,7 @@ class Crypt_RSA
     /**
      * Length of MGF hash function output
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $mgfHLen;
@@ -403,7 +403,7 @@ class Crypt_RSA
     /**
      * Encryption mode
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $encryptionMode = CRYPT_RSA_ENCRYPTION_OAEP;
@@ -411,7 +411,7 @@ class Crypt_RSA
     /**
      * Signature mode
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $signatureMode = CRYPT_RSA_SIGNATURE_PSS;
@@ -427,7 +427,7 @@ class Crypt_RSA
     /**
      * Password
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $password = false;
@@ -445,7 +445,7 @@ class Crypt_RSA
     var $components = array();
 
     /**
-     * Current String
+     * Current string
      *
      * For use with parsing XML formatted keys.
      *
@@ -469,7 +469,7 @@ class Crypt_RSA
     /**
      * Public key comment field.
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $comment = 'phpseclib-generated-key';
@@ -558,7 +558,7 @@ class Crypt_RSA
      *
      * @access public
      * @param optional Integer $bits
-     * @param optional Integer $timeout
+     * @param int $time (optional)out
      * @param optional Math_BigInteger $p
      */
     function createKey($bits = 1024, $timeout = false, $partial = array())
@@ -737,8 +737,8 @@ class Crypt_RSA
      *
      * @access private
      * @see setPrivateKeyFormat()
-     * @param String $RSAPrivateKey
-     * @return String
+     * @param string $RSAPrivateKey
+     * @return string
      */
     function _convertPrivateKey($n, $e, $d, $primes, $exponents, $coefficients)
     {
@@ -937,8 +937,8 @@ class Crypt_RSA
      *
      * @access private
      * @see setPublicKeyFormat()
-     * @param String $RSAPrivateKey
-     * @return String
+     * @param string $RSAPrivateKey
+     * @return string
      */
     function _convertPublicKey($n, $e)
     {
@@ -1010,8 +1010,8 @@ class Crypt_RSA
      * @access private
      * @see _convertPublicKey()
      * @see _convertPrivateKey()
-     * @param String $key
-     * @param Integer $type
+     * @param string $key
+     * @param int $type
      * @return Array
      */
     function _parseKey($key, $type)
@@ -1428,7 +1428,7 @@ class Crypt_RSA
      * More specifically, this returns the size of the modulo in bits.
      *
      * @access public
-     * @return Integer
+     * @return int
      */
     function getSize()
     {
@@ -1442,7 +1442,7 @@ class Crypt_RSA
      *
      * @access private
      * @param Resource $parser
-     * @param String $name
+     * @param string $name
      * @param Array $attribs
      */
     function _start_element_handler($parser, $name, $attribs)
@@ -1483,7 +1483,7 @@ class Crypt_RSA
      *
      * @access private
      * @param Resource $parser
-     * @param String $name
+     * @param string $name
      */
     function _stop_element_handler($parser, $name)
     {
@@ -1500,7 +1500,7 @@ class Crypt_RSA
      *
      * @access private
      * @param Resource $parser
-     * @param String $data
+     * @param string $data
      */
     function _data_handler($parser, $data)
     {
@@ -1516,8 +1516,8 @@ class Crypt_RSA
      * Returns true on success and false on failure (ie. an incorrect password was provided or the key was malformed)
      *
      * @access public
-     * @param String $key
-     * @param Integer $type optional
+     * @param string $key
+     * @param int $type optional
      */
     function loadKey($key, $type = false)
     {
@@ -1634,7 +1634,7 @@ class Crypt_RSA
      * @see createKey()
      * @see loadKey()
      * @access public
-     * @param String $password
+     * @param string $password
      */
     function setPassword($password = false)
     {
@@ -1658,8 +1658,8 @@ class Crypt_RSA
      *
      * @see getPublicKey()
      * @access public
-     * @param String $key optional
-     * @param Integer $type optional
+     * @param string $key optional
+     * @param int $type optional
      * @return Boolean
      */
     function setPublicKey($key = false, $type = false)
@@ -1718,8 +1718,8 @@ class Crypt_RSA
      *
      * @see getPublicKey()
      * @access public
-     * @param String $key optional
-     * @param Integer $type optional
+     * @param string $key optional
+     * @param int $type optional
      * @return Boolean
      */
     function setPrivateKey($key = false, $type = false)
@@ -1749,8 +1749,8 @@ class Crypt_RSA
      *
      * @see getPublicKey()
      * @access public
-     * @param String $key
-     * @param Integer $type optional
+     * @param string $key
+     * @param int $type optional
      */
     function getPublicKey($type = CRYPT_RSA_PUBLIC_FORMAT_PKCS8)
     {
@@ -1772,8 +1772,8 @@ class Crypt_RSA
      *
      * @see getPublicKey()
      * @access public
-     * @param String $key
-     * @param Integer $type optional
+     * @param string $key
+     * @param int $type optional
      */
     function getPrivateKey($type = CRYPT_RSA_PUBLIC_FORMAT_PKCS1)
     {
@@ -1796,8 +1796,8 @@ class Crypt_RSA
      *
      * @see getPrivateKey()
      * @access private
-     * @param String $key
-     * @param Integer $type optional
+     * @param string $key
+     * @param int $type optional
      */
     function _getPrivatePublicKey($mode = CRYPT_RSA_PUBLIC_FORMAT_PKCS8)
     {
@@ -1843,7 +1843,7 @@ class Crypt_RSA
      * Generates the smallest and largest numbers requiring $bits bits
      *
      * @access private
-     * @param Integer $bits
+     * @param int $bits
      * @return Array
      */
     function _generateMinMax($bits)
@@ -1872,8 +1872,8 @@ class Crypt_RSA
      * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
      *
      * @access private
-     * @param String $string
-     * @return Integer
+     * @param string $string
+     * @return int
      */
     function _decodeLength(&$string)
     {
@@ -1893,8 +1893,8 @@ class Crypt_RSA
      * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
      *
      * @access private
-     * @param Integer $length
-     * @return String
+     * @param int $length
+     * @return string
      */
     function _encodeLength($length)
     {
@@ -1907,13 +1907,13 @@ class Crypt_RSA
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
-     * @return String
+     * @param string $string
+     * @param int $index (optional)
+     * @return string
      * @access private
      */
     function _string_shift(&$string, $index = 1)
@@ -1928,7 +1928,7 @@ class Crypt_RSA
      *
      * @see createKey()
      * @access public
-     * @param Integer $format
+     * @param int $format
      */
     function setPrivateKeyFormat($format)
     {
@@ -1940,7 +1940,7 @@ class Crypt_RSA
      *
      * @see createKey()
      * @access public
-     * @param Integer $format
+     * @param int $format
      */
     function setPublicKeyFormat($format)
     {
@@ -1954,7 +1954,7 @@ class Crypt_RSA
      * decryption.  If $hash isn't supported, sha1 is used.
      *
      * @access public
-     * @param String $hash
+     * @param string $hash
      */
     function setHash($hash)
     {
@@ -1983,7 +1983,7 @@ class Crypt_RSA
      * best if Hash and MGFHash are set to the same thing this is not a requirement.
      *
      * @access public
-     * @param String $hash
+     * @param string $hash
      */
     function setMGFHash($hash)
     {
@@ -2012,7 +2012,7 @@ class Crypt_RSA
      *    of the hash function Hash) and 0.
      *
      * @access public
-     * @param Integer $format
+     * @param int $format
      */
     function setSaltLength($sLen)
     {
@@ -2026,8 +2026,8 @@ class Crypt_RSA
      *
      * @access private
      * @param Math_BigInteger $x
-     * @param Integer $xLen
-     * @return String
+     * @param int $xLen
+     * @return string
      */
     function _i2osp($x, $xLen)
     {
@@ -2045,7 +2045,7 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-4.2 RFC3447#section-4.2}.
      *
      * @access private
-     * @param String $x
+     * @param string $x
      * @return Math_BigInteger
      */
     function _os2ip($x)
@@ -2139,7 +2139,7 @@ class Crypt_RSA
      * @access private
      * @param Math_BigInteger $x
      * @param Math_BigInteger $r
-     * @param Integer $i
+     * @param int $i
      * @return Math_BigInteger
      */
     function _blind($x, $r, $i)
@@ -2164,8 +2164,8 @@ class Crypt_RSA
      * Thanks for the heads up singpolyma!
      *
      * @access private
-     * @param String $x
-     * @param String $y
+     * @param string $x
+     * @param string $y
      * @return Boolean
      */
     function _equals($x, $y)
@@ -2260,9 +2260,9 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#appendix-B.2.1 RFC3447#appendix-B.2.1}.
      *
      * @access private
-     * @param String $mgfSeed
-     * @param Integer $mgfLen
-     * @return String
+     * @param string $mgfSeed
+     * @param int $mgfLen
+     * @return string
      */
     function _mgf1($mgfSeed, $maskLen)
     {
@@ -2285,9 +2285,9 @@ class Crypt_RSA
      * {http://en.wikipedia.org/wiki/Optimal_Asymmetric_Encryption_Padding OAES}.
      *
      * @access private
-     * @param String $m
-     * @param String $l
-     * @return String
+     * @param string $m
+     * @param string $l
+     * @return string
      */
     function _rsaes_oaep_encrypt($m, $l = '')
     {
@@ -2348,9 +2348,9 @@ class Crypt_RSA
      *    this document.
      *
      * @access private
-     * @param String $c
-     * @param String $l
-     * @return String
+     * @param string $c
+     * @param string $l
+     * @return string
      */
     function _rsaes_oaep_decrypt($c, $l = '')
     {
@@ -2407,8 +2407,8 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-7.2.1 RFC3447#section-7.2.1}.
      *
      * @access private
-     * @param String $m
-     * @return String
+     * @param string $m
+     * @return string
      */
     function _rsaes_pkcs1_v1_5_encrypt($m)
     {
@@ -2466,8 +2466,8 @@ class Crypt_RSA
      * not private key encrypted ciphertext's.
      *
      * @access private
-     * @param String $c
-     * @return String
+     * @param string $c
+     * @return string
      */
     function _rsaes_pkcs1_v1_5_decrypt($c)
     {
@@ -2515,8 +2515,8 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-9.1.1 RFC3447#section-9.1.1}.
      *
      * @access private
-     * @param String $m
-     * @param Integer $emBits
+     * @param string $m
+     * @param int $emBits
      */
     function _emsa_pss_encode($m, $emBits)
     {
@@ -2551,10 +2551,10 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-9.1.2 RFC3447#section-9.1.2}.
      *
      * @access private
-     * @param String $m
-     * @param String $em
-     * @param Integer $emBits
-     * @return String
+     * @param string $m
+     * @param string $em
+     * @param int $emBits
+     * @return string
      */
     function _emsa_pss_verify($m, $em, $emBits)
     {
@@ -2598,8 +2598,8 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-8.1.1 RFC3447#section-8.1.1}.
      *
      * @access private
-     * @param String $m
-     * @return String
+     * @param string $m
+     * @return string
      */
     function _rsassa_pss_sign($m)
     {
@@ -2624,9 +2624,9 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-8.1.2 RFC3447#section-8.1.2}.
      *
      * @access private
-     * @param String $m
-     * @param String $s
-     * @return String
+     * @param string $m
+     * @param string $s
+     * @return string
      */
     function _rsassa_pss_verify($m, $s)
     {
@@ -2664,9 +2664,9 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-9.2 RFC3447#section-9.2}.
      *
      * @access private
-     * @param String $m
-     * @param Integer $emLen
-     * @return String
+     * @param string $m
+     * @param int $emLen
+     * @return string
      */
     function _emsa_pkcs1_v1_5_encode($m, $emLen)
     {
@@ -2716,8 +2716,8 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-8.2.1 RFC3447#section-8.2.1}.
      *
      * @access private
-     * @param String $m
-     * @return String
+     * @param string $m
+     * @return string
      */
     function _rsassa_pkcs1_v1_5_sign($m)
     {
@@ -2746,8 +2746,8 @@ class Crypt_RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-8.2.2 RFC3447#section-8.2.2}.
      *
      * @access private
-     * @param String $m
-     * @return String
+     * @param string $m
+     * @return string
      */
     function _rsassa_pkcs1_v1_5_verify($m, $s)
     {
@@ -2790,7 +2790,7 @@ class Crypt_RSA
      * Valid values include CRYPT_RSA_ENCRYPTION_OAEP and CRYPT_RSA_ENCRYPTION_PKCS1.
      *
      * @access public
-     * @param Integer $mode
+     * @param int $mode
      */
     function setEncryptionMode($mode)
     {
@@ -2803,7 +2803,7 @@ class Crypt_RSA
      * Valid values include CRYPT_RSA_SIGNATURE_PSS and CRYPT_RSA_SIGNATURE_PKCS1
      *
      * @access public
-     * @param Integer $mode
+     * @param int $mode
      */
     function setSignatureMode($mode)
     {
@@ -2814,7 +2814,7 @@ class Crypt_RSA
      * Set public key comment.
      *
      * @access public
-     * @param String $comment
+     * @param string $comment
      */
     function setComment($comment)
     {
@@ -2825,7 +2825,7 @@ class Crypt_RSA
      * Get public key comment.
      *
      * @access public
-     * @return String
+     * @return string
      */
     function getComment()
     {
@@ -2841,8 +2841,8 @@ class Crypt_RSA
      *
      * @see decrypt()
      * @access public
-     * @param String $plaintext
-     * @return String
+     * @param string $plaintext
+     * @return string
      */
     function encrypt($plaintext)
     {
@@ -2880,8 +2880,8 @@ class Crypt_RSA
      *
      * @see encrypt()
      * @access public
-     * @param String $plaintext
-     * @return String
+     * @param string $plaintext
+     * @return string
      */
     function decrypt($ciphertext)
     {
@@ -2919,8 +2919,8 @@ class Crypt_RSA
      *
      * @see verify()
      * @access public
-     * @param String $message
-     * @return String
+     * @param string $message
+     * @return string
      */
     function sign($message)
     {
@@ -2942,8 +2942,8 @@ class Crypt_RSA
      *
      * @see sign()
      * @access public
-     * @param String $message
-     * @param String $signature
+     * @param string $message
+     * @param string $signature
      * @return Boolean
      */
     function verify($message, $signature)
@@ -2965,8 +2965,8 @@ class Crypt_RSA
      * Extract raw BER from Base64 encoding
      *
      * @access private
-     * @param String $str
-     * @return String
+     * @param string $str
+     * @return string
      */
     function _extractBER($str)
     {

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -558,7 +558,7 @@ class Crypt_RSA
      *
      * @access public
      * @param optional Integer $bits
-     * @param int $time (optional)out
+     * @param int $timeout (optional)
      * @param optional Math_BigInteger $p
      */
     function createKey($bits = 1024, $timeout = false, $partial = array())

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -61,8 +61,8 @@ if (!function_exists('crypt_random_string')) {
      * microoptimizations because this function has the potential of being called a huge number of times.
      * eg. for RSA key generation.
      *
-     * @param Integer $length
-     * @return String
+     * @param int $length
+     * @return string
      * @access public
      */
     function crypt_random_string($length)

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -190,7 +190,7 @@ class Crypt_Rijndael extends Crypt_Base
      * Has the key length explicitly been set or should it be derived from the key, itself?
      *
      * @see setKeyLength()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $explicit_key_length = false;

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -146,7 +146,7 @@ class Crypt_Rijndael extends Crypt_Base
      *
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 16;
@@ -155,7 +155,7 @@ class Crypt_Rijndael extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'RIJNDAEL';
@@ -171,7 +171,7 @@ class Crypt_Rijndael extends Crypt_Base
      * @see Crypt_Base::cipher_name_mcrypt
      * @see Crypt_Base::engine
      * @see _setupEngine()
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'rijndael-128';
@@ -181,7 +181,7 @@ class Crypt_Rijndael extends Crypt_Base
      *
      * @see Crypt_Base::password_default_salt
      * @see Crypt_Base::setPassword()
-     * @var String
+     * @var string
      * @access private
      */
     var $password_default_salt = 'phpseclib';
@@ -217,7 +217,7 @@ class Crypt_Rijndael extends Crypt_Base
      * The Block Length divided by 32
      *
      * @see setBlockLength()
-     * @var Integer
+     * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4.  Exists in conjunction with $block_size
      *    because the encryption / decryption / key schedule creation requires this number and not $block_size.  We could
@@ -231,7 +231,7 @@ class Crypt_Rijndael extends Crypt_Base
      * The Key Length
      *
      * @see setKeyLength()
-     * @var Integer
+     * @var int
      * @access private
      * @internal The max value is 256 / 8 = 32, the min value is 128 / 8 = 16.  Exists in conjunction with $Nk
      *    because the encryption / decryption / key schedule creation requires this number and not $key_size.  We could
@@ -244,7 +244,7 @@ class Crypt_Rijndael extends Crypt_Base
      * The Key Length divided by 32
      *
      * @see setKeyLength()
-     * @var Integer
+     * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4
      */
@@ -253,7 +253,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Number of Rounds
      *
-     * @var Integer
+     * @var int
      * @access private
      * @internal The max value is 14, the min value is 10.
      */
@@ -690,7 +690,7 @@ class Crypt_Rijndael extends Crypt_Base
      * @see Crypt_Base:setKey()
      * @see setKeyLength()
      * @access public
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -736,7 +736,7 @@ class Crypt_Rijndael extends Crypt_Base
      *             This results then in slower encryption.
      *
      * @access public
-     * @param Integer $length
+     * @param int $length
      */
     function setKeyLength($length)
     {
@@ -769,7 +769,7 @@ class Crypt_Rijndael extends Crypt_Base
      * 128.  If the length is greater than 128 and invalid, it will be rounded down to the closest valid amount.
      *
      * @access public
-     * @param Integer $length
+     * @param int $length
      */
     function setBlockLength($length)
     {
@@ -858,8 +858,8 @@ class Crypt_Rijndael extends Crypt_Base
      * Encrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -960,8 +960,8 @@ class Crypt_Rijndael extends Crypt_Base
      * Decrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {
@@ -1167,7 +1167,7 @@ class Crypt_Rijndael extends Crypt_Base
      * Performs S-Box substitutions
      *
      * @access private
-     * @param Integer $word
+     * @param int $word
      */
     function _subWord($word)
     {

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -88,7 +88,7 @@ class Crypt_TripleDES extends Crypt_DES
      * @see Crypt_DES::password_key_size
      * @see Crypt_Base::password_key_size
      * @see Crypt_Base::setPassword()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $password_key_size = 24;
@@ -98,7 +98,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_Base::password_default_salt
      * @see Crypt_Base::setPassword()
-     * @var String
+     * @var string
      * @access private
      */
     var $password_default_salt = 'phpseclib';
@@ -108,7 +108,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_DES::const_namespace
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'DES';
@@ -118,7 +118,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_DES::cipher_name_mcrypt
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'tripledes';
@@ -127,7 +127,7 @@ class Crypt_TripleDES extends Crypt_DES
      * Optimizing value while CFB-encrypting
      *
      * @see Crypt_Base::cfb_init_len
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 750;
@@ -137,7 +137,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_TripleDES::setKey()
      * @see Crypt_DES::setKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $key_size_max = 24;
@@ -183,7 +183,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_DES::Crypt_DES()
      * @see Crypt_Base::Crypt_Base()
-     * @param optional Integer $mode
+     * @param int $mode (optional)
      * @access public
      */
     function Crypt_TripleDES($mode = CRYPT_DES_MODE_CBC)
@@ -221,7 +221,7 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_Base::setIV()
      * @access public
-     * @param String $iv
+     * @param string $iv
      */
     function setIV($iv)
     {
@@ -246,7 +246,7 @@ class Crypt_TripleDES extends Crypt_DES
      * @access public
      * @see Crypt_DES::setKey()
      * @see Crypt_Base::setKey()
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -277,8 +277,8 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_Base::encrypt()
      * @access public
-     * @param String $plaintext
-     * @return String $cipertext
+     * @param string $plaintext
+     * @return string $cipertext
      */
     function encrypt($plaintext)
     {
@@ -304,8 +304,8 @@ class Crypt_TripleDES extends Crypt_DES
      *
      * @see Crypt_Base::decrypt()
      * @access public
-     * @param String $ciphertext
-     * @return String $plaintext
+     * @param string $ciphertext
+     * @return string $plaintext
      */
     function decrypt($ciphertext)
     {

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -145,7 +145,7 @@ class Crypt_TripleDES extends Crypt_DES
     /**
      * Internal flag whether using CRYPT_DES_MODE_3CBC or not
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $mode_3cbc;

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -129,7 +129,7 @@ class Crypt_Twofish extends Crypt_Base
      * The namespace used by the cipher for its constants.
      *
      * @see Crypt_Base::const_namespace
-     * @var String
+     * @var string
      * @access private
      */
     var $const_namespace = 'TWOFISH';
@@ -138,7 +138,7 @@ class Crypt_Twofish extends Crypt_Base
      * The mcrypt specific name of the cipher
      *
      * @see Crypt_Base::cipher_name_mcrypt
-     * @var String
+     * @var string
      * @access private
      */
     var $cipher_name_mcrypt = 'twofish';
@@ -147,7 +147,7 @@ class Crypt_Twofish extends Crypt_Base
      * Optimizing value while CFB-encrypting
      *
      * @see Crypt_Base::cfb_init_len
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cfb_init_len = 800;
@@ -457,7 +457,7 @@ class Crypt_Twofish extends Crypt_Base
      *
      * @access public
      * @see Crypt_Base::setKey()
-     * @param String $key
+     * @param string $key
      */
     function setKey($key)
     {
@@ -589,8 +589,8 @@ class Crypt_Twofish extends Crypt_Base
      * _mdsrem function using by the twofish cipher algorithm
      *
      * @access private
-     * @param String $A
-     * @param String $B
+     * @param string $A
+     * @param string $B
      * @return Array
      */
     function _mdsrem($A, $B)
@@ -635,8 +635,8 @@ class Crypt_Twofish extends Crypt_Base
      * Encrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _encryptBlock($in)
     {
@@ -691,8 +691,8 @@ class Crypt_Twofish extends Crypt_Base
      * Decrypts a block
      *
      * @access private
-     * @param String $in
-     * @return String
+     * @param string $in
+     * @return string
      */
     function _decryptBlock($in)
     {

--- a/phpseclib/File/ANSI.php
+++ b/phpseclib/File/ANSI.php
@@ -160,7 +160,7 @@ class File_ANSI
     /**
      * Bold flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $bold;
@@ -168,7 +168,7 @@ class File_ANSI
     /**
      * Underline flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $underline;
@@ -176,7 +176,7 @@ class File_ANSI
     /**
      * Blink flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $blink;
@@ -184,7 +184,7 @@ class File_ANSI
     /**
      * Reverse flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $reverse;
@@ -192,7 +192,7 @@ class File_ANSI
     /**
      * Color flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $color;

--- a/phpseclib/File/ANSI.php
+++ b/phpseclib/File/ANSI.php
@@ -48,7 +48,7 @@ class File_ANSI
     /**
      * Max Width
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $max_x;
@@ -56,7 +56,7 @@ class File_ANSI
     /**
      * Max Height
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $max_y;
@@ -64,7 +64,7 @@ class File_ANSI
     /**
      * Max History
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $max_history;
@@ -88,7 +88,7 @@ class File_ANSI
     /**
      * Current Column
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $x;
@@ -96,7 +96,7 @@ class File_ANSI
     /**
      * Current Row
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $y;
@@ -104,7 +104,7 @@ class File_ANSI
     /**
      * Old Column
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $old_x;
@@ -112,7 +112,7 @@ class File_ANSI
     /**
      * Old Row
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $old_y;
@@ -144,7 +144,7 @@ class File_ANSI
     /**
      * The current foreground color
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $foreground;
@@ -152,7 +152,7 @@ class File_ANSI
     /**
      * The current background color
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $background;
@@ -200,7 +200,7 @@ class File_ANSI
     /**
      * Current ANSI code
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $ansi;
@@ -222,8 +222,8 @@ class File_ANSI
      *
      * Resets the screen as well
      *
-     * @param Integer $x
-     * @param Integer $y
+     * @param int $x
+     * @param int $y
      * @access public
      */
     function setDimensions($x, $y)
@@ -249,8 +249,8 @@ class File_ANSI
     /**
      * Set the number of lines that should be logged past the terminal height
      *
-     * @param Integer $x
-     * @param Integer $y
+     * @param int $x
+     * @param int $y
      * @access public
      */
     function setHistory($history)
@@ -261,7 +261,7 @@ class File_ANSI
     /**
      * Load a string
      *
-     * @param String $source
+     * @param string $source
      * @access public
      */
     function loadString($source)
@@ -273,7 +273,7 @@ class File_ANSI
     /**
      * Appdend a string
      *
-     * @param String $source
+     * @param string $source
      * @access public
      */
     function appendString($source)
@@ -502,7 +502,7 @@ class File_ANSI
      * Returns the current screen without preformating
      *
      * @access private
-     * @return String
+     * @return string
      */
     function _getScreen()
     {
@@ -525,7 +525,7 @@ class File_ANSI
      * Returns the current screen
      *
      * @access public
-     * @return String
+     * @return string
      */
     function getScreen()
     {
@@ -536,7 +536,7 @@ class File_ANSI
      * Returns the current screen and the x previous lines
      *
      * @access public
-     * @return String
+     * @return string
      */
     function getHistory()
     {

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -119,7 +119,7 @@ class File_ASN1_Element
     /**
      * Raw element value
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $element;
@@ -127,7 +127,7 @@ class File_ASN1_Element
     /**
      * Constructor
      *
-     * @param String $encoded
+     * @param string $encoded
      * @return File_ASN1_Element
      * @access public
      */
@@ -158,7 +158,7 @@ class File_ASN1
     /**
      * Default date format
      *
-     * @var String
+     * @var string
      * @access private
      * @link http://php.net/class.datetime
      */
@@ -222,7 +222,7 @@ class File_ASN1
     );
 
     /**
-     * String type to character size mapping table.
+     * string type to character size mapping table.
      *
      * Non-convertable types are absent from this table.
      * size == 0 indicates variable length encoding.
@@ -261,7 +261,7 @@ class File_ASN1
      *
      * Serves a similar purpose to openssl's asn1parse
      *
-     * @param String $encoded
+     * @param string $encoded
      * @return Array
      * @access public
      */
@@ -283,8 +283,8 @@ class File_ASN1
      * $encoded is passed by reference for the recursive calls done for FILE_ASN1_TYPE_BIT_STRING and
      * FILE_ASN1_TYPE_OCTET_STRING. In those cases, the indefinite length is used.
      *
-     * @param String $encoded
-     * @param Integer $start
+     * @param string $encoded
+     * @param int $start
      * @return Array
      * @access private
      */
@@ -817,10 +817,10 @@ class File_ASN1
      *
      * "Special" mappings can be applied via $special.
      *
-     * @param String $source
-     * @param String $mapping
-     * @param Integer $idx
-     * @return String
+     * @param string $source
+     * @param string $mapping
+     * @param int $idx
+     * @return string
      * @access public
      */
     function encodeDER($source, $mapping, $special = array())
@@ -832,10 +832,10 @@ class File_ASN1
     /**
      * ASN.1 Encode (Helper function)
      *
-     * @param String $source
-     * @param String $mapping
-     * @param Integer $idx
-     * @return String
+     * @param string $source
+     * @param string $mapping
+     * @param int $idx
+     * @return string
      * @access private
      */
     function _encode_der($source, $mapping, $idx = null, $special = array())
@@ -1132,8 +1132,8 @@ class File_ASN1
      * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
      *
      * @access private
-     * @param Integer $length
-     * @return String
+     * @param int $length
+     * @return string
      */
     function _encodeLength($length)
     {
@@ -1151,9 +1151,9 @@ class File_ASN1
      * Called by _decode_ber() and in the case of implicit tags asn1map().
      *
      * @access private
-     * @param String $content
-     * @param Integer $tag
-     * @return String
+     * @param string $content
+     * @param int $tag
+     * @return string
      */
     function _decodeTime($content, $tag)
     {
@@ -1200,7 +1200,7 @@ class File_ASN1
      * Sets the time / date format for asn1map().
      *
      * @access public
-     * @param String $format
+     * @param string $format
      */
     function setTimeFormat($format)
     {
@@ -1234,13 +1234,13 @@ class File_ASN1
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
-     * @return String
+     * @param string $string
+     * @param int $index (optional)
+     * @return string
      * @access private
      */
     function _string_shift(&$string, $index = 1)
@@ -1251,15 +1251,15 @@ class File_ASN1
     }
 
     /**
-     * String type conversion
+     * string type conversion
      *
      * This is a lazy conversion, dealing only with character size.
      * No real conversion table is used.
      *
-     * @param String $in
-     * @param optional Integer $from
-     * @param optional Integer $to
-     * @return String
+     * @param string $in
+     * @param int $from (optional)
+     * @param int $to (optional)
+     * @return string
      * @access public
      */
     function convert($in, $from = FILE_ASN1_TYPE_UTF8_STRING, $to = FILE_ASN1_TYPE_UTF8_STRING)

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -292,7 +292,7 @@ class File_X509
     /**
      * CA Flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $caFlag = false;
@@ -1843,7 +1843,7 @@ class File_X509
      *
      * @param string $cert
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function loadCA($cert)
     {
@@ -1910,7 +1910,7 @@ class File_X509
      *
      * @param string $url
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function validateURL($url)
     {
@@ -2005,7 +2005,7 @@ class File_X509
      *
      * The behavior of this function is inspired by {@link http://php.net/openssl-verify openssl_verify}.
      *
-     * @param Boolean $caonly optional
+     * @param bool $caonly optional
      * @access public
      * @return mixed
      */
@@ -2307,10 +2307,10 @@ class File_X509
      * Set a Distinguished Name property
      *
      * @param string $propName
-     * @param Mixed $propValue
+     * @param mixed $propValue
      * @param string $type optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setDNProp($propName, $propValue, $type = 'utf8String')
     {
@@ -2369,7 +2369,7 @@ class File_X509
      *
      * @param string $propName
      * @param Array $dn optional
-     * @param Boolean $withType optional
+     * @param bool $withType optional
      * @return mixed
      * @access public
      */
@@ -2418,11 +2418,11 @@ class File_X509
     /**
      * Set a Distinguished Name
      *
-     * @param Mixed $dn
-     * @param Boolean $merge optional
+     * @param mixed $dn
+     * @param bool $merge optional
      * @param string $type optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setDN($dn, $merge = false, $type = 'utf8String')
     {
@@ -2461,10 +2461,10 @@ class File_X509
     /**
      * Get the Distinguished Name for a certificates subject
      *
-     * @param Mixed $format optional
+     * @param mixed $format optional
      * @param Array $dn optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function getDN($format = FILE_X509_DN_ARRAY, $dn = null)
     {
@@ -2653,7 +2653,7 @@ class File_X509
      * Get an individual Distinguished Name property for a certificate/crl issuer
      *
      * @param string $propName
-     * @param Boolean $withType optional
+     * @param bool $withType optional
      * @access public
      * @return mixed
      */
@@ -2675,7 +2675,7 @@ class File_X509
      * Get an individual Distinguished Name property for a certificate/csr subject
      *
      * @param string $propName
-     * @param Boolean $withType optional
+     * @param bool $withType optional
      * @access public
      * @return mixed
      */
@@ -2747,7 +2747,7 @@ class File_X509
      *
      * @param Object $key
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setPublicKey($key)
     {
@@ -3721,7 +3721,7 @@ class File_X509
      *
      * @param array $root
      * @param string $path  absolute path with / as component separator
-     * @param Boolean $create optional
+     * @param bool $create optional
      * @access private
      * @return array item ref or false
      */
@@ -3757,7 +3757,7 @@ class File_X509
      *
      * @param array $root
      * @param string $path optional absolute path with / as component separator
-     * @param Boolean $create optional
+     * @param bool $create optional
      * @access private
      * @return array ref or false
      */
@@ -3813,7 +3813,7 @@ class File_X509
      * @param string $id
      * @param string $path optional
      * @access private
-     * @return Boolean
+     * @return bool
      */
     function _removeExtension($id, $path = null)
     {
@@ -3889,12 +3889,12 @@ class File_X509
      * Set an Extension
      *
      * @param string $id
-     * @param Mixed $value
-     * @param Boolean $critical optional
-     * @param Boolean $replace optional
+     * @param mixed $value
+     * @param bool $critical optional
+     * @param bool $replace optional
      * @param string $path optional
      * @access private
-     * @return Boolean
+     * @return bool
      */
     function _setExtension($id, $value, $critical = false, $replace = true, $path = null)
     {
@@ -3926,7 +3926,7 @@ class File_X509
      *
      * @param string $id
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function removeExtension($id)
     {
@@ -3964,11 +3964,11 @@ class File_X509
      * Set a certificate, CSR or CRL Extension
      *
      * @param string $id
-     * @param Mixed $value
-     * @param Boolean $critical optional
-     * @param Boolean $replace optional
+     * @param mixed $value
+     * @param bool $critical optional
+     * @param bool $replace optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setExtension($id, $value, $critical = false, $replace = true)
     {
@@ -3981,7 +3981,7 @@ class File_X509
      * @param string $id
      * @param int $disposition optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function removeAttribute($id, $disposition = FILE_X509_ATTR_ALL)
     {
@@ -4096,10 +4096,10 @@ class File_X509
      * Set a CSR attribute
      *
      * @param string $id
-     * @param Mixed $value
-     * @param Boolean $disposition optional
+     * @param mixed $value
+     * @param bool $disposition optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setAttribute($id, $value, $disposition = FILE_X509_ATTR_ALL)
     {
@@ -4178,7 +4178,7 @@ class File_X509
      * - File_ASN1_Element object
      * - PEM or DER string
      *
-     * @param Mixed $key optional
+     * @param mixed $key optional
      * @param int $method optional
      * @access public
      * @return string binary key identifier
@@ -4344,7 +4344,7 @@ class File_X509
      *
      * @param array $rclist
      * @param string $serial
-     * @param Boolean $create optional
+     * @param bool $create optional
      * @access private
      * @return int or false
      */
@@ -4374,7 +4374,7 @@ class File_X509
      * @param string $serial
      * @param string $date optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function revoke($serial, $date = null)
     {
@@ -4401,7 +4401,7 @@ class File_X509
      *
      * @param string $serial
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function unrevoke($serial)
     {
@@ -4468,7 +4468,7 @@ class File_X509
      * @param string $serial
      * @param string $id
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function removeRevokedCertificateExtension($serial, $id)
     {
@@ -4535,11 +4535,11 @@ class File_X509
      *
      * @param string $serial
      * @param string $id
-     * @param Mixed $value
-     * @param Boolean $critical optional
-     * @param Boolean $replace optional
+     * @param mixed $value
+     * @param bool $critical optional
+     * @param bool $replace optional
      * @access public
-     * @return Boolean
+     * @return bool
      */
     function setRevokedCertificateExtension($serial, $id, $value, $critical = false, $replace = true)
     {

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -205,7 +205,7 @@ class File_X509
     /**
      * Public key
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $publicKey;
@@ -213,7 +213,7 @@ class File_X509
     /**
      * Private key
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $privateKey;
@@ -249,7 +249,7 @@ class File_X509
      * There's no guarantee File_X509 is going to reencode an X.509 cert in the same way it was originally
      * encoded so we take save the portion of the original cert that the signature would have made for.
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $signatureSubject;
@@ -257,7 +257,7 @@ class File_X509
     /**
      * Certificate Start Date
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $startDate;
@@ -265,7 +265,7 @@ class File_X509
     /**
      * Certificate End Date
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $endDate;
@@ -273,7 +273,7 @@ class File_X509
     /**
      * Serial Number
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $serialNumber;
@@ -284,7 +284,7 @@ class File_X509
      * See {@link http://tools.ietf.org/html/rfc5280#section-4.2.1.1 RFC5280#section-4.2.1.1} and
      * {@link http://tools.ietf.org/html/rfc5280#section-4.2.1.2 RFC5280#section-4.2.1.2}.
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $currentKeyIdentifier;
@@ -300,7 +300,7 @@ class File_X509
     /**
      * SPKAC Challenge
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $challenge;
@@ -1422,9 +1422,9 @@ class File_X509
      *
      * Returns an associative array describing the X.509 cert or a false if the cert failed to load
      *
-     * @param String $cert
+     * @param string $cert
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function loadX509($cert)
     {
@@ -1485,9 +1485,9 @@ class File_X509
      * Save X.509 certificate
      *
      * @param Array $cert
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return String
+     * @return string
      */
     function saveX509($cert, $format = FILE_X509_FORMAT_PEM)
     {
@@ -1551,7 +1551,7 @@ class File_X509
      *   format.
      *
      * @param Array ref $root
-     * @param String $path
+     * @param string $path
      * @param Object $asn1
      * @access private
      */
@@ -1601,7 +1601,7 @@ class File_X509
      *   octet string.
      *
      * @param Array ref $root
-     * @param String $path
+     * @param string $path
      * @param Object $asn1
      * @access private
      */
@@ -1663,7 +1663,7 @@ class File_X509
      *   format.
      *
      * @param Array ref $root
-     * @param String $path
+     * @param string $path
      * @param Object $asn1
      * @access private
      */
@@ -1704,7 +1704,7 @@ class File_X509
      *   ANY type.
      *
      * @param Array ref $root
-     * @param String $path
+     * @param string $path
      * @param Object $asn1
      * @access private
      */
@@ -1745,9 +1745,9 @@ class File_X509
     /**
      * Associate an extension ID to an extension mapping
      *
-     * @param String $extnId
+     * @param string $extnId
      * @access private
-     * @return Mixed
+     * @return mixed
      */
     function _getMapping($extnId)
     {
@@ -1841,7 +1841,7 @@ class File_X509
     /**
      * Load an X.509 certificate as a certificate authority
      *
-     * @param String $cert
+     * @param string $cert
      * @access public
      * @return Boolean
      */
@@ -1908,7 +1908,7 @@ class File_X509
      * component or component fragment. E.g., *.a.com matches foo.a.com but
      * not bar.foo.a.com. f*.com matches foo.com but not bar.com.
      *
-     * @param String $url
+     * @param string $url
      * @access public
      * @return Boolean
      */
@@ -1966,7 +1966,7 @@ class File_X509
      *
      * If $date isn't defined it is assumed to be the current date.
      *
-     * @param Integer $date optional
+     * @param int $date optional
      * @access public
      */
     function validateDate($date = null)
@@ -2007,7 +2007,7 @@ class File_X509
      *
      * @param Boolean $caonly optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function validateSignature($caonly = true)
     {
@@ -2115,13 +2115,13 @@ class File_X509
      *
      * Returns true if the signature is verified, false if it is not correct or null on error
      *
-     * @param String $publicKeyAlgorithm
-     * @param String $publicKey
-     * @param String $signatureAlgorithm
-     * @param String $signature
-     * @param String $signatureSubject
+     * @param string $publicKeyAlgorithm
+     * @param string $publicKey
+     * @param string $signatureAlgorithm
+     * @param string $signature
+     * @param string $signatureSubject
      * @access private
-     * @return Integer
+     * @return int
      */
     function _validateSignature($publicKeyAlgorithm, $publicKey, $signatureAlgorithm, $signature, $signatureSubject)
     {
@@ -2163,10 +2163,10 @@ class File_X509
      *
      * Reformats a public key to a format supported by phpseclib (if applicable)
      *
-     * @param String $algorithm
-     * @param String $key
+     * @param string $algorithm
+     * @param string $key
      * @access private
-     * @return String
+     * @return string
      */
     function _reformatKey($algorithm, $key)
     {
@@ -2189,9 +2189,9 @@ class File_X509
      *
      * Takes in a base64 encoded "blob" and returns a human readable IP address
      *
-     * @param String $ip
+     * @param string $ip
      * @access private
-     * @return String
+     * @return string
      */
     function _decodeIP($ip)
     {
@@ -2205,9 +2205,9 @@ class File_X509
      *
      * Takes a human readable IP address into a base64-encoded "blob"
      *
-     * @param String $ip
+     * @param string $ip
      * @access private
-     * @return String
+     * @return string
      */
     function _encodeIP($ip)
     {
@@ -2217,9 +2217,9 @@ class File_X509
     /**
      * "Normalizes" a Distinguished Name property
      *
-     * @param String $propName
+     * @param string $propName
      * @access private
-     * @return Mixed
+     * @return mixed
      */
     function _translateDNProp($propName)
     {
@@ -2306,9 +2306,9 @@ class File_X509
     /**
      * Set a Distinguished Name property
      *
-     * @param String $propName
+     * @param string $propName
      * @param Mixed $propValue
-     * @param String $type optional
+     * @param string $type optional
      * @access public
      * @return Boolean
      */
@@ -2340,7 +2340,7 @@ class File_X509
     /**
      * Remove Distinguished Name properties
      *
-     * @param String $propName
+     * @param string $propName
      * @access public
      */
     function removeDNProp($propName)
@@ -2367,10 +2367,10 @@ class File_X509
     /**
      * Get Distinguished Name properties
      *
-     * @param String $propName
+     * @param string $propName
      * @param Array $dn optional
      * @param Boolean $withType optional
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function getDNProp($propName, $dn = null, $withType = false)
@@ -2420,7 +2420,7 @@ class File_X509
      *
      * @param Mixed $dn
      * @param Boolean $merge optional
-     * @param String $type optional
+     * @param string $type optional
      * @access public
      * @return Boolean
      */
@@ -2607,9 +2607,9 @@ class File_X509
     /**
      * Get the Distinguished Name for a certificate/crl issuer
      *
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getIssuerDN($format = FILE_X509_DN_ARRAY)
     {
@@ -2629,9 +2629,9 @@ class File_X509
      * Get the Distinguished Name for a certificate/csr subject
      * Alias of getDN()
      *
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getSubjectDN($format = FILE_X509_DN_ARRAY)
     {
@@ -2652,10 +2652,10 @@ class File_X509
     /**
      * Get an individual Distinguished Name property for a certificate/crl issuer
      *
-     * @param String $propName
+     * @param string $propName
      * @param Boolean $withType optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getIssuerDNProp($propName, $withType = false)
     {
@@ -2674,10 +2674,10 @@ class File_X509
     /**
      * Get an individual Distinguished Name property for a certificate/csr subject
      *
-     * @param String $propName
+     * @param string $propName
      * @param Boolean $withType optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getSubjectDNProp($propName, $withType = false)
     {
@@ -2699,7 +2699,7 @@ class File_X509
      * Get the certificate chain for the current cert
      *
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getChain()
     {
@@ -2773,7 +2773,7 @@ class File_X509
      *
      * Used for SPKAC CSR's
      *
-     * @param String $challenge
+     * @param string $challenge
      * @access public
      */
     function setChallenge($challenge)
@@ -2787,7 +2787,7 @@ class File_X509
      * Returns a Crypt_RSA object or a false.
      *
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getPublicKey()
     {
@@ -2828,9 +2828,9 @@ class File_X509
     /**
      * Load a Certificate Signing Request
      *
-     * @param String $csr
+     * @param string $csr
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function loadCSR($csr)
     {
@@ -2905,9 +2905,9 @@ class File_X509
      * Save CSR request
      *
      * @param Array $csr
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return String
+     * @return string
      */
     function saveCSR($csr, $format = FILE_X509_FORMAT_PEM)
     {
@@ -2956,9 +2956,9 @@ class File_X509
      *
      * https://developer.mozilla.org/en-US/docs/HTML/Element/keygen
      *
-     * @param String $csr
+     * @param string $csr
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function loadSPKAC($spkac)
     {
@@ -3031,9 +3031,9 @@ class File_X509
      * Save a SPKAC CSR request
      *
      * @param Array $csr
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return String
+     * @return string
      */
     function saveSPKAC($spkac, $format = FILE_X509_FORMAT_PEM)
     {
@@ -3073,9 +3073,9 @@ class File_X509
     /**
      * Load a Certificate Revocation List
      *
-     * @param String $crl
+     * @param string $crl
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function loadCRL($crl)
     {
@@ -3129,9 +3129,9 @@ class File_X509
      * Save Certificate Revocation List.
      *
      * @param Array $crl
-     * @param Integer $format optional
+     * @param int $format optional
      * @access public
-     * @return String
+     * @return string
      */
     function saveCRL($crl, $format = FILE_X509_FORMAT_PEM)
     {
@@ -3190,7 +3190,7 @@ class File_X509
      *  - 5.1.2.6 Revoked Certificates
      * by choosing utcTime iff year of date given is before 2050 and generalTime else.
      *
-     * @param String $date in format date('D, d M Y H:i:s O')
+     * @param string $date in format date('D, d M Y H:i:s O')
      * @access private
      * @return Array
      */
@@ -3213,9 +3213,9 @@ class File_X509
      *
      * @param File_X509 $issuer
      * @param File_X509 $subject
-     * @param String $signatureAlgorithm optional
+     * @param string $signatureAlgorithm optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function sign($issuer, $subject, $signatureAlgorithm = 'sha1WithRSAEncryption')
     {
@@ -3380,7 +3380,7 @@ class File_X509
      * Sign a CSR
      *
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function signCSR($signatureAlgorithm = 'sha1WithRSAEncryption')
     {
@@ -3438,7 +3438,7 @@ class File_X509
      * Sign a SPKAC
      *
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function signSPKAC($signatureAlgorithm = 'sha1WithRSAEncryption')
     {
@@ -3506,9 +3506,9 @@ class File_X509
      *
      * @param File_X509 $issuer
      * @param File_X509 $crl
-     * @param String $signatureAlgorithm optional
+     * @param string $signatureAlgorithm optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function signCRL($issuer, $crl, $signatureAlgorithm = 'sha1WithRSAEncryption')
     {
@@ -3631,9 +3631,9 @@ class File_X509
      *
      * @param Object $key
      * @param File_X509 $subject
-     * @param String $signatureAlgorithm
+     * @param string $signatureAlgorithm
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function _sign($key, $signatureAlgorithm)
     {
@@ -3661,7 +3661,7 @@ class File_X509
     /**
      * Set certificate start date
      *
-     * @param String $date
+     * @param string $date
      * @access public
      */
     function setStartDate($date)
@@ -3672,7 +3672,7 @@ class File_X509
     /**
      * Set certificate end date
      *
-     * @param String $date
+     * @param string $date
      * @access public
      */
     function setEndDate($date)
@@ -3697,7 +3697,7 @@ class File_X509
     /**
      * Set Serial Number
      *
-     * @param String $serial
+     * @param string $serial
      * @param $base optional
      * @access public
      */
@@ -3720,7 +3720,7 @@ class File_X509
      * Get a reference to a subarray
      *
      * @param array $root
-     * @param String $path  absolute path with / as component separator
+     * @param string $path  absolute path with / as component separator
      * @param Boolean $create optional
      * @access private
      * @return array item ref or false
@@ -3756,7 +3756,7 @@ class File_X509
      * Get a reference to an extension subarray
      *
      * @param array $root
-     * @param String $path optional absolute path with / as component separator
+     * @param string $path optional absolute path with / as component separator
      * @param Boolean $create optional
      * @access private
      * @return array ref or false
@@ -3810,8 +3810,8 @@ class File_X509
     /**
      * Remove an Extension
      *
-     * @param String $id
-     * @param String $path optional
+     * @param string $id
+     * @param string $path optional
      * @access private
      * @return Boolean
      */
@@ -3840,11 +3840,11 @@ class File_X509
      *
      * Returns the extension if it exists and false if not
      *
-     * @param String $id
+     * @param string $id
      * @param Array $cert optional
-     * @param String $path optional
+     * @param string $path optional
      * @access private
-     * @return Mixed
+     * @return mixed
      */
     function _getExtension($id, $cert = null, $path = null)
     {
@@ -3867,7 +3867,7 @@ class File_X509
      * Returns a list of all extensions in use
      *
      * @param array $cert optional
-     * @param String $path optional
+     * @param string $path optional
      * @access private
      * @return Array
      */
@@ -3888,11 +3888,11 @@ class File_X509
     /**
      * Set an Extension
      *
-     * @param String $id
+     * @param string $id
      * @param Mixed $value
      * @param Boolean $critical optional
      * @param Boolean $replace optional
-     * @param String $path optional
+     * @param string $path optional
      * @access private
      * @return Boolean
      */
@@ -3924,7 +3924,7 @@ class File_X509
     /**
      * Remove a certificate, CSR or CRL Extension
      *
-     * @param String $id
+     * @param string $id
      * @access public
      * @return Boolean
      */
@@ -3938,10 +3938,10 @@ class File_X509
      *
      * Returns the extension if it exists and false if not
      *
-     * @param String $id
+     * @param string $id
      * @param Array $cert optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getExtension($id, $cert = null)
     {
@@ -3963,7 +3963,7 @@ class File_X509
     /**
      * Set a certificate, CSR or CRL Extension
      *
-     * @param String $id
+     * @param string $id
      * @param Mixed $value
      * @param Boolean $critical optional
      * @param Boolean $replace optional
@@ -3978,8 +3978,8 @@ class File_X509
     /**
      * Remove a CSR attribute.
      *
-     * @param String $id
-     * @param Integer $disposition optional
+     * @param string $id
+     * @param int $disposition optional
      * @access public
      * @return Boolean
      */
@@ -4028,11 +4028,11 @@ class File_X509
      *
      * Returns the attribute if it exists and false if not
      *
-     * @param String $id
-     * @param Integer $disposition optional
+     * @param string $id
+     * @param int $disposition optional
      * @param Array $csr optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getAttribute($id, $disposition = FILE_X509_ATTR_ALL, $csr = null)
     {
@@ -4095,7 +4095,7 @@ class File_X509
     /**
      * Set a CSR attribute
      *
-     * @param String $id
+     * @param string $id
      * @param Mixed $value
      * @param Boolean $disposition optional
      * @access public
@@ -4153,7 +4153,7 @@ class File_X509
      *
      * This is used by the id-ce-authorityKeyIdentifier and the id-ce-subjectKeyIdentifier extensions.
      *
-     * @param String $value
+     * @param string $value
      * @access public
      */
     function setKeyIdentifier($value)
@@ -4179,9 +4179,9 @@ class File_X509
      * - PEM or DER string
      *
      * @param Mixed $key optional
-     * @param Integer $method optional
+     * @param int $method optional
      * @access public
-     * @return String binary key identifier
+     * @return string binary key identifier
      */
     function computeKeyIdentifier($key = null, $method = 1)
     {
@@ -4300,7 +4300,7 @@ class File_X509
      * Set the IP Addresses's which the cert is to be valid for
      *
      * @access public
-     * @param String $ipAddress optional
+     * @param string $ipAddress optional
      */
     function setIPAddress()
     {
@@ -4317,7 +4317,7 @@ class File_X509
      * Helper function to build domain array
      *
      * @access private
-     * @param String $domain
+     * @param string $domain
      * @return Array
      */
     function _dnsName($domain)
@@ -4331,7 +4331,7 @@ class File_X509
      * (IPv6 is not currently supported)
      *
      * @access private
-     * @param String $address
+     * @param string $address
      * @return Array
      */
     function _iPAddress($address)
@@ -4343,10 +4343,10 @@ class File_X509
      * Get the index of a revoked certificate.
      *
      * @param array $rclist
-     * @param String $serial
+     * @param string $serial
      * @param Boolean $create optional
      * @access private
-     * @return Integer or false
+     * @return int or false
      */
     function _revokedCertificate(&$rclist, $serial, $create = false)
     {
@@ -4371,8 +4371,8 @@ class File_X509
     /**
      * Revoke a certificate.
      *
-     * @param String $serial
-     * @param String $date optional
+     * @param string $serial
+     * @param string $date optional
      * @access public
      * @return Boolean
      */
@@ -4399,7 +4399,7 @@ class File_X509
     /**
      * Unrevoke a certificate.
      *
-     * @param String $serial
+     * @param string $serial
      * @access public
      * @return Boolean
      */
@@ -4419,9 +4419,9 @@ class File_X509
     /**
      * Get a revoked certificate.
      *
-     * @param String $serial
+     * @param string $serial
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getRevoked($serial)
     {
@@ -4465,8 +4465,8 @@ class File_X509
     /**
      * Remove a Revoked Certificate Extension
      *
-     * @param String $serial
-     * @param String $id
+     * @param string $serial
+     * @param string $id
      * @access public
      * @return Boolean
      */
@@ -4486,11 +4486,11 @@ class File_X509
      *
      * Returns the extension if it exists and false if not
      *
-     * @param String $serial
-     * @param String $id
+     * @param string $serial
+     * @param string $id
      * @param Array $crl optional
      * @access public
-     * @return Mixed
+     * @return mixed
      */
     function getRevokedCertificateExtension($serial, $id, $crl = null)
     {
@@ -4510,7 +4510,7 @@ class File_X509
     /**
      * Returns a list of all extensions in use for a given revoked certificate
      *
-     * @param String $serial
+     * @param string $serial
      * @param array $crl optional
      * @access public
      * @return Array
@@ -4533,8 +4533,8 @@ class File_X509
     /**
      * Set a Revoked Certificate Extension
      *
-     * @param String $serial
-     * @param String $id
+     * @param string $serial
+     * @param string $id
      * @param Mixed $value
      * @param Boolean $critical optional
      * @param Boolean $replace optional
@@ -4558,8 +4558,8 @@ class File_X509
      * Extract raw BER from Base64 encoding
      *
      * @access private
-     * @param String $str
-     * @return String
+     * @param string $str
+     * @return string
      */
     function _extractBER($str)
     {

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -3180,7 +3180,7 @@ class Math_BigInteger
      *
      * @param Math_BigInteger $arg1
      * @param optional Math_BigInteger $arg2
-     * @param int $time (optional)out
+     * @param int $timeout (optional)
      * @return mixed
      * @access public
      * @internal See {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap4.pdf#page=15 HAC 4.44}.

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -186,7 +186,7 @@ class Math_BigInteger
     /**
      * Holds the BigInteger's magnitude.
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $is_negative = false;
@@ -517,7 +517,7 @@ class Math_BigInteger
      * ?>
      * </code>
      *
-     * @param Boolean $twos_compliment
+     * @param bool $twos_compliment
      * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**8
@@ -614,7 +614,7 @@ class Math_BigInteger
      * ?>
      * </code>
      *
-     * @param Boolean $twos_compliment
+     * @param bool $twos_compliment
      * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**8
@@ -641,7 +641,7 @@ class Math_BigInteger
      * ?>
      * </code>
      *
-     * @param Boolean $twos_compliment
+     * @param bool $twos_compliment
      * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**2
@@ -868,9 +868,9 @@ class Math_BigInteger
      * Performs addition.
      *
      * @param Array $x_value
-     * @param Boolean $x_negative
+     * @param bool $x_negative
      * @param Array $y_value
-     * @param Boolean $y_negative
+     * @param bool $y_negative
      * @return Array
      * @access private
      */
@@ -999,9 +999,9 @@ class Math_BigInteger
      * Performs subtraction.
      *
      * @param Array $x_value
-     * @param Boolean $x_negative
+     * @param bool $x_negative
      * @param Array $y_value
-     * @param Boolean $y_negative
+     * @param bool $y_negative
      * @return Array
      * @access private
      */
@@ -1134,9 +1134,9 @@ class Math_BigInteger
      * Performs multiplication.
      *
      * @param Array $x_value
-     * @param Boolean $x_negative
+     * @param bool $x_negative
      * @param Array $y_value
-     * @param Boolean $y_negative
+     * @param bool $y_negative
      * @return Array
      * @access private
      */
@@ -2158,9 +2158,9 @@ class Math_BigInteger
      *
      * @see _regularBarrett()
      * @param Array $x_value
-     * @param Boolean $x_negative
+     * @param bool $x_negative
      * @param Array $y_value
-     * @param Boolean $y_negative
+     * @param bool $y_negative
      * @param int $stop
      * @return Array
      * @access private
@@ -2681,9 +2681,9 @@ class Math_BigInteger
      * Compares two numbers.
      *
      * @param Array $x_value
-     * @param Boolean $x_negative
+     * @param bool $x_negative
      * @param Array $y_value
-     * @param Boolean $y_negative
+     * @param bool $y_negative
      * @return int
      * @see compare()
      * @access private
@@ -2719,7 +2719,7 @@ class Math_BigInteger
      * If you need to see if one number is greater than or less than another number, use Math_BigInteger::compare()
      *
      * @param Math_BigInteger $x
-     * @return Boolean
+     * @return bool
      * @access public
      * @see compare()
      */
@@ -3309,7 +3309,7 @@ class Math_BigInteger
      * on a website instead of just one.
      *
      * @param optional Math_BigInteger $t
-     * @return Boolean
+     * @return bool
      * @access public
      * @internal Uses the
      *     {@link http://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test Miller-Rabin primality test}.  See

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -224,7 +224,7 @@ class Math_BigInteger
      *
      * @see __sleep()
      * @see __wakeup()
-     * @var String
+     * @var string
      * @access private
      */
     var $hex;
@@ -246,8 +246,8 @@ class Math_BigInteger
      * ?>
      * </code>
      *
-     * @param optional $x base-10 number or base-$base number if $base set.
-     * @param optional integer $base
+     * @param $x base-10 number or base-$base number if $base set. (optional)
+     * @param int $base (optional)
      * @return Math_BigInteger
      * @access public
      */
@@ -518,7 +518,7 @@ class Math_BigInteger
      * </code>
      *
      * @param Boolean $twos_compliment
-     * @return String
+     * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**8
      */
@@ -615,7 +615,7 @@ class Math_BigInteger
      * </code>
      *
      * @param Boolean $twos_compliment
-     * @return String
+     * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**8
      */
@@ -642,7 +642,7 @@ class Math_BigInteger
      * </code>
      *
      * @param Boolean $twos_compliment
-     * @return String
+     * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-2**2
      */
@@ -679,7 +679,7 @@ class Math_BigInteger
      * ?>
      * </code>
      *
-     * @return String
+     * @return string
      * @access public
      * @internal Converts a base-2**26 number to base-10**7 (which is pretty much base-10)
      */
@@ -1790,7 +1790,7 @@ class Math_BigInteger
      *
      * @param Math_BigInteger $e
      * @param Math_BigInteger $n
-     * @param Integer $mode
+     * @param int $mode
      * @return Math_BigInteger
      * @access private
      */
@@ -1866,7 +1866,7 @@ class Math_BigInteger
      * @access private
      * @param Array $x
      * @param Array $n
-     * @param Integer $mode
+     * @param int $mode
      * @return Array
      */
     function _reduce($x, $n, $mode)
@@ -1903,7 +1903,7 @@ class Math_BigInteger
      * @access private
      * @param Array $x
      * @param Array $n
-     * @param Integer $mode
+     * @param int $mode
      * @return Array
      */
     function _prepareReduce($x, $n, $mode)
@@ -1922,7 +1922,7 @@ class Math_BigInteger
      * @param Array $x
      * @param Array $y
      * @param Array $n
-     * @param Integer $mode
+     * @param int $mode
      * @return Array
      */
     function _multiplyReduce($x, $y, $n, $mode)
@@ -1941,7 +1941,7 @@ class Math_BigInteger
      * @access private
      * @param Array $x
      * @param Array $n
-     * @param Integer $mode
+     * @param int $mode
      * @return Array
      */
     function _squareReduce($x, $n, $mode)
@@ -2161,7 +2161,7 @@ class Math_BigInteger
      * @param Boolean $x_negative
      * @param Array $y_value
      * @param Boolean $y_negative
-     * @param Integer $stop
+     * @param int $stop
      * @return Array
      * @access private
      */
@@ -2378,7 +2378,7 @@ class Math_BigInteger
      * @see _montgomery()
      * @access private
      * @param Array $x
-     * @return Integer
+     * @return int
      */
     function _modInverse67108864($x) // 2**26 == 67,108,864
     {
@@ -2660,7 +2660,7 @@ class Math_BigInteger
      * Note how the same comparison operator is used.  If you want to test for equality, use $x->equals($y).
      *
      * @param Math_BigInteger $y
-     * @return Integer < 0 if $this is less than $y; > 0 if $this is greater than $y, and 0 if they are equal.
+     * @return int < 0 if $this is less than $y; > 0 if $this is greater than $y, and 0 if they are equal.
      * @access public
      * @see equals()
      * @internal Could return $this->subtract($x), but that's not as fast as what we do do.
@@ -2684,7 +2684,7 @@ class Math_BigInteger
      * @param Boolean $x_negative
      * @param Array $y_value
      * @param Boolean $y_negative
-     * @return Integer
+     * @return int
      * @see compare()
      * @access private
      */
@@ -2739,7 +2739,7 @@ class Math_BigInteger
      * Some bitwise operations give different results depending on the precision being used.  Examples include left
      * shift, not, and rotates.
      *
-     * @param Integer $bits
+     * @param int $bits
      * @access public
      */
     function setPrecision($bits)
@@ -2917,7 +2917,7 @@ class Math_BigInteger
      *
      * Shifts BigInteger's by $shift bits, effectively dividing by 2**$shift.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @return Math_BigInteger
      * @access public
      * @internal The only version that yields any speed increases is the internal version.
@@ -2955,7 +2955,7 @@ class Math_BigInteger
      *
      * Shifts BigInteger's by $shift bits, effectively multiplying by 2**$shift.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @return Math_BigInteger
      * @access public
      * @internal The only version that yields any speed increases is the internal version.
@@ -2993,7 +2993,7 @@ class Math_BigInteger
      *
      * Instead of the top x bits being dropped they're appended to the shifted bit string.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @return Math_BigInteger
      * @access public
      */
@@ -3037,7 +3037,7 @@ class Math_BigInteger
      *
      * Instead of the bottom x bits being dropped they're prepended to the shifted bit string.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @return Math_BigInteger
      * @access public
      */
@@ -3051,7 +3051,7 @@ class Math_BigInteger
      *
      * This function is deprecated.
      *
-     * @param String $generator
+     * @param string $generator
      * @access public
      */
     function setRandomGenerator($generator)
@@ -3063,7 +3063,7 @@ class Math_BigInteger
      *
      * Byte length is equal to $length. Uses crypt_random if it's loaded and mt_rand if it's not.
      *
-     * @param Integer $length
+     * @param int $length
      * @return Math_BigInteger
      * @access private
      */
@@ -3180,8 +3180,8 @@ class Math_BigInteger
      *
      * @param Math_BigInteger $arg1
      * @param optional Math_BigInteger $arg2
-     * @param optional Integer $timeout
-     * @return Mixed
+     * @param int $time (optional)out
+     * @return mixed
      * @access public
      * @internal See {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap4.pdf#page=15 HAC 4.44}.
      */
@@ -3460,7 +3460,7 @@ class Math_BigInteger
      *
      * Shifts BigInteger's by $shift bits.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @access private
      */
     function _lshift($shift)
@@ -3495,7 +3495,7 @@ class Math_BigInteger
      *
      * Shifts BigInteger's by $shift bits.
      *
-     * @param Integer $shift
+     * @param int $shift
      * @access private
      */
     function _rshift($shift)
@@ -3613,9 +3613,9 @@ class Math_BigInteger
      *
      * Shifts binary strings $shift bits, essentially multiplying by 2**$shift.
      *
-     * @param $x String
-     * @param $shift Integer
-     * @return String
+     * @param $x string
+     * @param int $shift
+     * @return string
      * @access private
      */
     function _base256_lshift(&$x, $shift)
@@ -3642,9 +3642,9 @@ class Math_BigInteger
      *
      * Shifts binary strings $shift bits, essentially dividing by 2**$shift and returning the remainder.
      *
-     * @param $x String
-     * @param $shift Integer
-     * @return String
+     * @param $x string
+     * @param int $shift
+     * @return string
      * @access private
      */
     function _base256_rshift(&$x, $shift)
@@ -3684,8 +3684,8 @@ class Math_BigInteger
     /**
      * Converts 32-bit integers to bytes.
      *
-     * @param Integer $x
-     * @return String
+     * @param int $x
+     * @return string
      * @access private
      */
     function _int2bytes($x)
@@ -3696,8 +3696,8 @@ class Math_BigInteger
     /**
      * Converts bytes to 32-bit integers
      *
-     * @param String $x
-     * @return Integer
+     * @param string $x
+     * @return int
      * @access private
      */
     function _bytes2int($x)
@@ -3713,8 +3713,8 @@ class Math_BigInteger
      *
      * @see modPow()
      * @access private
-     * @param Integer $length
-     * @return String
+     * @param int $length
+     * @return string
      */
     function _encodeASN1Length($length)
     {
@@ -3735,9 +3735,9 @@ class Math_BigInteger
      * we'll guarantee that the dividend is divisible by first subtracting the remainder.
      *
      * @access private
-     * @param Integer $x
-     * @param Integer $y
-     * @return Integer
+     * @param int $x
+     * @param int $y
+     * @return int
      */
     function _safe_divide($x, $y)
     {

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -98,7 +98,7 @@ class Net_SCP
     /**
      * Packet Size
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $packet_size;
@@ -106,7 +106,7 @@ class Net_SCP
     /**
      * Mode
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $mode;
@@ -116,9 +116,9 @@ class Net_SCP
      *
      * Connects to an SSH server
      *
-     * @param String $host
-     * @param optional Integer $port
-     * @param optional Integer $timeout
+     * @param string $host
+     * @param int $port (optional)
+     * @param int $timeout (optional)
      * @return Net_SCP
      * @access public
      */
@@ -157,9 +157,9 @@ class Net_SCP
      * Currently, only binary mode is supported.  As such, if the line endings need to be adjusted, you will need to take
      * care of that, yourself.
      *
-     * @param String $remote_file
-     * @param String $data
-     * @param optional Integer $mode
+     * @param string $remote_file
+     * @param string $data
+     * @param int $mode (optional)
      * @param optional Callable $callback
      * @return Boolean
      * @access public
@@ -233,9 +233,9 @@ class Net_SCP
      * the operation was unsuccessful.  If $local_file is defined, returns true or false depending on the success of the
      * operation
      *
-     * @param String $remote_file
-     * @param optional String $local_file
-     * @return Mixed
+     * @param string $remote_file
+     * @param optional string $local_file
+     * @return mixed
      * @access public
      */
     function get($remote_file, $local_file = false)
@@ -291,7 +291,7 @@ class Net_SCP
     /**
      * Sends a packet to an SSH server
      *
-     * @param String $data
+     * @param string $data
      * @access private
      */
     function _send($data)
@@ -309,7 +309,7 @@ class Net_SCP
     /**
      * Receives a packet from an SSH server
      *
-     * @return String
+     * @return string
      * @access private
      */
     function _receive()

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -161,7 +161,7 @@ class Net_SCP
      * @param string $data
      * @param int $mode (optional)
      * @param optional Callable $callback
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function put($remote_file, $data, $mode = NET_SCP_STRING, $callback = null)

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -257,7 +257,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @see Net_SFTP::disableStatCache()
      * @see Net_SFTP::enableStatCache()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $use_stat_cache = true;
@@ -417,7 +417,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $username
      * @param optional string $password
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function login($username)
@@ -677,7 +677,7 @@ class Net_SFTP extends Net_SSH2
      * Changes the current directory
      *
      * @param string $dir
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function chdir($dir)
@@ -752,7 +752,7 @@ class Net_SFTP extends Net_SSH2
      * Helper method for nlist
      *
      * @param string $dir
-     * @param Boolean $recursive
+     * @param bool $recursive
      * @param string $relativeDir
      * @return mixed
      * @access private
@@ -1052,7 +1052,7 @@ class Net_SFTP extends Net_SSH2
      * Save files / directories to cache
      *
      * @param string $path
-     * @param Mixed $value
+     * @param mixed $value
      * @access private
      */
     function _update_stat_cache($path, $value)
@@ -1078,7 +1078,7 @@ class Net_SFTP extends Net_SSH2
      * Remove files / directories from cache
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _remove_from_stat_cache($path)
@@ -1281,7 +1281,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $filename
      * @param int $new_size
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function truncate($filename, $new_size)
@@ -1299,7 +1299,7 @@ class Net_SFTP extends Net_SSH2
      * @param string $filename
      * @param int $time (optional)
      * @param int $atime (optional)
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function touch($filename, $time = null, $atime = null)
@@ -1350,7 +1350,7 @@ class Net_SFTP extends Net_SSH2
      * @param string $filename
      * @param int $uid
      * @param optional Boolean $recursive
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function chown($filename, $uid, $recursive = false)
@@ -1370,7 +1370,7 @@ class Net_SFTP extends Net_SSH2
      * @param string $filename
      * @param int $gid
      * @param optional Boolean $recursive
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function chgrp($filename, $gid, $recursive = false)
@@ -1435,8 +1435,8 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $filename
      * @param string $attr
-     * @param Boolean $recursive
-     * @return Boolean
+     * @param bool $recursive
+     * @return bool
      * @access private
      */
     function _setstat($filename, $attr, $recursive)
@@ -1495,7 +1495,7 @@ class Net_SFTP extends Net_SSH2
      * @param string $path
      * @param string $attr
      * @param int $i
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _setstat_recursive($path, $attr, &$i)
@@ -1607,7 +1607,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $target
      * @param string $link
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function symlink($target, $link)
@@ -1643,7 +1643,7 @@ class Net_SFTP extends Net_SSH2
      * Creates a directory.
      *
      * @param string $dir
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function mkdir($dir, $mode = -1, $recursive = false)
@@ -1678,7 +1678,7 @@ class Net_SFTP extends Net_SSH2
      * Helper function for directory creation
      *
      * @param string $dir
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _mkdir_helper($dir, $attr)
@@ -1706,7 +1706,7 @@ class Net_SFTP extends Net_SSH2
      * Removes a directory.
      *
      * @param string $dir
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function rmdir($dir)
@@ -1784,7 +1784,7 @@ class Net_SFTP extends Net_SSH2
      * @param int $mode (optional)
      * @param optional Integer $start
      * @param optional Integer $local_start
-     * @return Boolean
+     * @return bool
      * @access public
      * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - Net_SFTP::setMode().
      */
@@ -1919,7 +1919,7 @@ class Net_SFTP extends Net_SSH2
      * SSH_FXP_WRITEs, in succession, and then reading $i responses.
      *
      * @param int $i
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _read_put_responses($i)
@@ -1945,7 +1945,7 @@ class Net_SFTP extends Net_SSH2
      * Close handle
      *
      * @param string $handle
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _close_handle($handle)
@@ -2097,8 +2097,8 @@ class Net_SFTP extends Net_SSH2
      * Deletes a file on the SFTP server.
      *
      * @param string $path
-     * @param Boolean $recursive
-     * @return Boolean
+     * @param bool $recursive
+     * @return bool
      * @access public
      */
     function delete($path, $recursive = true)
@@ -2148,7 +2148,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $path
      * @param int $i
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _delete_recursive($path, &$i)
@@ -2213,7 +2213,7 @@ class Net_SFTP extends Net_SSH2
      * Checks whether a file or directory exists
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function file_exists($path)
@@ -2236,7 +2236,7 @@ class Net_SFTP extends Net_SSH2
      * Tells whether the filename is a directory
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function is_dir($path)
@@ -2252,7 +2252,7 @@ class Net_SFTP extends Net_SSH2
      * Tells whether the filename is a regular file
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function is_file($path)
@@ -2268,7 +2268,7 @@ class Net_SFTP extends Net_SSH2
      * Tells whether the filename is a symbolic link
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function is_link($path)
@@ -2413,7 +2413,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $oldname
      * @param string $newname
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function rename($oldname, $newname)
@@ -2595,7 +2595,7 @@ class Net_SFTP extends Net_SSH2
      * @param string $data
      * @see Net_SFTP::_get_sftp_packet()
      * @see Net_SSH2::_send_channel_packet()
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _send_sftp_packet($type, $data)
@@ -2767,7 +2767,7 @@ class Net_SFTP extends Net_SSH2
      * Disconnect
      *
      * @param int $reason
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _disconnect($reason)

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -279,7 +279,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param string $host
      * @param optional Integer $port
-     * @param int $time (optional)out
+     * @param int $timeout (optional)
      * @return Net_SFTP
      * @access public
      */

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -145,7 +145,7 @@ class Net_SFTP extends Net_SSH2
      * The request ID exists in the off chance that a packet is sent out-of-order.  Of course, this library doesn't support
      * concurrent actions, so it's somewhat academic, here.
      *
-     * @var Integer
+     * @var int
      * @see Net_SFTP::_send_sftp_packet()
      * @access private
      */
@@ -157,7 +157,7 @@ class Net_SFTP extends Net_SSH2
      * The request ID exists in the off chance that a packet is sent out-of-order.  Of course, this library doesn't support
      * concurrent actions, so it's somewhat academic, here.
      *
-     * @var Integer
+     * @var int
      * @see Net_SFTP::_get_sftp_packet()
      * @access private
      */
@@ -166,7 +166,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Packet Buffer
      *
-     * @var String
+     * @var string
      * @see Net_SFTP::_get_sftp_packet()
      * @access private
      */
@@ -184,7 +184,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Server SFTP version
      *
-     * @var Integer
+     * @var int
      * @see Net_SFTP::_initChannel()
      * @access private
      */
@@ -193,7 +193,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Current working directory
      *
-     * @var String
+     * @var string
      * @see Net_SFTP::_realpath()
      * @see Net_SFTP::chdir()
      * @access private
@@ -223,7 +223,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @see Net_SFTP::getSFTPErrors()
      * @see Net_SFTP::getLastSFTPError()
-     * @var String
+     * @var string
      * @access private
      */
     var $sftp_errors = array();
@@ -277,9 +277,9 @@ class Net_SFTP extends Net_SSH2
      *
      * Connects to an SFTP server
      *
-     * @param String $host
+     * @param string $host
      * @param optional Integer $port
-     * @param optional Integer $timeout
+     * @param int $time (optional)out
      * @return Net_SFTP
      * @access public
      */
@@ -415,8 +415,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Login
      *
-     * @param String $username
-     * @param optional String $password
+     * @param string $username
+     * @param optional string $password
      * @return Boolean
      * @access public
      */
@@ -582,7 +582,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Returns the current directory name
      *
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function pwd()
@@ -593,8 +593,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Logs errors
      *
-     * @param String $response
-     * @param optional Integer $status
+     * @param string $response
+     * @param int $status (optional)
      * @access public
      */
     function _logError($response, $status = -1)
@@ -620,8 +620,8 @@ class Net_SFTP extends Net_SSH2
      * the absolute (canonicalized) path.
      *
      * @see Net_SFTP::chdir()
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access private
      */
     function _realpath($path)
@@ -676,7 +676,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Changes the current directory
      *
-     * @param String $dir
+     * @param string $dir
      * @return Boolean
      * @access public
      */
@@ -738,9 +738,9 @@ class Net_SFTP extends Net_SSH2
     /**
      * Returns a list of files in the given directory
      *
-     * @param optional String $dir
+     * @param optional string $dir
      * @param optional Boolean $recursive
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function nlist($dir = '.', $recursive = false)
@@ -751,10 +751,10 @@ class Net_SFTP extends Net_SSH2
     /**
      * Helper method for nlist
      *
-     * @param String $dir
+     * @param string $dir
      * @param Boolean $recursive
-     * @param String $relativeDir
-     * @return Mixed
+     * @param string $relativeDir
+     * @return mixed
      * @access private
      */
     function _nlist_helper($dir, $recursive, $relativeDir)
@@ -787,9 +787,9 @@ class Net_SFTP extends Net_SSH2
     /**
      * Returns a detailed list of files in the given directory
      *
-     * @param optional String $dir
+     * @param optional string $dir
      * @param optional Boolean $recursive
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function rawlist($dir = '.', $recursive = false)
@@ -821,9 +821,9 @@ class Net_SFTP extends Net_SSH2
     /**
      * Reads a list, be it detailed or not, of files in the given directory
      *
-     * @param String $dir
+     * @param string $dir
      * @param optional Boolean $raw
-     * @return Mixed
+     * @return mixed
      * @access private
      */
     function _list($dir, $raw = true)
@@ -933,7 +933,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param Array $a
      * @param Array $b
-     * @return Integer
+     * @return int
      * @access private
      */
     function _comparator($a, $b)
@@ -1031,8 +1031,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Files larger than 4GB will show up as being exactly 4GB.
      *
-     * @param String $filename
-     * @return Mixed
+     * @param string $filename
+     * @return mixed
      * @access public
      */
     function size($filename)
@@ -1051,7 +1051,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Save files / directories to cache
      *
-     * @param String $path
+     * @param string $path
      * @param Mixed $value
      * @access private
      */
@@ -1077,7 +1077,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Remove files / directories from cache
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access private
      */
@@ -1104,8 +1104,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Mainly used by file_exists
      *
-     * @param String $dir
-     * @return Mixed
+     * @param string $dir
+     * @return mixed
      * @access private
      */
     function _query_stat_cache($path)
@@ -1127,8 +1127,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Returns an array on success and false otherwise.
      *
-     * @param String $filename
-     * @return Mixed
+     * @param string $filename
+     * @return mixed
      * @access public
      */
     function stat($filename)
@@ -1184,8 +1184,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Returns an array on success and false otherwise.
      *
-     * @param String $filename
-     * @return Mixed
+     * @param string $filename
+     * @return mixed
      * @access public
      */
     function lstat($filename)
@@ -1250,9 +1250,9 @@ class Net_SFTP extends Net_SSH2
      * Determines information without calling Net_SFTP::_realpath().
      * The second parameter can be either NET_SFTP_STAT or NET_SFTP_LSTAT.
      *
-     * @param String $filename
-     * @param Integer $type
-     * @return Mixed
+     * @param string $filename
+     * @param int $type
+     * @return mixed
      * @access private
      */
     function _stat($filename, $type)
@@ -1279,8 +1279,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Truncates a file to a given length
      *
-     * @param String $filename
-     * @param Integer $new_size
+     * @param string $filename
+     * @param int $new_size
      * @return Boolean
      * @access public
      */
@@ -1296,9 +1296,9 @@ class Net_SFTP extends Net_SSH2
      *
      * If the file does not exist, it will be created.
      *
-     * @param String $filename
-     * @param optional Integer $time
-     * @param optional Integer $atime
+     * @param string $filename
+     * @param int $time (optional)
+     * @param int $atime (optional)
      * @return Boolean
      * @access public
      */
@@ -1347,8 +1347,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Returns true on success or false on error.
      *
-     * @param String $filename
-     * @param Integer $uid
+     * @param string $filename
+     * @param int $uid
      * @param optional Boolean $recursive
      * @return Boolean
      * @access public
@@ -1367,8 +1367,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Returns true on success or false on error.
      *
-     * @param String $filename
-     * @param Integer $gid
+     * @param string $filename
+     * @param int $gid
      * @param optional Boolean $recursive
      * @return Boolean
      * @access public
@@ -1386,10 +1386,10 @@ class Net_SFTP extends Net_SSH2
      * Returns the new file permissions on success or false on error.
      * If $recursive is true than this just returns true or false.
      *
-     * @param Integer $mode
-     * @param String $filename
+     * @param int $mode
+     * @param string $filename
      * @param optional Boolean $recursive
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function chmod($mode, $filename, $recursive = false)
@@ -1433,8 +1433,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Sets information about a file
      *
-     * @param String $filename
-     * @param String $attr
+     * @param string $filename
+     * @param string $attr
      * @param Boolean $recursive
      * @return Boolean
      * @access private
@@ -1492,9 +1492,9 @@ class Net_SFTP extends Net_SSH2
      *
      * Minimizes directory lookups and SSH_FXP_STATUS requests for speed.
      *
-     * @param String $path
-     * @param String $attr
-     * @param Integer $i
+     * @param string $path
+     * @param string $attr
+     * @param int $i
      * @return Boolean
      * @access private
      */
@@ -1562,8 +1562,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Return the target of a symbolic link
      *
-     * @param String $link
-     * @return Mixed
+     * @param string $link
+     * @return mixed
      * @access public
      */
     function readlink($link)
@@ -1605,8 +1605,8 @@ class Net_SFTP extends Net_SSH2
      *
      * symlink() creates a symbolic link to the existing target with the specified name link.
      *
-     * @param String $target
-     * @param String $link
+     * @param string $target
+     * @param string $link
      * @return Boolean
      * @access public
      */
@@ -1642,7 +1642,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Creates a directory.
      *
-     * @param String $dir
+     * @param string $dir
      * @return Boolean
      * @access public
      */
@@ -1677,7 +1677,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Helper function for directory creation
      *
-     * @param String $dir
+     * @param string $dir
      * @return Boolean
      * @access private
      */
@@ -1705,7 +1705,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Removes a directory.
      *
-     * @param String $dir
+     * @param string $dir
      * @return Boolean
      * @access public
      */
@@ -1779,9 +1779,9 @@ class Net_SFTP extends Net_SSH2
      *
      * Setting $local_start to > 0 or $mode | NET_SFTP_RESUME_START doesn't do anything unless $mode | NET_SFTP_LOCAL_FILE.
      *
-     * @param String $remote_file
-     * @param String|resource $data
-     * @param optional Integer $mode
+     * @param string $remote_file
+     * @param string|resource $data
+     * @param int $mode (optional)
      * @param optional Integer $start
      * @param optional Integer $local_start
      * @return Boolean
@@ -1918,7 +1918,7 @@ class Net_SFTP extends Net_SSH2
      * Sending an SSH_FXP_WRITE packet and immediately reading its response isn't as efficient as blindly sending out $i
      * SSH_FXP_WRITEs, in succession, and then reading $i responses.
      *
-     * @param Integer $i
+     * @param int $i
      * @return Boolean
      * @access private
      */
@@ -1944,7 +1944,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Close handle
      *
-     * @param String $handle
+     * @param string $handle
      * @return Boolean
      * @access private
      */
@@ -1980,11 +1980,11 @@ class Net_SFTP extends Net_SSH2
      *
      * $offset and $length can be used to download files in chunks.
      *
-     * @param String $remote_file
-     * @param optional String $local_file
+     * @param string $remote_file
+     * @param optional string $local_file
      * @param optional Integer $offset
      * @param optional Integer $length
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function get($remote_file, $local_file = false, $offset = 0, $length = -1)
@@ -2096,7 +2096,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Deletes a file on the SFTP server.
      *
-     * @param String $path
+     * @param string $path
      * @param Boolean $recursive
      * @return Boolean
      * @access public
@@ -2146,8 +2146,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Minimizes directory lookups and SSH_FXP_STATUS requests for speed.
      *
-     * @param String $path
-     * @param Integer $i
+     * @param string $path
+     * @param int $i
      * @return Boolean
      * @access private
      */
@@ -2212,7 +2212,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Checks whether a file or directory exists
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access public
      */
@@ -2235,7 +2235,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Tells whether the filename is a directory
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access public
      */
@@ -2251,7 +2251,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Tells whether the filename is a regular file
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access public
      */
@@ -2267,7 +2267,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Tells whether the filename is a symbolic link
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access public
      */
@@ -2283,8 +2283,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets last access time of file
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function fileatime($path)
@@ -2295,8 +2295,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file modification time
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function filemtime($path)
@@ -2307,8 +2307,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file permissions
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function fileperms($path)
@@ -2319,8 +2319,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file owner
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function fileowner($path)
@@ -2331,8 +2331,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file group
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function filegroup($path)
@@ -2343,8 +2343,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file size
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function filesize($path)
@@ -2355,8 +2355,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Gets file type
      *
-     * @param String $path
-     * @return Mixed
+     * @param string $path
+     * @return mixed
      * @access public
      */
     function filetype($path)
@@ -2382,9 +2382,9 @@ class Net_SFTP extends Net_SSH2
      *
      * Uses cache if appropriate.
      *
-     * @param String $path
-     * @param String $prop
-     * @return Mixed
+     * @param string $path
+     * @param string $prop
+     * @return mixed
      * @access private
      */
     function _get_stat_cache_prop($path, $prop)
@@ -2411,8 +2411,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Renames a file or a directory on the SFTP server
      *
-     * @param String $oldname
-     * @param String $newname
+     * @param string $oldname
+     * @param string $newname
      * @return Boolean
      * @access public
      */
@@ -2461,7 +2461,7 @@ class Net_SFTP extends Net_SSH2
      *
      * See '7.  File Attributes' of draft-ietf-secsh-filexfer-13 for more info.
      *
-     * @param String $response
+     * @param string $response
      * @return Array
      * @access private
      */
@@ -2515,8 +2515,8 @@ class Net_SFTP extends Net_SSH2
      *
      * Quoting the SFTP RFC, "Implementations MUST NOT send bits that are not defined" but they seem to anyway
      *
-     * @param Integer $mode
-     * @return Integer
+     * @param int $mode
+     * @return int
      * @access private
      */
     function _parseMode($mode)
@@ -2562,8 +2562,8 @@ class Net_SFTP extends Net_SSH2
      *
      * If the longname is in an unrecognized format bool(false) is returned.
      *
-     * @param String $longname
-     * @return Mixed
+     * @param string $longname
+     * @return mixed
      * @access private
      */
     function _parseLongname($longname)
@@ -2591,8 +2591,8 @@ class Net_SFTP extends Net_SSH2
      *
      * See '6. General Packet Format' of draft-ietf-secsh-filexfer-13 for more info.
      *
-     * @param Integer $type
-     * @param String $data
+     * @param int $type
+     * @param string $data
      * @see Net_SFTP::_get_sftp_packet()
      * @see Net_SSH2::_send_channel_packet()
      * @return Boolean
@@ -2636,7 +2636,7 @@ class Net_SFTP extends Net_SSH2
      * messages containing one SFTP packet.
      *
      * @see Net_SFTP::_send_sftp_packet()
-     * @return String
+     * @return string
      * @access private
      */
     function _get_sftp_packet()
@@ -2708,7 +2708,7 @@ class Net_SFTP extends Net_SSH2
      * Returns a string if NET_SFTP_LOGGING == NET_SFTP_LOG_COMPLEX, an array if NET_SFTP_LOGGING == NET_SFTP_LOG_SIMPLE and false if !defined('NET_SFTP_LOGGING')
      *
      * @access public
-     * @return String or Array
+     * @return string or Array
      */
     function getSFTPLog()
     {
@@ -2729,7 +2729,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Returns all errors
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getSFTPErrors()
@@ -2740,7 +2740,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Returns the last error
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getLastSFTPError()
@@ -2766,7 +2766,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Disconnect
      *
-     * @param Integer $reason
+     * @param int $reason
      * @return Boolean
      * @access private
      */

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -63,7 +63,7 @@ class Net_SFTP_Stream
     /**
      * Path
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $path;
@@ -71,7 +71,7 @@ class Net_SFTP_Stream
     /**
      * Mode
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $mode;
@@ -79,7 +79,7 @@ class Net_SFTP_Stream
     /**
      * Position
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $pos;
@@ -87,7 +87,7 @@ class Net_SFTP_Stream
     /**
      * Size
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $size;
@@ -129,7 +129,7 @@ class Net_SFTP_Stream
     /**
      * Registers this class as a URL wrapper.
      *
-     * @param optional String $protocol The wrapper name to be registered.
+     * @param optional string $protocol The wrapper name to be registered.
      * @return Boolean True on success, false otherwise.
      * @access public
      */
@@ -166,8 +166,8 @@ class Net_SFTP_Stream
      * If "notification" is set as a context parameter the message code for successful login is
      * NET_SSH2_MSG_USERAUTH_SUCCESS. For a failed login it's NET_SSH2_MSG_USERAUTH_FAILURE.
      *
-     * @param String $path
-     * @return String
+     * @param string $path
+     * @return string
      * @access private
      */
     function _parse_path($path)
@@ -258,10 +258,10 @@ class Net_SFTP_Stream
     /**
      * Opens file or URL
      *
-     * @param String $path
-     * @param String $mode
-     * @param Integer $options
-     * @param String $opened_path
+     * @param string $path
+     * @param string $mode
+     * @param int $options
+     * @param string $opened_path
      * @return Boolean
      * @access public
      */
@@ -300,8 +300,8 @@ class Net_SFTP_Stream
     /**
      * Read from stream
      *
-     * @param Integer $count
-     * @return Mixed
+     * @param int $count
+     * @return mixed
      * @access public
      */
     function _stream_read($count)
@@ -342,8 +342,8 @@ class Net_SFTP_Stream
     /**
      * Write to stream
      *
-     * @param String $data
-     * @return Mixed
+     * @param string $data
+     * @return mixed
      * @access public
      */
     function _stream_write($data)
@@ -377,7 +377,7 @@ class Net_SFTP_Stream
     /**
      * Retrieve the current position of a stream
      *
-     * @return Integer
+     * @return int
      * @access public
      */
     function _stream_tell()
@@ -406,8 +406,8 @@ class Net_SFTP_Stream
     /**
      * Seeks to specific location in a stream
      *
-     * @param Integer $offset
-     * @param Integer $whence
+     * @param int $offset
+     * @param int $whence
      * @return Boolean
      * @access public
      */
@@ -434,8 +434,8 @@ class Net_SFTP_Stream
     /**
      * Change stream options
      *
-     * @param String $path
-     * @param Integer $option
+     * @param string $path
+     * @param int $option
      * @param Mixed $var
      * @return Boolean
      * @access public
@@ -468,7 +468,7 @@ class Net_SFTP_Stream
     /**
      * Retrieve the underlaying resource
      *
-     * @param Integer $cast_as
+     * @param int $cast_as
      * @return Resource
      * @access public
      */
@@ -480,7 +480,7 @@ class Net_SFTP_Stream
     /**
      * Advisory file locking
      *
-     * @param Integer $operation
+     * @param int $operation
      * @return Boolean
      * @access public
      */
@@ -496,8 +496,8 @@ class Net_SFTP_Stream
      * If newname exists, it will be overwritten.  This is a departure from what Net_SFTP
      * does.
      *
-     * @param String $path_from
-     * @param String $path_to
+     * @param string $path_from
+     * @param string $path_to
      * @return Boolean
      * @access public
      */
@@ -548,8 +548,8 @@ class Net_SFTP_Stream
      *                string     longname
      *                ATTRS      attrs
      *
-     * @param String $path
-     * @param Integer $options
+     * @param string $path
+     * @param int $options
      * @return Boolean
      * @access public
      */
@@ -567,7 +567,7 @@ class Net_SFTP_Stream
     /**
      * Read entry from directory handle
      *
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function _dir_readdir()
@@ -606,9 +606,9 @@ class Net_SFTP_Stream
      *
      * Only valid $options is STREAM_MKDIR_RECURSIVE
      *
-     * @param String $path
-     * @param Integer $mode
-     * @param Integer $options
+     * @param string $path
+     * @param int $mode
+     * @param int $options
      * @return Boolean
      * @access public
      */
@@ -630,9 +630,9 @@ class Net_SFTP_Stream
      * STREAM_MKDIR_RECURSIVE is supposed to be set. Also, when I try it out with rmdir() I get 8 as
      * $options. What does 8 correspond to?
      *
-     * @param String $path
-     * @param Integer $mode
-     * @param Integer $options
+     * @param string $path
+     * @param int $mode
+     * @param int $options
      * @return Boolean
      * @access public
      */
@@ -662,7 +662,7 @@ class Net_SFTP_Stream
     /**
      * Retrieve information about a file resource
      *
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function _stream_stat()
@@ -677,7 +677,7 @@ class Net_SFTP_Stream
     /**
      * Delete a file
      *
-     * @param String $path
+     * @param string $path
      * @return Boolean
      * @access public
      */
@@ -698,9 +698,9 @@ class Net_SFTP_Stream
      * might be worthwhile to reconstruct bits 12-16 (ie. the file type) if mode doesn't have them but we'll
      * cross that bridge when and if it's reached
      *
-     * @param String $path
-     * @param Integer $flags
-     * @return Mixed
+     * @param string $path
+     * @param int $flags
+     * @return mixed
      * @access public
      */
     function _url_stat($path, $flags)
@@ -721,7 +721,7 @@ class Net_SFTP_Stream
     /**
      * Truncate stream
      *
-     * @param Integer $new_size
+     * @param int $new_size
      * @return Boolean
      * @access public
      */
@@ -743,9 +743,9 @@ class Net_SFTP_Stream
      * STREAM_OPTION_WRITE_BUFFER isn't supported for the same reason stream_flush isn't.
      * The other two aren't supported because of limitations in Net_SFTP.
      *
-     * @param Integer $option
-     * @param Integer $arg1
-     * @param Integer $arg2
+     * @param int $option
+     * @param int $arg1
+     * @param int $arg2
      * @return Boolean
      * @access public
      */
@@ -773,9 +773,9 @@ class Net_SFTP_Stream
      * If NET_SFTP_STREAM_LOGGING is defined all calls will be output on the screen and then (regardless of whether or not
      * NET_SFTP_STREAM_LOGGING is enabled) the parameters will be passed through to the appropriate method.
      *
-     * @param String
+     * @param string
      * @param Array
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function __call($name, $arguments)

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -103,7 +103,7 @@ class Net_SFTP_Stream
     /**
      * EOF flag
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $eof;
@@ -113,7 +113,7 @@ class Net_SFTP_Stream
      *
      * Technically this needs to be publically accessible so PHP can set it directly
      *
-     * @var Resource
+     * @var resource
      * @access public
      */
     var $context;
@@ -121,7 +121,7 @@ class Net_SFTP_Stream
     /**
      * Notification callback function
      *
-     * @var Callable
+     * @var callable
      * @access public
      */
     var $notification;
@@ -130,7 +130,7 @@ class Net_SFTP_Stream
      * Registers this class as a URL wrapper.
      *
      * @param optional string $protocol The wrapper name to be registered.
-     * @return Boolean True on success, false otherwise.
+     * @return bool True on success, false otherwise.
      * @access public
      */
     static function register($protocol = 'sftp')
@@ -262,7 +262,7 @@ class Net_SFTP_Stream
      * @param string $mode
      * @param int $options
      * @param string $opened_path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_open($path, $mode, $options, &$opened_path)
@@ -395,7 +395,7 @@ class Net_SFTP_Stream
      * will return false. do fread($fp, 1) and feof() will then return true. do fseek($fp, 10) on ablank file and feof()
      * will return false. do fread($fp, 1) and feof() will then return true.
      *
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_eof()
@@ -408,7 +408,7 @@ class Net_SFTP_Stream
      *
      * @param int $offset
      * @param int $whence
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_seek($offset, $whence)
@@ -436,8 +436,8 @@ class Net_SFTP_Stream
      *
      * @param string $path
      * @param int $option
-     * @param Mixed $var
-     * @return Boolean
+     * @param mixed $var
+     * @return bool
      * @access public
      */
     function _stream_metadata($path, $option, $var)
@@ -469,7 +469,7 @@ class Net_SFTP_Stream
      * Retrieve the underlaying resource
      *
      * @param int $cast_as
-     * @return Resource
+     * @return resource
      * @access public
      */
     function _stream_cast($cast_as)
@@ -481,7 +481,7 @@ class Net_SFTP_Stream
      * Advisory file locking
      *
      * @param int $operation
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_lock($operation)
@@ -498,7 +498,7 @@ class Net_SFTP_Stream
      *
      * @param string $path_from
      * @param string $path_to
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _rename($path_from, $path_to)
@@ -550,7 +550,7 @@ class Net_SFTP_Stream
      *
      * @param string $path
      * @param int $options
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _dir_opendir($path, $options)
@@ -581,7 +581,7 @@ class Net_SFTP_Stream
     /**
      * Rewind directory handle
      *
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _dir_rewinddir()
@@ -593,7 +593,7 @@ class Net_SFTP_Stream
     /**
      * Close directory handle
      *
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _dir_closedir()
@@ -609,7 +609,7 @@ class Net_SFTP_Stream
      * @param string $path
      * @param int $mode
      * @param int $options
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _mkdir($path, $mode, $options)
@@ -633,7 +633,7 @@ class Net_SFTP_Stream
      * @param string $path
      * @param int $mode
      * @param int $options
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _rmdir($path, $options)
@@ -651,7 +651,7 @@ class Net_SFTP_Stream
      *
      * See <http://php.net/fflush>. Always returns true because Net_SFTP doesn't cache stuff before writing
      *
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_flush()
@@ -678,7 +678,7 @@ class Net_SFTP_Stream
      * Delete a file
      *
      * @param string $path
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _unlink($path)
@@ -722,7 +722,7 @@ class Net_SFTP_Stream
      * Truncate stream
      *
      * @param int $new_size
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_truncate($new_size)
@@ -746,7 +746,7 @@ class Net_SFTP_Stream
      * @param int $option
      * @param int $arg1
      * @param int $arg2
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function _stream_set_option($option, $arg1, $arg2)

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -386,7 +386,7 @@ class Net_SSH1
      * Real-time log file pointer
      *
      * @see Net_SSH1::_append_log()
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $realtime_log_file;
@@ -404,7 +404,7 @@ class Net_SSH1
      * Real-time log file wrap boolean
      *
      * @see Net_SSH1::_append_log()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $realtime_log_wrap;
@@ -560,7 +560,7 @@ class Net_SSH1
     /**
      * Connect to an SSHv1 server
      *
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _connect()
@@ -729,7 +729,7 @@ class Net_SSH1
      *
      * @param string $username
      * @param optional string $password
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function login($username, $password = '')
@@ -800,7 +800,7 @@ class Net_SSH1
      * $ssh->exec('ping 127.0.0.1'); on a Linux host will never return and will run indefinitely.  setTimeout() makes it so it'll timeout.
      * Setting $timeout to false or 0 will mean there is no timeout.
      *
-     * @param Mixed $timeout
+     * @param mixed $timeout
      */
     function setTimeout($timeout)
     {
@@ -873,7 +873,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::interactiveRead()
      * @see Net_SSH1::interactiveWrite()
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _initShell()
@@ -917,7 +917,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::interactiveWrite()
      * @param string $cmd
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function write($cmd)
@@ -934,7 +934,7 @@ class Net_SSH1
      * @see Net_SSH1::write()
      * @param string $expect
      * @param int $mode
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function read($expect, $mode = NET_SSH1_READ_SIMPLE)
@@ -973,7 +973,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::interactiveRead()
      * @param string $cmd
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function interactiveWrite($cmd)
@@ -1174,7 +1174,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::_get_binary_packet()
      * @param string $data
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _send_binary_packet($data)

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -235,7 +235,7 @@ class Net_SSH1
     /**
      * The SSH identifier
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $identifier = 'SSH-1.5-phpseclib';
@@ -262,7 +262,7 @@ class Net_SSH1
      * The bits that are set represent functions that have been called already.  This is used to determine
      * if a requisite function has been successfully executed.  If not, an error should be thrown.
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $bitmap = 0;
@@ -273,7 +273,7 @@ class Net_SSH1
      * Logged for debug purposes
      *
      * @see Net_SSH1::getServerKeyPublicExponent()
-     * @var String
+     * @var string
      * @access private
      */
     var $server_key_public_exponent;
@@ -284,7 +284,7 @@ class Net_SSH1
      * Logged for debug purposes
      *
      * @see Net_SSH1::getServerKeyPublicModulus()
-     * @var String
+     * @var string
      * @access private
      */
     var $server_key_public_modulus;
@@ -295,7 +295,7 @@ class Net_SSH1
      * Logged for debug purposes
      *
      * @see Net_SSH1::getHostKeyPublicExponent()
-     * @var String
+     * @var string
      * @access private
      */
     var $host_key_public_exponent;
@@ -306,7 +306,7 @@ class Net_SSH1
      * Logged for debug purposes
      *
      * @see Net_SSH1::getHostKeyPublicModulus()
-     * @var String
+     * @var string
      * @access private
      */
     var $host_key_public_modulus;
@@ -350,7 +350,7 @@ class Net_SSH1
      * Server Identification
      *
      * @see Net_SSH1::getServerIdentification()
-     * @var String
+     * @var string
      * @access private
      */
     var $server_identification = '';
@@ -395,7 +395,7 @@ class Net_SSH1
      * Real-time log file size
      *
      * @see Net_SSH1::_append_log()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $realtime_log_size;
@@ -463,7 +463,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::Net_SSH1()
      * @see Net_SSH1::_connect()
-     * @var String
+     * @var string
      * @access private
      */
     var $host;
@@ -473,7 +473,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::Net_SSH1()
      * @see Net_SSH1::_connect()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $port;
@@ -488,7 +488,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::Net_SSH1()
      * @see Net_SSH1::_connect()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $connectionTimeout;
@@ -498,7 +498,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::Net_SSH1()
      * @see Net_SSH1::_connect()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $cipher;
@@ -508,9 +508,9 @@ class Net_SSH1
      *
      * Connects to an SSHv1 server
      *
-     * @param String $host
+     * @param string $host
      * @param optional Integer $port
-     * @param optional Integer $timeout
+     * @param int $time (optional)out
      * @param optional Integer $cipher
      * @return Net_SSH1
      * @access public
@@ -727,8 +727,8 @@ class Net_SSH1
     /**
      * Login
      *
-     * @param String $username
-     * @param optional String $password
+     * @param string $username
+     * @param optional string $password
      * @return Boolean
      * @access public
      */
@@ -823,7 +823,7 @@ class Net_SSH1
      *
      * @see Net_SSH1::interactiveRead()
      * @see Net_SSH1::interactiveWrite()
-     * @param String $cmd
+     * @param string $cmd
      * @return mixed
      * @access public
      */
@@ -916,7 +916,7 @@ class Net_SSH1
      * Inputs a command into an interactive shell.
      *
      * @see Net_SSH1::interactiveWrite()
-     * @param String $cmd
+     * @param string $cmd
      * @return Boolean
      * @access public
      */
@@ -932,8 +932,8 @@ class Net_SSH1
      * a regular expression.
      *
      * @see Net_SSH1::write()
-     * @param String $expect
-     * @param Integer $mode
+     * @param string $expect
+     * @param int $mode
      * @return Boolean
      * @access public
      */
@@ -972,7 +972,7 @@ class Net_SSH1
      * Inputs a command into an interactive shell.
      *
      * @see Net_SSH1::interactiveRead()
-     * @param String $cmd
+     * @param string $cmd
      * @return Boolean
      * @access public
      */
@@ -1008,7 +1008,7 @@ class Net_SSH1
      * there's not going to be much recourse.
      *
      * @see Net_SSH1::interactiveRead()
-     * @return String
+     * @return string
      * @access public
      */
     function interactiveRead()
@@ -1059,7 +1059,7 @@ class Net_SSH1
     /**
      * Disconnect
      *
-     * @param String $msg
+     * @param string $msg
      * @access private
      */
     function _disconnect($msg = 'Client Quit')
@@ -1173,7 +1173,7 @@ class Net_SSH1
      * Returns true on success, false on failure.
      *
      * @see Net_SSH1::_get_binary_packet()
-     * @param String $data
+     * @param string $data
      * @return Boolean
      * @access private
      */
@@ -1221,8 +1221,8 @@ class Net_SSH1
      *
      * @see Net_SSH1::_get_binary_packet()
      * @see Net_SSH1::_send_binary_packet()
-     * @param String $data
-     * @return Integer
+     * @param string $data
+     * @return int
      * @access private
      */
     function _crc($data)
@@ -1313,13 +1313,13 @@ class Net_SSH1
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
-     * @return String
+     * @param string $string
+     * @param int $index (optional)
+     * @return string
      * @access private
      */
     function _string_shift(&$string, $index = 1)
@@ -1414,7 +1414,7 @@ class Net_SSH1
      * Returns a string if NET_SSH1_LOGGING == NET_SSH1_LOG_COMPLEX, an array if NET_SSH1_LOGGING == NET_SSH1_LOG_SIMPLE and false if !defined('NET_SSH1_LOGGING')
      *
      * @access public
-     * @return String or Array
+     * @return string or Array
      */
     function getLog()
     {
@@ -1440,7 +1440,7 @@ class Net_SSH1
      * @param Array $message_log
      * @param Array $message_number_log
      * @access private
-     * @return String
+     * @return string
      */
     function _format_log($message_log, $message_number_log)
     {
@@ -1475,7 +1475,7 @@ class Net_SSH1
      *
      * @param Array $matches
      * @access private
-     * @return String
+     * @return string
      */
     function _format_log_helper($matches)
     {
@@ -1489,7 +1489,7 @@ class Net_SSH1
      * the raw bytes.  This behavior is similar to PHP's md5() function.
      *
      * @param optional Boolean $raw_output
-     * @return String
+     * @return string
      * @access public
      */
     function getServerKeyPublicExponent($raw_output = false)
@@ -1504,7 +1504,7 @@ class Net_SSH1
      * the raw bytes.  This behavior is similar to PHP's md5() function.
      *
      * @param optional Boolean $raw_output
-     * @return String
+     * @return string
      * @access public
      */
     function getServerKeyPublicModulus($raw_output = false)
@@ -1519,7 +1519,7 @@ class Net_SSH1
      * the raw bytes.  This behavior is similar to PHP's md5() function.
      *
      * @param optional Boolean $raw_output
-     * @return String
+     * @return string
      * @access public
      */
     function getHostKeyPublicExponent($raw_output = false)
@@ -1534,7 +1534,7 @@ class Net_SSH1
      * the raw bytes.  This behavior is similar to PHP's md5() function.
      *
      * @param optional Boolean $raw_output
-     * @return String
+     * @return string
      * @access public
      */
     function getHostKeyPublicModulus($raw_output = false)
@@ -1577,7 +1577,7 @@ class Net_SSH1
     /**
      * Return the server identification.
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getServerIdentification()
@@ -1590,7 +1590,7 @@ class Net_SSH1
      *
      * Makes sure that only the last 1MB worth of packets will be logged
      *
-     * @param String $data
+     * @param string $data
      * @access private
      */
     function _append_log($protocol_flags, $message)

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -510,7 +510,7 @@ class Net_SSH1
      *
      * @param string $host
      * @param optional Integer $port
-     * @param int $time (optional)out
+     * @param int $timeout (optional)
      * @param optional Integer $cipher
      * @return Net_SSH1
      * @access public

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -845,7 +845,7 @@ class Net_SSH2
      *
      * @param string $host
      * @param optional Integer $port
-     * @param int $time (optional)out
+     * @param int $timeout (optional)
      * @see Net_SSH2::login()
      * @return Net_SSH2
      * @access public

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -153,7 +153,7 @@ class Net_SSH2
     /**
      * The SSH identifier
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $identifier;
@@ -172,7 +172,7 @@ class Net_SSH2
      * The bits that are set represent functions that have been called already.  This is used to determine
      * if a requisite function has been successfully executed.  If not, an error should be thrown.
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $bitmap = 0;
@@ -182,7 +182,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::getErrors()
      * @see Net_SSH2::getLastError()
-     * @var String
+     * @var string
      * @access private
      */
     var $errors = array();
@@ -298,7 +298,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::Net_SSH2()
      * @see Net_SSH2::_send_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $encrypt_block_size = 8;
@@ -308,7 +308,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::Net_SSH2()
      * @see Net_SSH2::_get_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $decrypt_block_size = 8;
@@ -357,7 +357,7 @@ class Net_SSH2
      * append it.
      *
      * @see Net_SSH2::_get_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $hmac_size = false;
@@ -366,7 +366,7 @@ class Net_SSH2
      * Server Public Host Key
      *
      * @see Net_SSH2::getServerPublicHostKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $server_public_host_key;
@@ -381,7 +381,7 @@ class Net_SSH2
      *  -- http://tools.ietf.org/html/rfc4253#section-7.2
      *
      * @see Net_SSH2::_key_exchange()
-     * @var String
+     * @var string
      * @access private
      */
     var $session_id = false;
@@ -392,7 +392,7 @@ class Net_SSH2
      * The current exchange hash
      *
      * @see Net_SSH2::_key_exchange()
-     * @var String
+     * @var string
      * @access private
      */
     var $exchange_hash = false;
@@ -450,7 +450,7 @@ class Net_SSH2
      * See 'Section 6.4.  Data Integrity' of rfc4253 for more info.
      *
      * @see Net_SSH2::_send_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $send_seq_no = 0;
@@ -461,7 +461,7 @@ class Net_SSH2
      * See 'Section 6.4.  Data Integrity' of rfc4253 for more info.
      *
      * @see Net_SSH2::_get_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $get_seq_no = 0;
@@ -536,7 +536,7 @@ class Net_SSH2
      *
      * Bytes the other party can send before it must wait for the window to be adjusted (0x7FFFFFFF = 2GB)
      *
-     * @var Integer
+     * @var int
      * @see Net_SSH2::_send_channel_packet()
      * @see Net_SSH2::exec()
      * @access private
@@ -571,7 +571,7 @@ class Net_SSH2
      * Verified against $this->session_id
      *
      * @see Net_SSH2::getServerPublicHostKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $signature = '';
@@ -582,7 +582,7 @@ class Net_SSH2
      * ssh-rsa or ssh-dss.
      *
      * @see Net_SSH2::getServerPublicHostKey()
-     * @var String
+     * @var string
      * @access private
      */
     var $signature_format = '';
@@ -603,7 +603,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::_send_binary_packet()
      * @see Net_SSH2::_get_binary_packet()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $log_size;
@@ -637,7 +637,7 @@ class Net_SSH2
      * Real-time log file size
      *
      * @see Net_SSH2::_append_log()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $realtime_log_size;
@@ -670,7 +670,7 @@ class Net_SSH2
     /**
      * Time of first network activity
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $last_packet;
@@ -678,7 +678,7 @@ class Net_SSH2
     /**
      * Exit status returned from ssh if any
      *
-     * @var Integer
+     * @var int
      * @access private
      */
     var $exit_status;
@@ -711,7 +711,7 @@ class Net_SSH2
     /**
      * Contents of stdError
      *
-     * @var String
+     * @var string
      * @access private
      */
     var $stdErrorLog;
@@ -720,7 +720,7 @@ class Net_SSH2
      * The Last Interactive Response
      *
      * @see Net_SSH2::_keyboard_interactive_process()
-     * @var String
+     * @var string
      * @access private
      */
     var $last_interactive_response = '';
@@ -742,7 +742,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::_filter()
      * @see Net_SSH2::getBannerMessage()
-     * @var String
+     * @var string
      * @access private
      */
     var $banner_message = '';
@@ -760,7 +760,7 @@ class Net_SSH2
      * Log Boundary
      *
      * @see Net_SSH2::_format_log()
-     * @var String
+     * @var string
      * @access private
      */
     var $log_boundary = ':';
@@ -769,7 +769,7 @@ class Net_SSH2
      * Log Long Width
      *
      * @see Net_SSH2::_format_log()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $log_long_width = 65;
@@ -778,7 +778,7 @@ class Net_SSH2
      * Log Short Width
      *
      * @see Net_SSH2::_format_log()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $log_short_width = 16;
@@ -788,7 +788,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::Net_SSH2()
      * @see Net_SSH2::_connect()
-     * @var String
+     * @var string
      * @access private
      */
     var $host;
@@ -798,7 +798,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::Net_SSH2()
      * @see Net_SSH2::_connect()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $port;
@@ -813,7 +813,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::Net_SSH2()
      * @see Net_SSH2::_connect()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $connectionTimeout;
@@ -824,7 +824,7 @@ class Net_SSH2
      * @see Net_SSH2::getWindowColumns()
      * @see Net_SSH2::setWindowColumns()
      * @see Net_SSH2::setWindowSize()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $windowColumns = 80;
@@ -835,7 +835,7 @@ class Net_SSH2
      * @see Net_SSH2::getWindowRows()
      * @see Net_SSH2::setWindowRows()
      * @see Net_SSH2::setWindowSize()
-     * @var Integer
+     * @var int
      * @access private
      */
     var $windowRows = 24;
@@ -843,9 +843,9 @@ class Net_SSH2
     /**
      * Default Constructor.
      *
-     * @param String $host
+     * @param string $host
      * @param optional Integer $port
-     * @param optional Integer $timeout
+     * @param int $time (optional)out
      * @see Net_SSH2::login()
      * @return Net_SSH2
      * @access public
@@ -1055,7 +1055,7 @@ class Net_SSH2
      * You should overwrite this method in your own class if you want to use another identifier
      *
      * @access protected
-     * @return String
+     * @return string
      */
     function _generate_identifier()
     {
@@ -1082,7 +1082,7 @@ class Net_SSH2
     /**
      * Key Exchange
      *
-     * @param String $kexinit_payload_server
+     * @param string $kexinit_payload_server
      * @access private
      */
     function _key_exchange($kexinit_payload_server)
@@ -1791,7 +1791,7 @@ class Net_SSH2
      *
      * The $password parameter can be a plaintext password, a Crypt_RSA object or an array
      *
-     * @param String $username
+     * @param string $username
      * @param Mixed $password
      * @param Mixed $...
      * @return Boolean
@@ -1807,7 +1807,7 @@ class Net_SSH2
     /**
      * Login Helper
      *
-     * @param String $username
+     * @param string $username
      * @param Mixed $password
      * @param Mixed $...
      * @return Boolean
@@ -1838,8 +1838,8 @@ class Net_SSH2
     /**
      * Login Helper
      *
-     * @param String $username
-     * @param optional String $password
+     * @param string $username
+     * @param optional string $password
      * @return Boolean
      * @access private
      * @internal It might be worthwhile, at some point, to protect against {@link http://tools.ietf.org/html/rfc4251#section-9.3.9 traffic analysis}
@@ -1989,8 +1989,8 @@ class Net_SSH2
      *
      * See {@link http://tools.ietf.org/html/rfc4256 RFC4256} for details.  This is not a full-featured keyboard-interactive authenticator.
      *
-     * @param String $username
-     * @param String $password
+     * @param string $username
+     * @param string $password
      * @return Boolean
      * @access private
      */
@@ -2011,7 +2011,7 @@ class Net_SSH2
     /**
      * Handle the keyboard-interactive requests / responses.
      *
-     * @param String $responses...
+     * @param string $responses...
      * @return Boolean
      * @access private
      */
@@ -2125,7 +2125,7 @@ class Net_SSH2
     /**
      * Login with an ssh-agent provided key
      *
-     * @param String $username
+     * @param string $username
      * @param System_SSH_Agent $agent
      * @return Boolean
      * @access private
@@ -2145,7 +2145,7 @@ class Net_SSH2
     /**
      * Login with an RSA private key
      *
-     * @param String $username
+     * @param string $username
      * @param Crypt_RSA $password
      * @return Boolean
      * @access private
@@ -2264,9 +2264,9 @@ class Net_SSH2
      * If $callback is set to false then Net_SSH2::_get_channel_packet(NET_SSH2_CHANNEL_EXEC) will need to be called manually.
      * In all likelihood, this is not a feature you want to be taking advantage of.
      *
-     * @param String $command
+     * @param string $command
      * @param optional Callback $callback
-     * @return String
+     * @return string
      * @access public
      */
     function exec($command, $callback = null)
@@ -2462,7 +2462,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::read()
      * @see Net_SSH2::write()
-     * @return Integer
+     * @return int
      * @access public
      */
     function _get_interactive_channel()
@@ -2484,9 +2484,9 @@ class Net_SSH2
      * if $mode == NET_SSH2_READ_REGEX, a regular expression.
      *
      * @see Net_SSH2::write()
-     * @param String $expect
-     * @param Integer $mode
-     * @return String
+     * @param string $expect
+     * @param int $mode
+     * @return string
      * @access public
      */
     function read($expect = '', $mode = NET_SSH2_READ_SIMPLE)
@@ -2530,7 +2530,7 @@ class Net_SSH2
      * Inputs a command into an interactive shell.
      *
      * @see Net_SSH2::read()
-     * @param String $cmd
+     * @param string $cmd
      * @return Boolean
      * @access public
      */
@@ -2559,7 +2559,7 @@ class Net_SSH2
      * if there's sufficient demand for such a feature.
      *
      * @see Net_SSH2::stopSubsystem()
-     * @param String $subsystem
+     * @param string $subsystem
      * @return Boolean
      * @access public
      */
@@ -2684,7 +2684,7 @@ class Net_SSH2
      * See '6. Binary Packet Protocol' of rfc4253 for more info.
      *
      * @see Net_SSH2::_send_binary_packet()
-     * @return String
+     * @return string
      * @access private
      */
     function _get_binary_packet()
@@ -2777,7 +2777,7 @@ class Net_SSH2
      * Because some binary packets need to be ignored...
      *
      * @see Net_SSH2::_get_binary_packet()
-     * @return String
+     * @return string
      * @access private
      */
     function _filter($payload)
@@ -2940,7 +2940,7 @@ class Net_SSH2
      * Returns the data as a string if it's available and false if not.
      *
      * @param $client_channel
-     * @return Mixed
+     * @return mixed
      * @access private
      */
     function _get_channel_packet($client_channel, $skip_extended = false)
@@ -3131,8 +3131,8 @@ class Net_SSH2
      *
      * See '6. Binary Packet Protocol' of rfc4253 for more info.
      *
-     * @param String $data
-     * @param optional String $logged
+     * @param string $data
+     * @param optional string $logged
      * @see Net_SSH2::_get_binary_packet()
      * @return Boolean
      * @access private
@@ -3192,7 +3192,7 @@ class Net_SSH2
      *
      * Makes sure that only the last 1MB worth of packets will be logged
      *
-     * @param String $data
+     * @param string $data
      * @access private
      */
     function _append_log($message_number, $message)
@@ -3268,8 +3268,8 @@ class Net_SSH2
      *
      * Spans multiple SSH_MSG_CHANNEL_DATAs if appropriate
      *
-     * @param Integer $client_channel
-     * @param String $data
+     * @param int $client_channel
+     * @param string $data
      * @return Boolean
      * @access private
      */
@@ -3315,7 +3315,7 @@ class Net_SSH2
      * and for SFTP channels are presumably closed when the client disconnects.  This functions is intended
      * for SCP more than anything.
      *
-     * @param Integer $client_channel
+     * @param int $client_channel
      * @param Boolean $want_reply
      * @return Boolean
      * @access private
@@ -3348,7 +3348,7 @@ class Net_SSH2
     /**
      * Disconnect
      *
-     * @param Integer $reason
+     * @param int $reason
      * @return Boolean
      * @access private
      */
@@ -3364,13 +3364,13 @@ class Net_SSH2
     }
 
     /**
-     * String Shift
+     * string Shift
      *
      * Inspired by array_shift
      *
-     * @param String $string
-     * @param optional Integer $index
-     * @return String
+     * @param string $string
+     * @param int $index (optional)
+     * @return string
      * @access private
      */
     function _string_shift(&$string, $index = 1)
@@ -3410,7 +3410,7 @@ class Net_SSH2
      * Returns a string if NET_SSH2_LOGGING == NET_SSH2_LOG_COMPLEX, an array if NET_SSH2_LOGGING == NET_SSH2_LOG_SIMPLE and false if !defined('NET_SSH2_LOGGING')
      *
      * @access public
-     * @return String or Array
+     * @return string or Array
      */
     function getLog()
     {
@@ -3436,7 +3436,7 @@ class Net_SSH2
      * @param Array $message_log
      * @param Array $message_number_log
      * @access private
-     * @return String
+     * @return string
      */
     function _format_log($message_log, $message_number_log)
     {
@@ -3471,7 +3471,7 @@ class Net_SSH2
      *
      * @param Array $matches
      * @access private
-     * @return String
+     * @return string
      */
     function _format_log_helper($matches)
     {
@@ -3481,7 +3481,7 @@ class Net_SSH2
     /**
      * Returns all errors
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getErrors()
@@ -3492,7 +3492,7 @@ class Net_SSH2
     /**
      * Returns the last error
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getLastError()
@@ -3503,7 +3503,7 @@ class Net_SSH2
     /**
      * Return the server identification.
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getServerIdentification()
@@ -3649,7 +3649,7 @@ class Net_SSH2
      * Quoting from the RFC, "in some jurisdictions, sending a warning message before
      * authentication may be relevant for getting legal protection."
      *
-     * @return String
+     * @return string
      * @access public
      */
     function getBannerMessage()
@@ -3663,7 +3663,7 @@ class Net_SSH2
      * Caching this the first time you connect to a server and checking the result on subsequent connections
      * is recommended.  Returns false if the server signature is not signed correctly with the public host key.
      *
-     * @return Mixed
+     * @return mixed
      * @access public
      */
     function getServerPublicHostKey()
@@ -3808,7 +3808,7 @@ class Net_SSH2
     /**
      * Returns the exit status of an SSH command or false.
      *
-     * @return Integer or false
+     * @return int or false
      * @access public
      */
     function getExitStatus()
@@ -3822,7 +3822,7 @@ class Net_SSH2
     /**
      * Returns the number of columns for the terminal window size.
      *
-     * @return Integer
+     * @return int
      * @access public
      */
     function getWindowColumns()
@@ -3833,7 +3833,7 @@ class Net_SSH2
     /**
      * Returns the number of rows for the terminal window size.
      *
-     * @return Integer
+     * @return int
      * @access public
      */
     function getWindowRows()
@@ -3844,7 +3844,7 @@ class Net_SSH2
     /**
      * Sets the number of columns for the terminal window size.
      *
-     * @param Integer $value
+     * @param int $value
      * @access public
      */
     function setWindowColumns($value)
@@ -3855,7 +3855,7 @@ class Net_SSH2
     /**
      * Sets the number of rows for the terminal window size.
      *
-     * @param Integer $value
+     * @param int $value
      * @access public
      */
     function setWindowRows($value)
@@ -3866,8 +3866,8 @@ class Net_SSH2
     /**
      * Sets the number of columns and rows for the terminal window size.
      *
-     * @param Integer $columns
-     * @param Integer $rows
+     * @param int $columns
+     * @param int $rows
      * @access public
      */
     function setWindowSize($columns = 80, $rows = 24)

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -628,7 +628,7 @@ class Net_SSH2
      * Real-time log file pointer
      *
      * @see Net_SSH2::_append_log()
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $realtime_log_file;
@@ -646,7 +646,7 @@ class Net_SSH2
      * Has the signature been validated?
      *
      * @see Net_SSH2::getServerPublicHostKey()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $signature_validated = false;
@@ -686,7 +686,7 @@ class Net_SSH2
     /**
      * Flag to request a PTY when using exec()
      *
-     * @var Boolean
+     * @var bool
      * @see Net_SSH2::enablePTY()
      * @access private
      */
@@ -695,7 +695,7 @@ class Net_SSH2
     /**
      * Flag set while exec() is running when using enablePTY()
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $in_request_pty_exec = false;
@@ -703,7 +703,7 @@ class Net_SSH2
     /**
      * Flag set after startSubsystem() is called
      *
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $in_subsystem;
@@ -751,7 +751,7 @@ class Net_SSH2
      * Did read() timeout or return normally?
      *
      * @see Net_SSH2::isTimeout()
-     * @var Boolean
+     * @var bool
      * @access private
      */
     var $is_timeout = false;
@@ -944,7 +944,7 @@ class Net_SSH2
     /**
      * Connect to an SSHv2 server
      *
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _connect()
@@ -1792,9 +1792,9 @@ class Net_SSH2
      * The $password parameter can be a plaintext password, a Crypt_RSA object or an array
      *
      * @param string $username
-     * @param Mixed $password
-     * @param Mixed $...
-     * @return Boolean
+     * @param mixed $password
+     * @param mixed $...
+     * @return bool
      * @see _login
      * @access public
      */
@@ -1808,9 +1808,9 @@ class Net_SSH2
      * Login Helper
      *
      * @param string $username
-     * @param Mixed $password
-     * @param Mixed $...
-     * @return Boolean
+     * @param mixed $password
+     * @param mixed $...
+     * @return bool
      * @see _login_helper
      * @access private
      */
@@ -1840,7 +1840,7 @@ class Net_SSH2
      *
      * @param string $username
      * @param optional string $password
-     * @return Boolean
+     * @return bool
      * @access private
      * @internal It might be worthwhile, at some point, to protect against {@link http://tools.ietf.org/html/rfc4251#section-9.3.9 traffic analysis}
      *           by sending dummy SSH_MSG_IGNORE messages.
@@ -1991,7 +1991,7 @@ class Net_SSH2
      *
      * @param string $username
      * @param string $password
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _keyboard_interactive_login($username, $password)
@@ -2012,7 +2012,7 @@ class Net_SSH2
      * Handle the keyboard-interactive requests / responses.
      *
      * @param string $responses...
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _keyboard_interactive_process()
@@ -2127,7 +2127,7 @@ class Net_SSH2
      *
      * @param string $username
      * @param System_SSH_Agent $agent
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _ssh_agent_login($username, $agent)
@@ -2147,7 +2147,7 @@ class Net_SSH2
      *
      * @param string $username
      * @param Crypt_RSA $password
-     * @return Boolean
+     * @return bool
      * @access private
      * @internal It might be worthwhile, at some point, to protect against {@link http://tools.ietf.org/html/rfc4251#section-9.3.9 traffic analysis}
      *           by sending dummy SSH_MSG_IGNORE messages.
@@ -2240,7 +2240,7 @@ class Net_SSH2
      * $ssh->exec('ping 127.0.0.1'); on a Linux host will never return and will run indefinitely.  setTimeout() makes it so it'll timeout.
      * Setting $timeout to false or 0 will mean there is no timeout.
      *
-     * @param Mixed $timeout
+     * @param mixed $timeout
      * @access public
      */
     function setTimeout($timeout)
@@ -2384,7 +2384,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::read()
      * @see Net_SSH2::write()
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _initShell()
@@ -2531,7 +2531,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::read()
      * @param string $cmd
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function write($cmd)
@@ -2560,7 +2560,7 @@ class Net_SSH2
      *
      * @see Net_SSH2::stopSubsystem()
      * @param string $subsystem
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function startSubsystem($subsystem)
@@ -2607,7 +2607,7 @@ class Net_SSH2
      * Stops a subsystem.
      *
      * @see Net_SSH2::startSubsystem()
-     * @return Boolean
+     * @return bool
      * @access public
      */
     function stopSubsystem()
@@ -3134,7 +3134,7 @@ class Net_SSH2
      * @param string $data
      * @param optional string $logged
      * @see Net_SSH2::_get_binary_packet()
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _send_binary_packet($data, $logged = null)
@@ -3270,7 +3270,7 @@ class Net_SSH2
      *
      * @param int $client_channel
      * @param string $data
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _send_channel_packet($client_channel, $data)
@@ -3316,8 +3316,8 @@ class Net_SSH2
      * for SCP more than anything.
      *
      * @param int $client_channel
-     * @param Boolean $want_reply
-     * @return Boolean
+     * @param bool $want_reply
+     * @return bool
      * @access private
      */
     function _close_channel($client_channel, $want_reply = false)
@@ -3349,7 +3349,7 @@ class Net_SSH2
      * Disconnect
      *
      * @param int $reason
-     * @return Boolean
+     * @return bool
      * @access private
      */
     function _disconnect($reason)

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -102,7 +102,7 @@ class System_SSH_Agent_Identity
     /**
      * Socket Resource
      *
-     * @var Resource
+     * @var resource
      * @access private
      * @see System_SSH_Agent_Identity::sign()
      */
@@ -111,7 +111,7 @@ class System_SSH_Agent_Identity
     /**
      * Default Constructor.
      *
-     * @param Resource $fsock
+     * @param resource $fsock
      * @return System_SSH_Agent_Identity
      * @access private
      */
@@ -220,7 +220,7 @@ class System_SSH_Agent
     /**
      * Socket Resource
      *
-     * @var Resource
+     * @var resource
      * @access private
      */
     var $fsock;

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -93,7 +93,7 @@ class System_SSH_Agent_Identity
     /**
      * Key Blob
      *
-     * @var String
+     * @var string
      * @access private
      * @see System_SSH_Agent_Identity::sign()
      */
@@ -140,7 +140,7 @@ class System_SSH_Agent_Identity
      * Called by System_SSH_Agent::requestIdentities(). The key blob could be extracted from $this->key
      * but this saves a small amount of computation.
      *
-     * @param String $key_blob
+     * @param string $key_blob
      * @access private
      */
     function setPublicKeyBlob($key_blob)
@@ -153,8 +153,8 @@ class System_SSH_Agent_Identity
      *
      * Wrapper for $this->key->getPublicKey()
      *
-     * @param Integer $format optional
-     * @return Mixed
+     * @param int $format optional
+     * @return mixed
      * @access public
      */
     function getPublicKey($format = null)
@@ -168,7 +168,7 @@ class System_SSH_Agent_Identity
      * Doesn't do anything as ssh-agent doesn't let you pick and choose the signature mode. ie.
      * ssh-agent's only supported mode is CRYPT_RSA_SIGNATURE_PKCS1
      *
-     * @param Integer $mode
+     * @param int $mode
      * @access public
      */
     function setSignatureMode($mode)
@@ -180,8 +180,8 @@ class System_SSH_Agent_Identity
      *
      * See "2.6.2 Protocol 2 private key signature request"
      *
-     * @param String $message
-     * @return String
+     * @param string $message
+     * @return string
      * @access public
      */
     function sign($message)


### PR DESCRIPTION
For example, `Integer` implies only an object of type `Integer` is allowed, but what you really meant was only a variable of a primitive type `int` is allowed.