### PR TITLE
Remove include statement from BigInteger TestCase.

### DIFF
--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -9,10 +9,7 @@ abstract class Unit_Math_BigInteger_TestCase extends PhpseclibTestCase
 {
     public static function setUpBeforeClass()
     {
-        include_once 'Math/BigInteger.php';
-
         parent::setUpBeforeClass();
-
         self::reRequireFile('Math/BigInteger.php');
     }
 


### PR DESCRIPTION
Follows #765

Fixes "PHP Warning:  include_once(Math/BigInteger.php): failed to open stream: No such file or directory in [...]/phpseclib/tests/Unit/Math/BigInteger/TestCase.php on line 12" when running without runkit extension.

This was previously required to load MATH_BIGINTEGER_MODE_* constants, but
these are autoloadable via \phpseclib\Math\BigInteger::MODE_* now and the
include path was removed.