### PR TITLE
Banner timeout feature (fixed)

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -978,7 +978,6 @@ class SSH2
            MUST be able to process such lines." */
         $temp = '';
         $extra = '';
-        stream_set_timeout($this->fsock, $sec, $usec);
         while (!feof($this->fsock) && !preg_match('#^SSH-(\d\.\d+)#', $temp, $matches)) {
             if (substr($temp, -2) == "\r\n") {
                 $extra.= $temp;
@@ -988,7 +987,7 @@ class SSH2
 
             $info = stream_get_meta_data($this->fsock);
             if($info['timed_out']) {
-                user_error('Banner timeout or wrong.');
+                user_error('Banner read timeout or wrong.');
                 return false;
             }
         }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -978,12 +978,19 @@ class SSH2
            MUST be able to process such lines." */
         $temp = '';
         $extra = '';
+        stream_set_timeout($this->fsock, $sec, $usec);
         while (!feof($this->fsock) && !preg_match('#^SSH-(\d\.\d+)#', $temp, $matches)) {
             if (substr($temp, -2) == "\r\n") {
                 $extra.= $temp;
                 $temp = '';
             }
             $temp.= fgets($this->fsock, 255);
+            
+            $info = stream_get_meta_data($this->fsock);
+	        if($info['timed_out']) {
+		        user_error('Banner timeout or wrong.');
+		        return false;
+	        }
         }
 
         if (feof($this->fsock)) {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -985,12 +985,12 @@ class SSH2
                 $temp = '';
             }
             $temp.= fgets($this->fsock, 255);
-            
+
             $info = stream_get_meta_data($this->fsock);
-	        if($info['timed_out']) {
-		        user_error('Banner timeout or wrong.');
-		        return false;
-	        }
+            if($info['timed_out']) {
+                user_error('Banner timeout or wrong.');
+                return false;
+            }
         }
 
         if (feof($this->fsock)) {


### PR DESCRIPTION
I bumped of situations when server sending some non ssh banner (not "SSH-...") but some another, like "MyProtoV1.1". So then we still waiting for next string and then again and so on. But any way we could not reach header need for us. For this situations we need some timeout. This patch made this timeout feature.

Function stream_set_timeout provide breaking of waiting for gets. And then we get information about socket (stream_get_meta_data) and test there "timed_out" flag.