### PR TITLE
.travis.yml: Remove outdated comment about .scrutinizer.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-# When adding environments here, the number of runs specified in .scrutinizer.yml
-# may have to be adjusted.
 php:
   - 5.3.3
   - 5.3


### PR DESCRIPTION
.scrutinizer.yml no longer exists