### PR TITLE
SSH2: limit the size of data that expect() looks at

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2670,7 +2670,7 @@ class Net_SSH2
         $match = $expect;
         while (true) {
             if ($mode == NET_SSH2_READ_REGEX) {
-                preg_match($expect, $this->interactiveBuffer, $matches);
+                preg_match($expect, substr($this->interactiveBuffer, -1024), $matches);
                 $match = isset($matches[0]) ? $matches[0] : '';
             }
             $pos = strlen($match) ? strpos($this->interactiveBuffer, $match) : false;


### PR DESCRIPTION
Fixes #670.