### PR TITLE
Mark Base as abstract

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -44,9 +44,8 @@ use phpseclib\Crypt\Hash;
  * @package Base
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
- * @access  public
  */
-class Base
+abstract class Base
 {
     /**#@+
      * @access public
@@ -1170,10 +1169,7 @@ class Base
      * @param String $in
      * @return String
      */
-    function _encryptBlock($in)
-    {
-        user_error(__METHOD__ . '() must extend by class ' . get_class($this), E_USER_ERROR);
-    }
+    abstract function _encryptBlock($in);
 
     /**
      * Decrypts a block
@@ -1184,10 +1180,7 @@ class Base
      * @param String $in
      * @return String
      */
-    function _decryptBlock($in)
-    {
-        user_error(__METHOD__ . '() must extend by class ' . get_class($this), E_USER_ERROR);
-    }
+    abstract function _decryptBlock($in);
 
     /**
      * Setup the key (expansion)
@@ -1199,10 +1192,7 @@ class Base
      * @see \phpseclib\Crypt\Base::_setup()
      * @access private
      */
-    function _setupKey()
-    {
-        user_error(__METHOD__ . '() must extend by class ' . get_class($this), E_USER_ERROR);
-    }
+    abstract function _setupKey();
 
     /**
      * Setup the self::ENGINE_INTERNAL $engine

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -219,6 +219,27 @@ class RC4 extends Base
         return $this->_crypt($ciphertext, self::DECRYPT);
     }
 
+    /**
+     * Encrypts a block
+     *
+     * @access private
+     * @param String $in
+     */
+    function _encryptBlock($in)
+    {
+        // RC4 does not utilize this method
+    }
+
+    /**
+     * Decrypts a block
+     *
+     * @access private
+     * @param String $in
+     */
+    function _decryptBlock($in)
+    {
+        // RC4 does not utilize this method
+    }
 
     /**
      * Setup the key (expansion)


### PR DESCRIPTION
This PR marks Crypt\Base as abstract as well as the three methods that must be implemented in derived classes. This allows the PHP engine to throw proper errors if derived classes do not implement methods as required by the Base class.