### PR TITLE
small CS changes

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -51,7 +51,7 @@ class Random
      * @param int $length
      * @return string
      */
-    public static function string($length)
+    static function string($length)
     {
         if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
             try {

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -330,7 +330,6 @@ class BigInteger
                     self::$max10     = 10000000;
                     self::$max10Len  = 7;
                     self::$maxDigit2 = pow(2, 52); // pow() prevents truncation
-                    break;
             }
         }
 


### PR DESCRIPTION
`public static function` is replaced with `static function` in Random.php for reasons described at https://github.com/phpseclib/phpseclib/pull/813#commitcomment-13197976

I also removed an unnecessary `break`. This `break` isn't present in the 1.0 branch:

https://github.com/phpseclib/phpseclib/blob/1.0/phpseclib/Math/BigInteger.php#L322