### PR TITLE
Use placeholder variables in list() calls

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1182,7 +1182,7 @@ class RSA
                                 return false;
                             }
                             $this->_decodeLength($temp);
-                            list(, $iterationCount) = unpack('N', str_pad($temp, 4, chr(0), STR_PAD_LEFT));
+                            list($null, $iterationCount) = unpack('N', str_pad($temp, 4, chr(0), STR_PAD_LEFT));
                             $this->_string_shift($key); // assume it's an octet string
                             $length = $this->_decodeLength($key);
                             if (strlen($key) != $length) {
@@ -1911,7 +1911,7 @@ class RSA
         if ($length & 0x80) { // definite length, long form
             $length&= 0x7F;
             $temp = $this->_string_shift($string, $length);
-            list(, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
+            list($null, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
         }
         return $length;
     }
@@ -2107,7 +2107,7 @@ class RSA
             );
             $h = $m_i[1]->subtract($m_i[2]);
             $h = $h->multiply($this->coefficients[2]);
-            list(, $h) = $h->divide($this->primes[1]);
+            list($null, $h) = $h->divide($this->primes[1]);
             $m = $m_i[2]->add($h->multiply($this->primes[2]));
 
             $r = $this->primes[1];
@@ -2118,7 +2118,7 @@ class RSA
 
                 $h = $m_i->subtract($m);
                 $h = $h->multiply($this->coefficients[$i]);
-                list(, $h) = $h->divide($this->primes[$i]);
+                list($null, $h) = $h->divide($this->primes[$i]);
 
                 $m = $m->add($r->multiply($h));
             }
@@ -2140,7 +2140,7 @@ class RSA
             );
             $h = $m_i[1]->subtract($m_i[2]);
             $h = $h->multiply($this->coefficients[2]);
-            list(, $h) = $h->divide($this->primes[1]);
+            list($null, $h) = $h->divide($this->primes[1]);
             $m = $m_i[2]->add($h->multiply($this->primes[2]));
 
             $r = $this->primes[1];
@@ -2151,7 +2151,7 @@ class RSA
 
                 $h = $m_i->subtract($m);
                 $h = $h->multiply($this->coefficients[$i]);
-                list(, $h) = $h->divide($this->primes[$i]);
+                list($null, $h) = $h->divide($this->primes[$i]);
 
                 $m = $m->add($r->multiply($h));
             }
@@ -2179,7 +2179,7 @@ class RSA
 
         $r = $r->modInverse($this->primes[$i]);
         $x = $x->multiply($r);
-        list(, $x) = $x->divide($this->primes[$i]);
+        list($null, $x) = $x->divide($this->primes[$i]);
 
         return $x;
     }

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -679,7 +679,8 @@ class Rijndael extends Base
     {
         static $sbox;
         if (empty($sbox)) {
-            list(,,,, $sbox) = $this->_getTables();
+            $parts = $this->_getTables();
+            $sbox = $parts[4];
         }
 
         return  $sbox[$word       & 0x000000FF]        |

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -1128,7 +1128,7 @@ class ASN1
 
         preg_match($pattern, $content, $matches);
 
-        list(, $year, $month, $day, $hour, $minute, $second, $timezone) = $matches;
+        list($null, $year, $month, $day, $hour, $minute, $second, $timezone) = $matches;
 
         if ($tag == self::TYPE_UTC_TIME) {
             $year = $year >= 50 ? "19$year" : "20$year";

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -2187,7 +2187,7 @@ class X509
     function _decodeIP($ip)
     {
         $ip = base64_decode($ip);
-        list(, $ip) = unpack('N', $ip);
+        list($null, $ip) = unpack('N', $ip);
         return long2ip($ip);
     }
 

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -1641,7 +1641,7 @@ class BigInteger
         }
 
         if ($this->compare(new static()) < 0 || $this->compare($n) > 0) {
-            list(, $temp) = $this->divide($n);
+            list($null, $temp) = $this->divide($n);
             return $temp->modPow($e, $n);
         }
 
@@ -1700,14 +1700,14 @@ class BigInteger
         }
 
         if ($e->value == array(1)) {
-            list(, $temp) = $this->divide($n);
+            list($null, $temp) = $this->divide($n);
             return $this->_normalize($temp);
         }
 
         if ($e->value == array(2)) {
             $temp = new static();
             $temp->value = $this->_square($this->value);
-            list(, $temp) = $temp->divide($n);
+            list($null, $temp) = $temp->divide($n);
             return $this->_normalize($temp);
         }
 
@@ -1754,7 +1754,7 @@ class BigInteger
         $temp = $temp->multiply($y2);
 
         $result = $result->add($temp);
-        list(, $result) = $result->divide($n);
+        list($null, $result) = $result->divide($n);
 
         return $this->_normalize($result);
     }
@@ -1882,7 +1882,7 @@ class BigInteger
                 $lhs->value = $x;
                 $rhs = new static();
                 $rhs->value = $n;
-                list(, $temp) = $lhs->divide($rhs);
+                list($null, $temp) = $lhs->divide($rhs);
                 return $temp->value;
             case self::NONE:
                 return $x;
@@ -2004,7 +2004,7 @@ class BigInteger
             $rhs = new static();
             $lhs->value = $n;
             $rhs->value = $m;
-            list(, $temp) = $lhs->divide($rhs);
+            list($null, $temp) = $lhs->divide($rhs);
             return $temp->value;
         }
 
@@ -2100,7 +2100,7 @@ class BigInteger
             $rhs = new static();
             $lhs->value = $x;
             $rhs->value = $n;
-            list(, $temp) = $lhs->divide($rhs);
+            list($null, $temp) = $lhs->divide($rhs);
             return $temp->value;
         }
 
@@ -2345,7 +2345,7 @@ class BigInteger
         $rhs = new static();
         $rhs->value = $n;
 
-        list(, $temp) = $lhs->divide($rhs);
+        list($null, $temp) = $lhs->divide($rhs);
         return $temp->value;
     }
 
@@ -2403,7 +2403,7 @@ class BigInteger
      *    echo "\r\n";
      *
      *    $d = $a->multiply($c);
-     *    list(, $d) = $d->divide($b);
+     *    list($null, $d) = $d->divide($b);
      *    echo $d; // outputs 1 (as per the definition of modular inverse)
      * ?>
      * </code>
@@ -3145,7 +3145,7 @@ class BigInteger
             list($max_multiple) = $random_max->divide($max);
             $max_multiple = $max_multiple->multiply($max);
         }
-        list(, $random) = $random->divide($max);
+        list($null, $random) = $random->divide($max);
 
         return $this->_normalize($random->add($min));
     }
@@ -3372,7 +3372,7 @@ class BigInteger
         // see HAC 4.4.1 "Random search for probable primes"
         if (MATH_BIGINTEGER_MODE != self::MODE_INTERNAL) {
             foreach ($primes as $prime) {
-                list(, $r) = $this->divide($prime);
+                list($null, $r) = $this->divide($prime);
                 if ($r->equals($zero)) {
                     return $this->equals($prime);
                 }
@@ -3380,7 +3380,7 @@ class BigInteger
         } else {
             $value = $this->value;
             foreach ($primes as $prime) {
-                list(, $r) = $this->_divide_digit($value, $prime);
+                list($null, $r) = $this->_divide_digit($value, $prime);
                 if (!$r) {
                     return count($value) == 1 && $value[0] == $prime;
                 }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2434,7 +2434,7 @@ class SSH2
                 return false;
             }
 
-            list(, $type) = unpack('C', $this->_string_shift($response, 1));
+            list($null, $type) = unpack('C', $this->_string_shift($response, 1));
 
             switch ($type) {
                 case NET_SSH2_MSG_CHANNEL_SUCCESS:
@@ -2570,7 +2570,7 @@ class SSH2
             return false;
         }
 
-        list(, $type) = unpack('C', $this->_string_shift($response, 1));
+        list($null, $type) = unpack('C', $this->_string_shift($response, 1));
 
         switch ($type) {
             case NET_SSH2_MSG_CHANNEL_SUCCESS:
@@ -4009,17 +4009,17 @@ class SSH2
                 $w = $s->modInverse($q);
 
                 $u1 = $w->multiply(new BigInteger(sha1($this->exchange_hash), 16));
-                list(, $u1) = $u1->divide($q);
+                list($null, $u1) = $u1->divide($q);
 
                 $u2 = $w->multiply($r);
-                list(, $u2) = $u2->divide($q);
+                list($null, $u2) = $u2->divide($q);
 
                 $g = $g->modPow($u1, $p);
                 $y = $y->modPow($u2, $p);
 
                 $v = $g->multiply($y);
-                list(, $v) = $v->divide($p);
-                list(, $v) = $v->divide($q);
+                list($null, $v) = $v->divide($p);
+                list($null, $v) = $v->divide($q);
 
                 if (!$v->equals($r)) {
                     user_error('Bad server signature');


### PR DESCRIPTION
PHP7 does not support empty parameters in calls to list()

http://php.net/manual/en/migration70.incompatible.php