### PR TITLE
SFTP: update conditions under which cache for lstat / . is used for 1.0 branch

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1214,7 +1214,7 @@ class Net_SFTP extends Net_SSH2
 
         if ($this->use_stat_cache) {
             $result = $this->_query_stat_cache($filename);
-            if (is_array($result) && isset($result['.'])) {
+            if (is_array($result) && isset($result['.']) && isset($result['.']->lstat)) {
                 return $result['.']->lstat;
             }
             if (is_object($result) && isset($result->lstat)) {

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -433,10 +433,14 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     public function testStatOnCWD($sftp)
     {
         $stat = $sftp->stat('.');
+        $this->assertInternalType(
+            'array', $lstat,
+            'Failed asserting that stat on . returns an array'
+        );
         $lstat = $sftp->lstat('.');
-        $this->assertEquals(
-            $stat, $lstat,
-            'Failed asserting that stat and lstat on . are the same'
+        $this->assertInternalType(
+            'array', $lstat,
+            'Failed asserting that lstat on . returns an array'
         );
 
         return $sftp;

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -434,7 +434,7 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         $stat = $sftp->stat('.');
         $this->assertInternalType(
-            'array', $lstat,
+            'array', $stat,
             'Failed asserting that stat on . returns an array'
         );
         $lstat = $sftp->lstat('.');

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -427,8 +427,24 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     }
 
     /**
-     * on older versions this would result in a fatal error
      * @depends testReadlink
+     * @group github716
+     */
+    public function testStatOnCWD($sftp)
+    {
+        $stat = $sftp->stat('.');
+        $lstat = $sftp->lstat('.');
+        $this->assertEquals(
+            $stat, $lstat,
+            'Failed asserting that stat and lstat on . are the same'
+        );
+
+        return $sftp;
+    }
+
+    /**
+     * on older versions this would result in a fatal error
+     * @depends testStatOnCWD
      * @group github402
      */
     public function testStatcacheFix($sftp)


### PR DESCRIPTION
Fixes #716