### PR TITLE
[1.0] Various fixes to fopen mode handling in SFTP Stream

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -280,6 +280,8 @@ class Net_SFTP_Stream
         if ($this->size === false) {
             if ($this->mode[0] == 'r') {
                 return false;
+            } else {
+                $this->sftp->touch($path);
             }
         } else {
             switch ($this->mode[0]) {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -288,7 +288,6 @@ class Net_SFTP_Stream
                 case 'x':
                     return false;
                 case 'w':
-                case 'c':
                     $this->sftp->truncate($path, 0);
             }
         }

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -282,6 +282,7 @@ class Net_SFTP_Stream
                 return false;
             } else {
                 $this->sftp->touch($path);
+                $this->size = 0;
             }
         } else {
             switch ($this->mode[0]) {
@@ -289,6 +290,7 @@ class Net_SFTP_Stream
                     return false;
                 case 'w':
                     $this->sftp->truncate($path, 0);
+                    $this->size = 0;
             }
         }
 

--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -8,39 +8,14 @@
 
 require_once 'Crypt/Base.php';
 
-class Functional_Net_SFTPLargeFileTest extends PhpseclibFunctionalTestCase
+class Functional_Net_SFTPLargeFileTest extends Functional_Net_SFTPTestCase
 {
-    protected $sftp;
-    protected $scratchDir;
-
     static public function setUpBeforeClass()
     {
         if (!extension_loaded('mcrypt') && !extension_loaded('openssl')) {
             self::markTestSkipped('This test depends on mcrypt or openssl for performance.');
         }
         parent::setUpBeforeClass();
-    }
-
-    public function setUp()
-    {
-        $this->scratchDir = uniqid('phpseclib-sftp-large-scratch-');
-
-        $this->sftp = new Net_SFTP($this->getEnv('SSH_HOSTNAME'));
-        $this->assertTrue($this->sftp->login(
-            $this->getEnv('SSH_USERNAME'),
-            $this->getEnv('SSH_PASSWORD')
-        ));
-        $this->assertTrue($this->sftp->mkdir($this->scratchDir));
-        $this->assertTrue($this->sftp->chdir($this->scratchDir));
-    }
-
-    public function tearDown()
-    {
-        if ($this->sftp) {
-            $this->sftp->chdir($this->getEnv('SSH_HOME'));
-            $this->sftp->delete($this->scratchDir);
-        }
-        parent::tearDown();
     }
 
     /**

--- a/tests/Functional/Net/SFTPStreamTest.php
+++ b/tests/Functional/Net/SFTPStreamTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @author    Andreas Fischer <bantu@phpbb.com>
+ * @copyright 2015 Andreas Fischer
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+// Registers sftp:// as a side effect.
+require_once 'Net/SFTP/Stream.php';
+
+class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
+{
+    public function testFopenFcloseCreatesFile()
+    {
+        $context = stream_context_create(array(
+            'sftp' => array('session' => $this->sftp),
+        ));
+        $fp = fopen($this->buildUrl('fooo.txt'), 'wb', false, $context);
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+        $this->assertSame(0, $this->sftp->size('fooo.txt'));
+    }
+
+    protected function buildUrl($suffix)
+    {
+        return sprintf(
+            'sftp://via-context/%s/%s',
+            $this->sftp->pwd(),
+            $suffix
+        );
+    }
+}

--- a/tests/Functional/Net/SFTPTestCase.php
+++ b/tests/Functional/Net/SFTPTestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @author    Andreas Fischer <bantu@phpbb.com>
+ * @copyright 2015 Andreas Fischer
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+/**
+ * This class provides each test method with a new and empty $this->scratchDir.
+ */
+abstract class Functional_Net_SFTPTestCase extends PhpseclibFunctionalTestCase
+{
+    protected $sftp;
+    protected $scratchDir;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->scratchDir = uniqid('phpseclib-sftp-scratch-');
+
+        $this->sftp = new Net_SFTP($this->getEnv('SSH_HOSTNAME'));
+        $this->assertTrue($this->sftp->login(
+            $this->getEnv('SSH_USERNAME'),
+            $this->getEnv('SSH_PASSWORD')
+        ));
+        $this->assertTrue($this->sftp->mkdir($this->scratchDir));
+        $this->assertTrue($this->sftp->chdir($this->scratchDir));
+    }
+
+    public function tearDown()
+    {
+        if ($this->sftp) {
+            $this->sftp->chdir($this->getEnv('SSH_HOME'));
+            $this->sftp->delete($this->scratchDir);
+        }
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This reproduces https://github.com/owncloud/core/issues/17027#issuecomment-114929960

The following table was extracted from the description on http://php.net/manual/de/function.fopen.php
```
/*
* mode[0]  create  failOnExists  pos  truncate
*    r        n         n         l       n
*    w        y         n         l       y
*    a        y         n         r       n
*    x        y         y         l       y (implied by create and failOnExists)
*    c        y         n         l       n
*/
```