### PR TITLE
.scrutinizer.yml: Use large timeout to prevent coverage receiver from ti...

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,3 +4,4 @@ imports:
 tools:
     external_code_coverage:
         runs: 5 # No Code Coverage on PHP 5.2 and HHVM
+        timeout: 2700 # 45 minutes


### PR DESCRIPTION
...ming out.