### PR TITLE
Switch to extension_loaded instead of function_exists in most places

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -473,11 +473,7 @@ class RSA
                 case defined('MATH_BIGINTEGER_OPENSSL_DISABLE'):
                     define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
                     break;
-                // openssl_pkey_get_details - which is used in the only place Crypt/RSA.php uses OpenSSL - was introduced in PHP 5.2.0
-                case extension_loaded('openssl') && version_compare(PHP_VERSION, '5.2.0', "<="):
-                    define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
-                    break;
-                case extension_loaded('openssl') && version_compare(PHP_VERSION, '4.2.0', '>=') && file_exists($this->configFile):
+                case extension_loaded('openssl') && file_exists($this->configFile):
                     // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
                     ob_start();
                     @phpinfo();

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -474,7 +474,7 @@ class RSA
                     define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
                     break;
                 // openssl_pkey_get_details - which is used in the only place Crypt/RSA.php uses OpenSSL - was introduced in PHP 5.2.0
-                case !function_exists('openssl_pkey_get_details'):
+                case extension_loaded('openssl') && version_compare(PHP_VERSION, '5.2.0', "<="):
                     define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
                     break;
                 case extension_loaded('openssl') && version_compare(PHP_VERSION, '4.2.0', '>=') && file_exists($this->configFile):

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -56,7 +56,7 @@ class Random
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             // method 1. prior to PHP 5.3 this would call rand() on windows hence the function_exists('class_alias') call.
             // ie. class_alias is a function that was introduced in PHP 5.3
-            if (function_exists('mcrypt_create_iv') && function_exists('class_alias')) {
+            if (extension_loaded('mcrypt') && function_exists('class_alias')) {
                 return mcrypt_create_iv($length);
             }
             // method 2. openssl_random_pseudo_bytes was introduced in PHP 5.3.0 but prior to PHP 5.3.4 there was,
@@ -72,12 +72,12 @@ class Random
             // https://github.com/php/php-src/blob/7014a0eb6d1611151a286c0ff4f2238f92c120d6/win32/winutil.c#L80
             //
             // we're calling it, all the same, in the off chance that the mcrypt extension is not available
-            if (function_exists('openssl_random_pseudo_bytes') && version_compare(PHP_VERSION, '5.3.4', '>=')) {
+            if (extension_loaded('openssl') && version_compare(PHP_VERSION, '5.3.4', '>=')) {
                 return openssl_random_pseudo_bytes($length);
             }
         } else {
             // method 1. the fastest
-            if (function_exists('openssl_random_pseudo_bytes')) {
+            if (extension_loaded('openssl')) {
                 return openssl_random_pseudo_bytes($length);
             }
             // method 2
@@ -95,7 +95,7 @@ class Random
             // surprisingly slower than method 2. maybe that's because mcrypt_create_iv does a bunch of error checking that we're
             // not doing. regardless, this'll only be called if this PHP script couldn't open /dev/urandom due to open_basedir
             // restrictions or some such
-            if (function_exists('mcrypt_create_iv')) {
+            if (extension_loaded('mcrypt')) {
                 return mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
             }
         }

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -3199,7 +3199,7 @@ class BigInteger
         $x = $this->random($min, $max);
 
         // gmp_nextprime() requires PHP 5 >= 5.2.0 per <http://php.net/gmp-nextprime>.
-        if (MATH_BIGINTEGER_MODE == self::MODE_GMP && function_exists('gmp_nextprime')) {
+        if (MATH_BIGINTEGER_MODE == self::MODE_GMP && extension_loaded('gmp')) {
             $p = new static();
             $p->value = gmp_nextprime($x->value);
 

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -271,7 +271,7 @@ class BigInteger
             }
         }
 
-        if (function_exists('openssl_public_encrypt') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
+        if (extension_loaded('openssl') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
             // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
             ob_start();
             @phpinfo();

--- a/tests/PhpseclibTestCase.php
+++ b/tests/PhpseclibTestCase.php
@@ -59,7 +59,7 @@ abstract class PhpseclibTestCase extends PHPUnit_Framework_TestCase
             $value = constant($constant);
 
             if ($value !== $expected) {
-                if (function_exists('runkit_constant_redefine')) {
+                if (extension_loaded('runkit')) {
                     if (!runkit_constant_redefine($constant, $expected)) {
                         self::markTestSkipped(sprintf(
                             "Failed to redefine constant %s to %s",
@@ -88,7 +88,7 @@ abstract class PhpseclibTestCase extends PHPUnit_Framework_TestCase
      */
     protected static function reRequireFile($filename)
     {
-        if (function_exists('runkit_import')) {
+        if (extension_loaded('runkit')) {
             $result = runkit_import(
                 sprintf('%s/../phpseclib/%s', __DIR__, $filename),
                 RUNKIT_IMPORT_FUNCTIONS |

--- a/tests/Unit/Math/BigInteger/InternalOpenSSLTest.php
+++ b/tests/Unit/Math/BigInteger/InternalOpenSSLTest.php
@@ -9,7 +9,7 @@ class Unit_Math_BigInteger_InternalOpenSSLTest extends Unit_Math_BigInteger_Test
 {
     public static function setUpBeforeClass()
     {
-        if (!function_exists('openssl_public_encrypt')) {
+        if (!extension_loaded('openssl')) {
             self::markTestSkipped('openssl_public_encrypt() function is not available.');
         }
 


### PR DESCRIPTION
I'm working on a library called mcrypt-polyfill. The idea is to provide the same function names and signatures as the mcrypt extension, but backed by something more actively maintained than mcrypt (a combination of phpseclib, openssl, random_bytes() in PHP7 and possibly libsodium if it's present (and if phpseclib doesn't implement it first)).

In any case, function_exists() is not a good way to check that the mcrypt extension is loaded, because in the instance where I want to create a function with the same name, that changes behaviors in other code and that's not a desirable behavior. It also creates the possibility for infinite loops in some cases, which is also obviously not desirable.

To that end, I've switched phpseclib to use extension_loaded() throughout the code base, except for a few scenarios where function_exists really does make sense.

After applying this patch, these are the remaining instances of function_exists();

```
$ grep -r function_exists *
phpseclib/Crypt/Base.php:        if ($this->use_inline_crypt !== false && function_exists('create_function')) {
phpseclib/Crypt/Base.php:                    case !function_exists('hash_pbkdf2'):
phpseclib/Crypt/Base.php:                    case !function_exists('hash_algos'):
phpseclib/Crypt/Random.php:            // method 1. prior to PHP 5.3 this would call rand() on windows hence the function_exists('class_alias') call.
phpseclib/Crypt/Random.php:            if (extension_loaded('mcrypt') && function_exists('class_alias')) {
phpseclib/Math/BigInteger.php:        if (MATH_BIGINTEGER_MODE == self::MODE_GMP && function_exists('gmp_nextprime')) {
```

phpseclib/Crypt/Base.php:
* create_function makes sense
* The hash_* checks didn't make sense from grep, but in that context, I think it's a good idea to check it that way, because otherwise it'll be much more verbose, as I'd have to check for the extension being loaded AND a PHP version for the second one.

phpseclib/Crypt/Random.php:
* class_alias isn't part of a php ext, so this is the most straightforward check

phpseclib/Math/BigInteger.php:
* I went back and forth on this one. I don't have a strong opinion, so if you'd prefer `extension_loaded('gmp') && version_compare(PHP_VERSION, "5.2.0", "<=")`, I can change it. Probably more simple to do it this way though.