### PR TITLE
support for callback function for SFTP::put function - in order to pipe ...

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1807,6 +1807,9 @@ class SFTP extends SSH2
         $callback = false;
         switch (true) {
             case $mode & self::SOURCE_CALLBACK;
+                if (!is_callable($data)) {
+                    throw new Exception('if you specify SOURCE_CALLBACK then $data should be callable');
+                }
                 $callback = $data;
                 // do nothing
                 break;
@@ -1852,7 +1855,9 @@ class SFTP extends SSH2
         while ($callback || $sent < $size) {
             if ($callback) {
                 $temp = call_user_func($callback, $sftp_packet_size);
-                if (is_null($temp)) break;
+                if (is_null($temp)) {
+                    break;
+                }
             } else {
                 $temp = isset($fp) ? fread($fp, $sftp_packet_size) : substr($data, $sent, $sftp_packet_size);
             }

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1808,7 +1808,7 @@ class SFTP extends SSH2
         switch (true) {
             case $mode & self::SOURCE_CALLBACK;
                 if (!is_callable($data)) {
-                    throw new Exception('if you specify SOURCE_CALLBACK then $data should be callable');
+                    user_error("\$data should be is_callable() if you specify SOURCE_CALLBACK flag");
                 }
                 $callback = $data;
                 // do nothing

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -13,6 +13,7 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     static protected $scratchDir;
     static protected $exampleData;
     static protected $exampleDataLength;
+    static protected $buffer;
 
     static public function setUpBeforeClass()
     {
@@ -141,6 +142,41 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         $this->assertTrue(
             $sftp->put('file1.txt', self::$exampleData),
+            'Failed asserting that example data could be successfully put().'
+        );
+
+        $this->assertSame(
+            self::$exampleDataLength,
+            $sftp->size('file1.txt'),
+            'Failed asserting that put example data has the expected length'
+        );
+
+        $this->assertSame(
+            self::$exampleData,
+            $sftp->get('file1.txt'),
+            'Failed asserting that get() returns expected example data.'
+        );
+
+        return $sftp;
+    }
+
+
+    static function callback($length)
+    {
+        $r = substr(self::$buffer, 0, $length);
+        self::$buffer = substr(self::$buffer, $length);
+        if (strlen($r)) return $r;
+        return null;
+    }
+
+    /**
+    * @depends testStatOnDir
+    */
+    public function testPutSizeGetFileCallback($sftp)
+    {
+        self::$buffer =  self::$exampleData;
+        $this->assertTrue(
+            $sftp->put('file1.txt', array(__CLASS__, 'callback'), $sftp::SOURCE_CALLBACK),
             'Failed asserting that example data could be successfully put().'
         );
 


### PR DESCRIPTION
...data directly to remote server without putting it into file or keeping in memory. This can be useful particularly for dumping big databases directly to remote server.