### PR TITLE
RSA: Add support for calculating a public key's fingerprint

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1706,6 +1706,42 @@ class RSA
     }
 
     /**
+     * Returns the public key's fingerprint
+     *
+     * The public key's fingerprint is returned, which is equivalent to running `ssh-keygen -lf rsa.pub`. If there is
+     * no public key currently loaded, false is returned.
+     * Example output (md5): "c1:b1:30:29:d7:b8:de:6c:97:77:10:d7:46:41:63:87" (as specified by RFC 4716)
+     *
+     * @access public
+     * @param String $algorithm The hashing algorithm to be used. Valid options are 'md5' and 'sha256'. False is returned
+     * for invalid values.
+     */
+    public function getPublicKeyFingerprint($algorithm = 'md5')
+    {
+        if (empty($this->modulus) || empty($this->publicExponent)) {
+            return false;
+        }
+
+        $modulus = $this->modulus->toBytes(true);
+        $publicExponent = $this->publicExponent->toBytes(true);
+
+        $RSAPublicKey = pack('Na*Na*Na*', strlen('ssh-rsa'), 'ssh-rsa', strlen($publicExponent), $publicExponent, strlen($modulus), $modulus);
+
+        switch($algorithm)
+        {
+            case 'sha256':
+                $hash = new Hash;
+                $base = base64_encode($hash->_sha256($RSAPublicKey));
+                return substr($base, 0, strlen($base)-1);
+            case 'md5':
+                return join(':', str_split(md5($RSAPublicKey), 2));
+            default:
+                return false;
+        }
+
+    }
+
+    /**
      * Returns the private key
      *
      * The private key is only returned if the currently loaded key contains the constituent prime numbers.

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1730,11 +1730,11 @@ class RSA
         switch($algorithm)
         {
             case 'sha256':
-                $hash = new Hash;
-                $base = base64_encode($hash->_sha256($RSAPublicKey));
+                $hash = new Hash('sha256');
+                $base = base64_encode($hash->hash($RSAPublicKey));
                 return substr($base, 0, strlen($base)-1);
             case 'md5':
-                return join(':', str_split(md5($RSAPublicKey), 2));
+                return substr(chunk_split($RSAPublicKey, 2, ':'), 0, -1);
             default:
                 return false;
         }

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1734,7 +1734,7 @@ class RSA
                 $base = base64_encode($hash->hash($RSAPublicKey));
                 return substr($base, 0, strlen($base)-1);
             case 'md5':
-                return substr(chunk_split($RSAPublicKey, 2, ':'), 0, -1);
+                return substr(chunk_split(md5($RSAPublicKey), 2, ':'), 0, -1);
             default:
                 return false;
         }

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -241,6 +241,22 @@ ZQIDAQAB
         $this->assertFalse($rsa->getPrivateKey());
     }
 
+    public function testSSHPubKeyFingerprint()
+    {
+        $rsa = new RSA();
+
+        $key = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD9K+ebJRMN10kGanhi6kDz6EYFqZttZWZh0'.
+              'YoEbIbbere9N2Yvfc7oIoCTHYowhXND9WSJaIs1E4bx0085CZnofWaqf4NbZTzAh18iZup08ec'.
+              'COB5gJVS1efpgVSviDF2L7jxMsBVoOBfqsmA8m0RwDDVezyWvw4y+STSuVzu2jI8EfwN7ZFGC6'.
+              'Yo8m/Z94qIGzqPYGKJLuCeidB0TnUE0ZtzOJTiOc/WoTm/NOpCdfQZEJggd1MOTi+QUnqRu4Wu'.
+              'b6wYtY/q/WtUFr3nK+x0lgOtokhnJfRR/6fnmC1CztPnIT4BWK81VGKWONAxuhMyQ5XChyu6S9'.
+              'mWG5tUlUI/5';
+
+        $this->assertTrue($rsa->loadKey($key));
+        $this->assertSame($rsa->getPublicKeyFingerprint('md5'), 'bd:2c:2f:31:b9:ef:b8:f8:ad:fc:40:a6:94:4f:28:82');
+        $this->assertSame($rsa->getPublicKeyFingerprint('sha256'), 'N9sV2uSNZEe8TITODku0pRI27l+Zk0IY0TrRTw3ozwM');
+    }
+
     public function testSetPrivate()
     {
         $rsa = new RSA();


### PR DESCRIPTION
This adds the function `getPublicKeyFingerprint()` to `Crypt_RSA`:
```php
$rsa = new Crypt_RSA();
$rsa->loadPublicKey(file_get_contents('rsa.pub'));
echo $rsa->getPublicKeyFingerprint('md5');
echo $rsa->getPublicKeyFingerprint('sha256');
```
returns something like
```
c1:b1:30:29:d7:b8:de:6c:97:77:10:d7:46:41:63:87
N9sV2uSNZEe8TITODku0pRI27l+Zk0IY0TrRTw3ozwM
```
Calling this function outputs the same as running `ssh-keygen -lE sha256 f id.pub` or `ssh-keygen -lE md5 -f id.pub`.

The MD5 format is specified in https://tools.ietf.org/html/rfc4716#section-4.