### PR TITLE
ASN1 / CSR fixes

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -347,24 +347,31 @@ class File_ASN1
             case FILE_ASN1_CLASS_APPLICATION:
             case FILE_ASN1_CLASS_PRIVATE:
             case FILE_ASN1_CLASS_CONTEXT_SPECIFIC:
-                if ($constructed) {
+                if (!$constructed) {
+                    return array(
+                        'type'     => $class,
+                        'constant' => $tag,
+                        'content'  => $content,
+                        'length'   => $length + $start - $current['start']
+                    );
+                }
+
+                $newcontent = array();
+                if (strlen($content)) {
                     $newcontent = $this->_decode_ber($content, $start);
                     $length = $newcontent['length'];
                     if (substr($content, $length, 2) == "\0\0") {
                         $length+= 2;
                     }
-
-                    // the array encapsulation is for BC with the old format
-                    $content = array($newcontent);
+                    $start+= $length;
+                    $newcontent = array($newcontent);
                 }
-
-                $start+= $length;
 
                 return array(
                     'type'     => $class,
                     'constant' => $tag,
                     // the array encapsulation is for BC with the old format
-                    'content'  => $content,
+                    'content'  => $newcontent,
                     // the only time when $content['headerlength'] isn't defined is when the length is indefinite.
                     // the absence of $content['headerlength'] is how we know if something is indefinite or not.
                     // technically, it could be defined to be 2 and then another indicator could be used but whatever.

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -278,4 +278,15 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
         $decoded = $asn1->decodeBER(base64_decode('MBaAFJtUo7c00HsI5EPZ4bkICfkOY2Pv'));
         $this->assertInternalType('string', $decoded[0]['content'][0]['content']);
     }
+
+    /**
+    * @group github602
+    */
+    public function testEmptyContextTag()
+    {
+        $asn1 = new File_ASN1();
+        $decoded = $asn1->decodeBER("\xa0\x00");
+        $this->assertInternalType('array', $decoded);
+        $this->assertCount(0, $decoded[0]['content']);
+    }
 }

--- a/tests/Unit/File/X509/CSRTest.php
+++ b/tests/Unit/File/X509/CSRTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2014 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+require_once 'File/X509.php';
+
+class Unit_File_X509_CSRTest extends PhpseclibTestCase
+{
+    public function testLoadCSR()
+    {
+        $test = '-----BEGIN CERTIFICATE REQUEST-----
+MIIBWzCBxQIBADAeMRwwGgYDVQQKDBNwaHBzZWNsaWIgZGVtbyBjZXJ0MIGdMAsG
+CSqGSIb3DQEBAQOBjQAwgYkCgYEAtHDb4zoUyiRYsJ5PZrF/IJKAF9ZoHRpTxMA8
+a7iyFdsl/vvZLNPsNnFTXXnGdvsyFDEsF7AubaIXw8UKFPYqQRTzSVsvnNgIoVYj
+tTAXlB4oHipr7Kxcn4CXfmR0TYogyLvVZSZJYxh+CAuG4V9XM4HqkeE5gyBOsKGy
+5FUU8zMCAwEAAaAAMA0GCSqGSIb3DQEBBQUAA4GBAJjdaA9K9DN5xvSiOlCmmV1E
+npzHkI1Trraveu0gtRjT/EzHoqjCBI0ekCZ9+fhrex8Sm6Nsq9IgHYyrqnE+PQko
+4Nf2w2U3DWxU26D5E9DlI+bLyOCq4jqATLjHyyAsOZY/2+U73AZ82MJM/mGdh5fQ
+v5RwaQHmQEzHofTzF7I+
+-----END CERTIFICATE REQUEST-----';
+
+        $x509 = new File_X509();
+
+        $spkac = $x509->loadCSR($test);
+
+        $this->assertInternalType('array', $spkac);
+    }
+}


### PR DESCRIPTION
Fixes #602. The problem was if the attributes SET (context-specific) was included but empty it wasn't being processed correctly.