### PR TITLE
Make paths to runkit_import() absolute due to lack of include path.

### DIFF
--- a/tests/PhpseclibTestCase.php
+++ b/tests/PhpseclibTestCase.php
@@ -82,7 +82,7 @@ abstract class PhpseclibTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $filename
+     * @param string $filename Filename relative to library directory.
      *
      * @return null
      */
@@ -90,7 +90,7 @@ abstract class PhpseclibTestCase extends PHPUnit_Framework_TestCase
     {
         if (function_exists('runkit_import')) {
             $result = runkit_import(
-                $filename,
+                sprintf('%s/../phpseclib/%s', __DIR__, $filename),
                 RUNKIT_IMPORT_FUNCTIONS |
                 RUNKIT_IMPORT_CLASS_METHODS |
                 RUNKIT_IMPORT_OVERRIDE


### PR DESCRIPTION
Follows #773

Fixes "PHP Warning:  runkit_import(Math/BigInteger.php): failed to open stream: No such file or directory in /home/travis/build/phpseclib/phpseclib/tests/PhpseclibTestCase.php on line 97" as for example seen in https://travis-ci.org/phpseclib/phpseclib/jobs/75492795