### PR TITLE
Boolean comparisons was missing an equal sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # phpseclib - PHP Secure Communications Library
 
-[![Build Status](https://secure.travis-ci.org/phpseclib/phpseclib.png?branch=php5)](http://travis-ci.org/phpseclib/phpseclib)
+[![Build Status](https://secure.travis-ci.org/phpseclib/phpseclib.png?branch=php5)](http://travis-ci.org/phpseclib/phpseclib) [![Code Climate](https://codeclimate.com/github/phpseclib/phpseclib/badges/gpa.svg)](https://codeclimate.com/github/phpseclib/phpseclib)
 
 MIT-licensed pure-PHP implementations of an arbitrary-precision integer
 arithmetic library, fully PKCS#1 (v2.1) compliant RSA, DES, 3DES, RC4, Rijndael,

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -2464,7 +2464,7 @@ class RSA
         // be output.
 
         $emLen = ($emBits + 1) >> 3; // ie. ceil($emBits / 8)
-        $sLen = $this->sLen == false ? $this->hLen : $this->sLen;
+        $sLen = $this->sLen === false ? $this->hLen : $this->sLen;
 
         $mHash = $this->hash->hash($m);
         if ($emLen < $this->hLen + $sLen + 2) {
@@ -2502,7 +2502,7 @@ class RSA
         // be output.
 
         $emLen = ($emBits + 1) >> 3; // ie. ceil($emBits / 8);
-        $sLen = $this->sLen == false ? $this->hLen : $this->sLen;
+        $sLen = $this->sLen === false ? $this->hLen : $this->sLen;
 
         $mHash = $this->hash->hash($m);
         if ($emLen < $this->hLen + $sLen + 2) {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -493,7 +493,7 @@ class Stream
 
         $path_from = $this->_parse_path($path_from);
         $path_to = parse_url($path_to);
-        if ($path_from == false) {
+        if ($path_from === false) {
             return false;
         }
 


### PR DESCRIPTION
I ran the code through Code Climate and saw that there were three Boolean comparisons that were not using the identical operator (which is always recommended to avoid unexpected or incorrect results). I updated this to use the identical operator and added the Code Climate badge to the readme.