### PR TITLE
SFTP: delete stat cache for recursive deletes / 1.0 branch

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2219,6 +2219,8 @@ class Net_SFTP extends Net_SSH2
                     return false;
                 }
 
+                $this->_remove_from_stat_cache($temp);
+
                 $i++;
 
                 if ($i >= NET_SFTP_QUEUE_SIZE) {
@@ -2234,6 +2236,8 @@ class Net_SFTP extends Net_SSH2
         if (!$this->_send_sftp_packet(NET_SFTP_RMDIR, pack('Na*', strlen($path), $path))) {
             return false;
         }
+
+        $this->_remove_from_stat_cache($path);
 
         $i++;
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2230,7 +2230,6 @@ class Net_SFTP extends Net_SSH2
                     $i = 0;
                 }
             }
-            $this->_remove_from_stat_cache($path);
         }
 
         if (!$this->_send_sftp_packet(NET_SFTP_RMDIR, pack('Na*', strlen($path), $path))) {

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -543,13 +543,23 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 
     /**
      * @depends testRmDirScratch
+     * @group github706
      */
     public function testDeleteRecursiveScratch($sftp)
     {
+        $this->assertInternalType(
+            'array',
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on an existant directory returns an array'
+        );
         $this->assertTrue(
             $sftp->delete(self::$scratchDir),
             'Failed asserting that non-empty scratch directory could ' .
-            'be deleted using non-recursive delete().'
+            'be deleted using recursive delete().'
+        );
+        $this->assertFalse(
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on a deleted directory returns false'
         );
 
         return $sftp;
@@ -564,29 +574,6 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             $sftp->rmdir(self::$scratchDir),
             'Failed asserting that nonexistent scratch directory could ' .
             'not be deleted using rmdir().'
-        );
-
-        return $sftp;
-    }
-
-    /**
-     * @depends testRmDirScratchNonexistent
-     * @group github706
-     */
-    public function testStatOnDeletedDir($sftp)
-    {
-        $this->assertInternalType(
-            'array',
-            $sftp->stat(self::$scratchDir),
-            'Failed asserting that stat on an existant directory returns an array'
-        );
-        $this->assertTrue(
-            $sftp->delete(self::$scratchDir, true),
-            'Failed asserting that scratch directory could be deleted recursively'
-        );
-        $this->assertFalse(
-            $sftp->stat(self::$scratchDir),
-            'Failed asserting that stat on a deleted directory returns false'
         );
     }
 }

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -565,6 +565,8 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             'Failed asserting that nonexistent scratch directory could ' .
             'not be deleted using rmdir().'
         );
+
+        return $sftp;
     }
 
     /**

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -549,7 +549,7 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         $this->assertTrue(
             $sftp->delete(self::$scratchDir),
             'Failed asserting that non-empty scratch directory could ' .
-            'be deleted using recursive delete().'
+            'be deleted using non-recursive delete().'
         );
 
         return $sftp;
@@ -564,6 +564,27 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             $sftp->rmdir(self::$scratchDir),
             'Failed asserting that nonexistent scratch directory could ' .
             'not be deleted using rmdir().'
+        );
+    }
+
+    /**
+     * @depends testRmDirScratchNonexistent
+     * @group github706
+     */
+    public function testStatOnDeletedDir($sftp)
+    {
+        $this->assertInternalType(
+            'array',
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on an existant directory returns an array'
+        );
+        $this->assertTrue(
+            $sftp->delete(self::$scratchDir, true),
+            'Failed asserting that scratch directory could be deleted recursively'
+        );
+        $this->assertFalse(
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on a deleted directory returns false'
         );
     }
 }


### PR DESCRIPTION
Fixes #706. Duplicate of #726 but for the 1.0 branch.

bantu suggested, in #726, that the new unit test succeeded even without the change to Net/SFTP.php but https://travis-ci.org/terrafrost/phpseclib/builds/69507514 makes it seem as tho that's not the case?