### PR TITLE
SFTP: delete stat cache for recursive deletes / 1.0 branch

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2218,6 +2218,7 @@ class Net_SFTP extends Net_SSH2
                 if (!$this->_send_sftp_packet(NET_SFTP_REMOVE, pack('Na*', strlen($temp), $temp))) {
                     return false;
                 }
+                $this->_remove_from_stat_cache($temp);
 
                 $i++;
 
@@ -2228,12 +2229,12 @@ class Net_SFTP extends Net_SSH2
                     $i = 0;
                 }
             }
-            $this->_remove_from_stat_cache($path);
         }
 
         if (!$this->_send_sftp_packet(NET_SFTP_RMDIR, pack('Na*', strlen($path), $path))) {
             return false;
         }
+        $this->_remove_from_stat_cache($path);
 
         $i++;
 

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -565,5 +565,34 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             'Failed asserting that nonexistent scratch directory could ' .
             'not be deleted using rmdir().'
         );
+
+        return $sftp;
+    }
+
+    /**
+     * @depends testRmDirScratchNonexistent
+     * @group github706
+     */
+    public function testDeleteEmptyDir($sftp)
+    {
+        $this->assertTrue(
+            $sftp->mkdir(self::$scratchDir),
+            'Failed asserting that scratch directory could ' .
+            'be created.'
+        );
+        $this->assertInternalType(
+            'array',
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on an existant empty directory returns an array'
+        );
+        $this->assertTrue(
+            $sftp->delete(self::$scratchDir),
+            'Failed asserting that empty scratch directory could ' .
+            'be deleted using recursive delete().'
+        );
+        $this->assertFalse(
+            $sftp->stat(self::$scratchDir),
+            'Failed asserting that stat on a deleted directory returns false'
+        );
     }
 }


### PR DESCRIPTION
Fixes #706.

The code change is pretty much the same as the code change in #729 but the unit test is different (pretty much the issue is only an issue when empty directories are being deleted).