### PR TITLE
Documentation Fixes for Scrutinizer

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -1339,7 +1339,7 @@ class Base
      * @see \phpseclib\Crypt\Base::_pad()
      * @param String $text
      * @access private
-     * @return String
+     * @return String|boolean
      */
     function _unpad($text)
     {
@@ -1981,7 +1981,7 @@ class Base
      * for which $mode the lambda function was created.
      *
      * @access private
-     * @return &Array
+     * @return array
      */
     function &_getLambdaFunctions()
     {

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -71,7 +71,7 @@ class Hash
      * Hash Parameter
      *
      * @see \phpseclib\Crypt\Hash::setHash()
-     * @var Integer
+     * @var string
      * @access private
      */
     var $hashParam;
@@ -98,7 +98,7 @@ class Hash
      * Hash Algorithm
      *
      * @see \phpseclib\Crypt\Hash::setHash()
-     * @var String
+     * @var String|array
      * @access private
      */
     var $hash;
@@ -110,7 +110,7 @@ class Hash
      * @var String
      * @access private
      */
-    var $key = false;
+    var $key;
 
     /**
      * Outer XOR (Internal HMAC)
@@ -161,9 +161,9 @@ class Hash
      * Keys can be of any length.
      *
      * @access public
-     * @param optional String $key
+     * @param string $key Optional
      */
-    function setKey($key = false)
+    function setKey($key = '')
     {
         $this->key = $key;
     }

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -245,7 +245,7 @@ class RSA
     /**
      * Precomputed Zero
      *
-     * @var Array
+     * @var Array|\phpseclib\Math\BigInteger
      * @access private
      */
     var $zero;
@@ -253,7 +253,7 @@ class RSA
     /**
      * Precomputed One
      *
-     * @var Array
+     * @var Array|\phpseclib\Math\BigInteger
      * @access private
      */
     var $one;
@@ -285,7 +285,7 @@ class RSA
     /**
      * Modulus length
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib\Math\BigInteger|integer
      * @access private
      */
     var $k;
@@ -397,10 +397,10 @@ class RSA
     /**
      * Password
      *
-     * @var String
+     * @var String|boolean
      * @access private
      */
-    var $password = false;
+    var $password;
 
     /**
      * Components
@@ -1567,7 +1567,7 @@ class RSA
      * @see createKey()
      * @see loadKey()
      * @access public
-     * @param String $password
+     * @param String|boolean $password
      */
     function setPassword($password = false)
     {
@@ -1958,7 +1958,7 @@ class RSA
      * See {@link http://tools.ietf.org/html/rfc3447#section-4.1 RFC3447#section-4.1}.
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $x
+     * @param \phpseclib\Math\BigInteger|integer $x
      * @param Integer $xLen
      * @return String
      */
@@ -2122,7 +2122,7 @@ class RSA
      *
      * @access private
      * @param \phpseclib\Math\BigInteger $m
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib\Math\BigInteger|boolean
      */
     function _rsaep($m)
     {
@@ -2140,7 +2140,7 @@ class RSA
      *
      * @access private
      * @param \phpseclib\Math\BigInteger $c
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib\Math\BigInteger|boolean
      */
     function _rsadp($c)
     {
@@ -2158,7 +2158,7 @@ class RSA
      *
      * @access private
      * @param \phpseclib\Math\BigInteger $m
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib\Math\BigInteger|boolean
      */
     function _rsasp1($m)
     {
@@ -2176,7 +2176,7 @@ class RSA
      *
      * @access private
      * @param \phpseclib\Math\BigInteger $s
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib\Math\BigInteger|boolean
      */
     function _rsavp1($s)
     {
@@ -2598,8 +2598,8 @@ class RSA
      *
      * @access private
      * @param String $m
-     * @param Integer $emLen
-     * @return String
+     * @param \phpseclib\Math\BigInteger|integer $emLen
+     * @return String|boolean
      */
     function _emsa_pkcs1_v1_5_encode($m, $emLen)
     {

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -1126,6 +1126,8 @@ class Rijndael extends Base
             $init_encrypt = '';
             $init_decrypt = '';
         } else {
+            $w = array();
+            $dw = array();
             for ($i = 0, $cw = count($this->w); $i < $cw; ++$i) {
                 $w[]  = '$w['  . $i . ']';
                 $dw[] = '$dw[' . $i . ']';

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -286,7 +286,7 @@ class TripleDES extends DES
      * @see \phpseclib\Crypt\Base::decrypt()
      * @access public
      * @param String $ciphertext
-     * @return String $plaintext
+     * @return String|boolean $plaintext
      */
     function decrypt($ciphertext)
     {

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -467,7 +467,7 @@ class ASN1
      * @param Array $decoded
      * @param Array $mapping
      * @param Array $special
-     * @return Array
+     * @return \phpseclib\File\ASN1\Element|array|string|null
      * @access public
      */
     function asn1map($decoded, $mapping, $special = array())
@@ -756,7 +756,7 @@ class ASN1
      *
      * "Special" mappings can be applied via $special.
      *
-     * @param String $source
+     * @param mixed $source
      * @param String $mapping
      * @param Integer $idx
      * @return String
@@ -771,10 +771,10 @@ class ASN1
     /**
      * ASN.1 Encode (Helper function)
      *
-     * @param String $source
+     * @param mixed $source
      * @param String $mapping
      * @param Integer $idx
-     * @return String
+     * @return String|boolean
      * @access private
      */
     function _encode_der($source, $mapping, $idx = null, $special = array())

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -180,7 +180,7 @@ class X509
     /**
      * Distinguished Name
      *
-     * @var Array
+     * @var Array|null
      * @access private
      */
     var $dn;
@@ -188,7 +188,7 @@ class X509
     /**
      * Public key
      *
-     * @var String
+     * @var \phpseclib\Crypt\RSA
      * @access private
      */
     var $publicKey;
@@ -196,7 +196,7 @@ class X509
     /**
      * Private key
      *
-     * @var String
+     * @var \phpseclib\Crypt\RSA
      * @access private
      */
     var $privateKey;
@@ -248,7 +248,7 @@ class X509
     /**
      * Certificate End Date
      *
-     * @var String
+     * @var String|\phpseclib\File\ASN1\Element
      * @access private
      */
     var $endDate;
@@ -256,7 +256,7 @@ class X509
     /**
      * Serial Number
      *
-     * @var String
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
     var $serialNumber;
@@ -1429,7 +1429,7 @@ class X509
         $cert = $this->_extractBER($cert);
 
         if ($cert === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -1440,7 +1440,7 @@ class X509
             $x509 = $asn1->asn1map($decoded[0], $this->Certificate);
         }
         if (!isset($x509) || $x509 === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -2440,7 +2440,7 @@ class X509
      * @param Mixed $format optional
      * @param Array $dn optional
      * @access public
-     * @return Boolean
+     * @return Boolean|string|array
      */
     function getDN($format = self::DN_ARRAY, $dn = null)
     {
@@ -2716,9 +2716,7 @@ class X509
     /**
      * Set public key
      *
-     * Key needs to be a \phpseclib\Crypt\RSA object
-     *
-     * @param Object $key
+     * @param \phpseclib\Crypt\RSA $key
      * @access public
      * @return Boolean
      */
@@ -2731,9 +2729,7 @@ class X509
     /**
      * Set private key
      *
-     * Key needs to be a \phpseclib\Crypt\RSA object
-     *
-     * @param Object $key
+     * @param \phpseclib\Crypt\RSA $key
      * @access public
      */
     function setPrivateKey($key)
@@ -2757,10 +2753,8 @@ class X509
     /**
      * Gets the public key
      *
-     * Returns a \phpseclib\Crypt\RSA object or a false.
-     *
      * @access public
-     * @return Mixed
+     * @return \phpseclib\Crypt\RSA|false
      */
     function getPublicKey()
     {
@@ -2825,7 +2819,7 @@ class X509
         $orig = $csr;
 
         if ($csr === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -2833,13 +2827,13 @@ class X509
         $decoded = $asn1->decodeBER($csr);
 
         if (empty($decoded)) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
         $csr = $asn1->asn1map($decoded[0], $this->CertificationRequest);
         if (!isset($csr) || $csr === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -2950,7 +2944,7 @@ class X509
         $orig = $spkac;
 
         if ($spkac === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -2958,14 +2952,14 @@ class X509
         $decoded = $asn1->decodeBER($spkac);
 
         if (empty($decoded)) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
         $spkac = $asn1->asn1map($decoded[0], $this->SignedPublicKeyAndChallenge);
 
         if (!isset($spkac) || $spkac === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -3055,7 +3049,7 @@ class X509
         $orig = $crl;
 
         if ($crl === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -3063,13 +3057,13 @@ class X509
         $decoded = $asn1->decodeBER($crl);
 
         if (empty($decoded)) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
         $crl = $asn1->asn1map($decoded[0], $this->CertificateList);
         if (!isset($crl) || $crl === false) {
-            $this->currentCert = false;
+            unset($this->currentCert);
             return false;
         }
 
@@ -3662,7 +3656,7 @@ class X509
      * Set Serial Number
      *
      * @param String $serial
-     * @param $base optional
+     * @param Integer $base
      * @access public
      */
     function setSerialNumber($serial, $base = -256)
@@ -3687,24 +3681,22 @@ class X509
      * @param String $path  absolute path with / as component separator
      * @param Boolean $create optional
      * @access private
-     * @return array item ref or false
+     * @return array|boolean
      */
     function &_subArray(&$root, $path, $create = false)
     {
-        $false = false;
-
         if (!is_array($root)) {
-            return $false;
+            return false;
         }
 
         foreach (explode('/', $path) as $i) {
             if (!is_array($root)) {
-                return $false;
+                return false;
             }
 
             if (!isset($root[$i])) {
                 if (!$create) {
-                    return $false;
+                    return false;
                 }
 
                 $root[$i] = array();

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -186,7 +186,7 @@ class BigInteger
     /**
      * Holds the BigInteger's value.
      *
-     * @var Array
+     * @var Array|string
      * @access private
      */
     var $value;
@@ -202,6 +202,7 @@ class BigInteger
     /**
      * Random number generator function
      *
+     * @var string
      * @access private
      */
     var $generator = 'mt_rand';
@@ -210,6 +211,7 @@ class BigInteger
      * Precision
      *
      * @see setPrecision()
+     * @var integer
      * @access private
      */
     var $precision = -1;
@@ -218,9 +220,10 @@ class BigInteger
      * Precision Bitmask
      *
      * @see setPrecision()
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
-    var $bitmask = false;
+    var $bitmask;
 
     /**
      * Mode independent value used for serialization.
@@ -251,8 +254,8 @@ class BigInteger
      * ?>
      * </code>
      *
-     * @param optional $x base-10 number or base-$base number if $base set.
-     * @param optional integer $base
+     * @param mixed $x base-10 number or base-$base number if $base set. Optional.
+     * @param integer $base The base for $x. Optional.
      * @return \phpseclib\Math\BigInteger
      * @access public
      */
@@ -953,7 +956,7 @@ class BigInteger
      * ?>
      * </code>
      *
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib\Math\BigInteger|array $y
      * @return \phpseclib\Math\BigInteger
      * @access public
      * @internal Performs base-2**52 subtraction
@@ -1553,7 +1556,7 @@ class BigInteger
      * abc / x = a00 / x + b0 / x + c / x
      *
      * @param Array $dividend
-     * @param Array $divisor
+     * @param Array|\phpseclib\Math\BigInteger $divisor
      * @return Array
      * @access private
      */
@@ -1589,7 +1592,7 @@ class BigInteger
      *
      * @param \phpseclib\Math\BigInteger $e
      * @param \phpseclib\Math\BigInteger $n
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib\Math\BigInteger|boolean
      * @access public
      * @internal The most naive approach to modular exponentiation has very unreasonable requirements, and
      *    and although the approach involving repeated squaring does vastly better, it, too, is impractical
@@ -1613,7 +1616,7 @@ class BigInteger
      */
     function modPow($e, $n)
     {
-        $n = $this->bitmask !== false && $this->bitmask->compare($n) < 0 ? $this->bitmask : $n->abs();
+        $n = $this->bitmask instanceof BigInteger && $this->bitmask->compare($n) < 0 ? $this->bitmask : $n->abs();
 
         if ($e->compare(new static()) < 0) {
             $e = $e->abs();
@@ -2634,7 +2637,7 @@ class BigInteger
      *
      * Note how the same comparison operator is used.  If you want to test for equality, use $x->equals($y).
      *
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib\Math\BigInteger|array $y
      * @return Integer < 0 if $this is less than $y; > 0 if $this is greater than $y, and 0 if they are equal.
      * @access public
      * @see equals()
@@ -3061,8 +3064,8 @@ class BigInteger
      * $max->random($min)
      *
      * @param \phpseclib\Math\BigInteger $arg1
-     * @param optional \phpseclib\Math\BigInteger $arg2
-     * @return \phpseclib\Math\BigInteger
+     * @param boolean|\phpseclib\Math\BigInteger $arg2 Optional
+     * @return boolean|\phpseclib\Math\BigInteger
      * @access public
      * @internal The API for creating random numbers used to be $a->random($min, $max), where $a was a BigInteger object.
      *           That method is still supported for BC purposes.
@@ -3142,9 +3145,9 @@ class BigInteger
      * give up and return false.
      *
      * @param \phpseclib\Math\BigInteger $arg1
-     * @param optional \phpseclib\Math\BigInteger $arg2
-     * @param optional Integer $timeout
-     * @return Mixed
+     * @param boolean|\phpseclib\Math\BigInteger $arg2 Optional. Defaults to false.
+     * @param boolean|integer $timeout Optional. Defaults to false.
+     * @return boolean|\phpseclib\Math\BigInteger
      * @access public
      * @internal See {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap4.pdf#page=15 HAC 4.44}.
      */

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -76,7 +76,7 @@ class SCP
     /**
      * SSH Object
      *
-     * @var Object
+     * @var \phpseclib\Net\SSH1|\phpseclib\Net\SSH2
      * @access private
      */
     var $ssh;
@@ -84,7 +84,7 @@ class SCP
     /**
      * Packet Size
      *
-     * @var Integer
+     * @var Integer|float
      * @access private
      */
     var $packet_size;
@@ -102,9 +102,7 @@ class SCP
      *
      * Connects to an SSH server
      *
-     * @param String $host
-     * @param optional Integer $port
-     * @param optional Integer $timeout
+     * @param \phpseclib\Net\SSH1|\phpseclib\Net\SSH2 An instance of an SSH object.
      * @return \phpseclib\Net\SCP
      * @access public
      */
@@ -295,7 +293,7 @@ class SCP
     /**
      * Receives a packet from an SSH server
      *
-     * @return String
+     * @return String|boolean
      * @access private
      */
     function _receive()

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -118,7 +118,7 @@ class SFTP extends SSH2
      * The request ID exists in the off chance that a packet is sent out-of-order.  Of course, this library doesn't support
      * concurrent actions, so it's somewhat academic, here.
      *
-     * @var Integer
+     * @var Integer|boolean
      * @see \phpseclib\Net\SFTP::_get_sftp_packet()
      * @access private
      */
@@ -154,7 +154,7 @@ class SFTP extends SSH2
     /**
      * Current working directory
      *
-     * @var String
+     * @var String|boolean
      * @see \phpseclib\Net\SFTP::_realpath()
      * @see \phpseclib\Net\SFTP::chdir()
      * @access private
@@ -208,7 +208,7 @@ class SFTP extends SSH2
      *
      * @see \phpseclib\Net\SFTP::__construct()
      * @see \phpseclib\Net\SFTP::get()
-     * @var Array
+     * @var Array|integer
      * @access private
      */
     var $max_sftp_packet;
@@ -2477,7 +2477,7 @@ class SFTP extends SSH2
      * Quoting the SFTP RFC, "Implementations MUST NOT send bits that are not defined" but they seem to anyway
      *
      * @param Integer $mode
-     * @return Integer
+     * @return Integer|boolean
      * @access private
      */
     function _parseMode($mode)

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -262,7 +262,7 @@ class SSH1
      * Logged for debug purposes
      *
      * @see \phpseclib\Net\SSH1::getServerKeyPublicExponent()
-     * @var String
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
     var $server_key_public_exponent;
@@ -273,7 +273,7 @@ class SSH1
      * Logged for debug purposes
      *
      * @see \phpseclib\Net\SSH1::getServerKeyPublicModulus()
-     * @var String
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
     var $server_key_public_modulus;
@@ -284,7 +284,7 @@ class SSH1
      * Logged for debug purposes
      *
      * @see \phpseclib\Net\SSH1::getHostKeyPublicExponent()
-     * @var String
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
     var $host_key_public_exponent;
@@ -295,7 +295,7 @@ class SSH1
      * Logged for debug purposes
      *
      * @see \phpseclib\Net\SSH1::getHostKeyPublicModulus()
-     * @var String
+     * @var \phpseclib\Math\BigInteger
      * @access private
      */
     var $host_key_public_modulus;
@@ -1304,9 +1304,9 @@ class SSH1
      * calls this call modexp, instead, but I think this makes things clearer, maybe...
      *
      * @see \phpseclib\Net\SSH1::__construct()
-     * @param BigInteger $m
+     * @param \phpseclib\Math\BigInteger $m
      * @param Array $key
-     * @return BigInteger
+     * @return \phpseclib\Math\BigInteger
      * @access private
      */
     function _rsa_crypt($m, $key)
@@ -1377,7 +1377,7 @@ class SSH1
      * Returns a string if NET_SSH1_LOGGING == self::LOG_COMPLEX, an array if NET_SSH1_LOGGING == self::LOG_SIMPLE and false if !defined('NET_SSH1_LOGGING')
      *
      * @access public
-     * @return String or Array
+     * @return String|Array|boolean
      */
     function getLog()
     {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -664,7 +664,7 @@ class SSH2
     /**
      * Time of first network activity
      *
-     * @var Integer
+     * @var float Value comes from microtime(true)
      * @access private
      */
     var $last_packet;
@@ -1915,7 +1915,7 @@ class SSH2
      * See {@link http://tools.ietf.org/html/rfc4256 RFC4256} for details.  This is not a full-featured keyboard-interactive authenticator.
      *
      * @param String $username
-     * @param String $password
+     * @param String|array $password
      * @return Boolean
      * @access private
      */
@@ -2609,7 +2609,7 @@ class SSH2
      * See '6. Binary Packet Protocol' of rfc4253 for more info.
      *
      * @see \phpseclib\Net\SSH2::_send_binary_packet()
-     * @return String
+     * @return String|boolean
      * @access private
      */
     function _get_binary_packet()
@@ -2702,7 +2702,7 @@ class SSH2
      * Because some binary packets need to be ignored...
      *
      * @see \phpseclib\Net\SSH2::_get_binary_packet()
-     * @return String
+     * @return String|boolean
      * @access private
      */
     function _filter($payload)


### PR DESCRIPTION
This PR just adds a bunch of PHPDoc fixes (and other minor tweaks) to try to cut down on Scrutinizer errors in an attempt to make it a more useful debugging tool. Currently there is a lot of unnecessary noise in the reports, and this PR fixes a good deal of them.