### PR TITLE
RSA: make createKey static and make it return RSA objects

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -15,10 +15,10 @@
  *
  *    $plaintext = 'terrafrost';
  *
- *    $rsa->loadKey($privatekey);
+ *    $rsa->load($privatekey);
  *    $ciphertext = $rsa->encrypt($plaintext);
  *
- *    $rsa->loadKey($publickey);
+ *    $rsa->load($publickey);
  *    echo $rsa->decrypt($ciphertext);
  * ?>
  * </code>
@@ -33,10 +33,10 @@
  *
  *    $plaintext = 'terrafrost';
  *
- *    $rsa->loadKey($privatekey);
+ *    $rsa->load($privatekey);
  *    $signature = $rsa->sign($plaintext);
  *
- *    $rsa->loadKey($publickey);
+ *    $rsa->load($publickey);
  *    echo $rsa->verify($plaintext, $signature) ? 'verified' : 'unverified';
  * ?>
  * </code>
@@ -255,7 +255,7 @@ class RSA
      * @var array
      * @access private
      */
-    var $zero;
+    static $zero;
 
     /**
      * Precomputed One
@@ -263,7 +263,7 @@ class RSA
      * @var array
      * @access private
      */
-    var $one;
+    static $one;
 
     /**
      * Private Key Format
@@ -437,11 +437,12 @@ class RSA
      * OpenSSL configuration file name.
      *
      * Set to null to use system configuration file.
+     *
      * @see \phpseclib\Crypt\RSA::createKey()
      * @var mixed
-     * @Access public
+     * @access public
      */
-    var $configFile;
+    static $configFile;
 
     /**
      * Public key comment field.
@@ -450,6 +451,20 @@ class RSA
      * @access private
      */
     var $comment = 'phpseclib-generated-key';
+
+    /**
+     * Initialize static variables
+     *
+     * @access private
+     */
+    static function _initialize_static_variables()
+    {
+        if (!isset(self::$zero)) {
+            self::$zero= new BigInteger(0);
+            self::$one = new BigInteger(1);
+            self::$configFile = __DIR__ . '/../openssl.cnf';
+        }
+    }
 
     /**
      * The constructor
@@ -463,7 +478,32 @@ class RSA
      */
     function __construct()
     {
-        $this->configFile = dirname(__FILE__) . '/../openssl.cnf';
+        self::_initialize_static_variables();
+
+        $this->hash = new Hash('sha1');
+        $this->hLen = $this->hash->getLength();
+        $this->hashName = 'sha1';
+        $this->mgfHash = new Hash('sha1');
+        $this->mgfHLen = $this->mgfHash->getLength();
+    }
+
+    /**
+     * Create public / private key pair
+     *
+     * Returns an array with the following three elements:
+     *  - 'privatekey': The private key.
+     *  - 'publickey':  The public key.
+     *  - 'partialkey': A partially computed key (if the execution time exceeded $timeout).
+     *                  Will need to be passed back to \phpseclib\Crypt\RSA::createKey() as the third parameter for further processing.
+     *
+     * @access public
+     * @param int $bits
+     * @param int $timeout
+     * @param array $p
+     */
+    static function createKey($bits = 1024, $timeout = false, $partial = array())
+    {
+        self::_initialize_static_variables();
 
         if (!defined('CRYPT_RSA_MODE')) {
             switch (true) {
@@ -473,7 +513,7 @@ class RSA
                 case defined('MATH_BIGINTEGER_OPENSSL_DISABLE'):
                     define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
                     break;
-                case extension_loaded('openssl') && file_exists($this->configFile):
+                case extension_loaded('openssl') && file_exists(self::$configFile):
                     // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
                     ob_start();
                     @phpinfo();
@@ -513,32 +553,6 @@ class RSA
             }
         }
 
-        $this->zero = new BigInteger();
-        $this->one = new BigInteger(1);
-
-        $this->hash = new Hash('sha1');
-        $this->hLen = $this->hash->getLength();
-        $this->hashName = 'sha1';
-        $this->mgfHash = new Hash('sha1');
-        $this->mgfHLen = $this->mgfHash->getLength();
-    }
-
-    /**
-     * Create public / private key pair
-     *
-     * Returns an array with the following three elements:
-     *  - 'privatekey': The private key.
-     *  - 'publickey':  The public key.
-     *  - 'partialkey': A partially computed key (if the execution time exceeded $timeout).
-     *                  Will need to be passed back to \phpseclib\Crypt\RSA::createKey() as the third parameter for further processing.
-     *
-     * @access public
-     * @param int $bits
-     * @param int $timeout
-     * @param array $p
-     */
-    function createKey($bits = 1024, $timeout = false, $partial = array())
-    {
         if (!defined('CRYPT_RSA_EXPONENT')) {
             // http://en.wikipedia.org/wiki/65537_%28number%29
             define('CRYPT_RSA_EXPONENT', '65537');
@@ -556,16 +570,17 @@ class RSA
         // OpenSSL uses 65537 as the exponent and requires RSA keys be 384 bits minimum
         if (CRYPT_RSA_MODE == self::MODE_OPENSSL && $bits >= 384 && CRYPT_RSA_EXPONENT == 65537) {
             $config = array();
-            if (isset($this->configFile)) {
-                $config['config'] = $this->configFile;
+            if (isset(self::$configFile)) {
+                $config['config'] = self::$configFile;
             }
             $rsa = openssl_pkey_new(array('private_key_bits' => $bits) + $config);
-            openssl_pkey_export($rsa, $privatekey, null, $config);
-            $publickey = openssl_pkey_get_details($rsa);
-            $publickey = $publickey['key'];
+            openssl_pkey_export($rsa, $privatekeystr, null, $config);
+            $privatekey = new RSA();
+            $privatekey->load($privatekeystr);
 
-            $privatekey = call_user_func_array(array($this, '_convertPrivateKey'), array_values($this->_parseKey($privatekey, self::PRIVATE_FORMAT_PKCS1)));
-            $publickey = call_user_func_array(array($this, '_convertPublicKey'), array_values($this->_parseKey($publickey, self::PUBLIC_FORMAT_PKCS1)));
+            $publickeyarr = openssl_pkey_get_details($rsa);
+            $publickey = new RSA();
+            $publickey->load($publickeyarr['key']);
 
             // clear the buffer of error strings stemming from a minimalistic openssl.cnf
             while (openssl_error_string() !== false) {
@@ -583,7 +598,7 @@ class RSA
             $e = new BigInteger(CRYPT_RSA_EXPONENT);
         }
 
-        extract($this->_generateMinMax($bits));
+        extract(self::_generateMinMax($bits));
         $absoluteMin = $min;
         $temp = $bits >> 1; // divide by two to see how many bits P and Q would be
         if ($temp > CRYPT_RSA_SMALLEST_PRIME) {
@@ -592,19 +607,19 @@ class RSA
         } else {
             $num_primes = 2;
         }
-        extract($this->_generateMinMax($temp + $bits % $temp));
+        extract(self::_generateMinMax($temp + $bits % $temp));
         $finalMax = $max;
-        extract($this->_generateMinMax($temp));
+        extract(self::_generateMinMax($temp));
 
         $generator = new BigInteger();
 
-        $n = $this->one->copy();
+        $n = self::$one->copy();
         if (!empty($partial)) {
             extract(unserialize($partial));
         } else {
             $exponents = $coefficients = $primes = array();
             $lcm = array(
-                'top' => $this->one->copy(),
+                'top' => self::$one->copy(),
                 'bottom' => false
             );
         }
@@ -633,8 +648,8 @@ class RSA
 
                 if ($i == $num_primes) {
                     list($min, $temp) = $absoluteMin->divide($n);
-                    if (!$temp->equals($this->zero)) {
-                        $min = $min->add($this->one); // ie. ceil()
+                    if (!$temp->equals(self::$zero)) {
+                        $min = $min->add(self::$one); // ie. ceil()
                     }
                     $primes[$i] = $generator->randomPrime($min, $finalMax, $timeout);
                 } else {
@@ -655,8 +670,8 @@ class RSA
                     }
 
                     return array(
-                        'privatekey' => '',
-                        'publickey'  => '',
+                        'privatekey' => false,
+                        'publickey'  => false,
                         'partialkey' => $partialkey
                     );
                 }
@@ -669,7 +684,7 @@ class RSA
 
                 $n = $n->multiply($primes[$i]);
 
-                $temp = $primes[$i]->subtract($this->one);
+                $temp = $primes[$i]->subtract(self::$one);
 
                 // textbook RSA implementations use Euler's totient function instead of the least common multiple.
                 // see http://en.wikipedia.org/wiki/Euler%27s_totient_function
@@ -682,7 +697,7 @@ class RSA
             list($temp) = $lcm['top']->divide($lcm['bottom']);
             $gcd = $temp->gcd($e);
             $i0 = 1;
-        } while (!$gcd->equals($this->one));
+        } while (!$gcd->equals(self::$one));
 
         $d = $e->modInverse($temp);
 
@@ -701,10 +716,24 @@ class RSA
         //     coefficient       INTEGER,  -- (inverse of q) mod p
         //     otherPrimeInfos   OtherPrimeInfos OPTIONAL
         // }
+        $privatekey = new RSA();
+        $privatekey->modulus = $n;
+        $privatekey->k = $bits >> 3;
+        $privatekey->publicExponent = $e;
+        $privatekey->exponent = $d;
+        $privatekey->privateExponent = $e;
+        $privatekey->primes = $primes;
+        $privatekey->exponents = $exponents;
+        $privatekey->coefficients = $coefficients;
+
+        $publickey = new RSA();
+        $publickey->modulus = $n;
+        $publickey->k = $bits >> 3;
+        $publickey->exponent = $e;
 
         return array(
-            'privatekey' => $this->_convertPrivateKey($n, $e, $d, $primes, $exponents, $coefficients),
-            'publickey'  => $this->_convertPublicKey($n, $e),
+            'privatekey' => $privatekey,
+            'publickey'  => $publickey,
             'partialkey' => false
         );
     }
@@ -1398,9 +1427,9 @@ class RSA
                 }
                 $components['primes'][] = new BigInteger($this->_string_shift($private, $length), -256);
 
-                $temp = $components['primes'][1]->subtract($this->one);
+                $temp = $components['primes'][1]->subtract(self::$one);
                 $components['exponents'] = array(1 => $components['publicExponent']->modInverse($temp));
-                $temp = $components['primes'][2]->subtract($this->one);
+                $temp = $components['primes'][2]->subtract(self::$one);
                 $components['exponents'][] = $components['publicExponent']->modInverse($temp);
 
                 extract(unpack('Nlength', $this->_string_shift($private, 4)));
@@ -1510,7 +1539,7 @@ class RSA
      * @param string $key
      * @param int $type optional
      */
-    function loadKey($key, $type = false)
+    function load($key, $type = false)
     {
         if ($key instanceof RSA) {
             $this->privateKeyFormat = $key->privateKeyFormat;
@@ -1522,7 +1551,6 @@ class RSA
             $this->encryptionMode = $key->encryptionMode;
             $this->signatureMode = $key->signatureMode;
             $this->password = $key->password;
-            $this->configFile = $key->configFile;
             $this->comment = $key->comment;
 
             if (is_object($key->hash)) {
@@ -1622,7 +1650,7 @@ class RSA
      * Or rather, pass in $password such that empty($password) && !is_string($password) is true.
      *
      * @see createKey()
-     * @see loadKey()
+     * @see load()
      * @access public
      * @param string $password
      */
@@ -1720,13 +1748,13 @@ class RSA
         }
 
         $rsa = new RSA();
-        if (!$rsa->loadKey($key, $type)) {
+        if (!$rsa->load($key, $type)) {
             return false;
         }
         unset($rsa->publicExponent);
 
         // don't overwrite the old key if the new key is invalid
-        $this->loadKey($rsa);
+        $this->load($rsa);
         return true;
     }
 
@@ -1859,7 +1887,7 @@ class RSA
     function __clone()
     {
         $key = new RSA();
-        $key->loadKey($this);
+        $key->load($this);
         return $key;
     }
 
@@ -1870,7 +1898,7 @@ class RSA
      * @param int $bits
      * @return array
      */
-    function _generateMinMax($bits)
+    static function _generateMinMax($bits)
     {
         $bytes = $bits >> 3;
         $min = str_repeat(chr(0), $bytes);
@@ -2218,7 +2246,7 @@ class RSA
      */
     function _rsaep($m)
     {
-        if ($m->compare($this->zero) < 0 || $m->compare($this->modulus) > 0) {
+        if ($m->compare(self::$zero) < 0 || $m->compare($this->modulus) > 0) {
             throw new \OutOfRangeException('Message representative out of range');
         }
         return $this->_exponentiate($m);
@@ -2236,7 +2264,7 @@ class RSA
      */
     function _rsadp($c)
     {
-        if ($c->compare($this->zero) < 0 || $c->compare($this->modulus) > 0) {
+        if ($c->compare(self::$zero) < 0 || $c->compare($this->modulus) > 0) {
             throw new \OutOfRangeException('Ciphertext representative out of range');
         }
         return $this->_exponentiate($c);
@@ -2254,7 +2282,7 @@ class RSA
      */
     function _rsasp1($m)
     {
-        if ($m->compare($this->zero) < 0 || $m->compare($this->modulus) > 0) {
+        if ($m->compare(self::$zero) < 0 || $m->compare($this->modulus) > 0) {
             throw new \OutOfRangeException('Message representative out of range');
         }
         return $this->_exponentiate($m);
@@ -2272,7 +2300,7 @@ class RSA
      */
     function _rsavp1($s)
     {
-        if ($s->compare($this->zero) < 0 || $s->compare($this->modulus) > 0) {
+        if ($s->compare(self::$zero) < 0 || $s->compare($this->modulus) > 0) {
             throw new \OutOfRangeException('Signature representative out of range');
         }
         return $this->_exponentiate($s);

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -2125,7 +2125,7 @@ class X509
         switch ($publicKeyAlgorithm) {
             case 'rsaEncryption':
                 $rsa = new RSA();
-                $rsa->loadKey($publicKey);
+                $rsa->load($publicKey);
 
                 switch ($signatureAlgorithm) {
                     case 'md2WithRSAEncryption':
@@ -2803,7 +2803,7 @@ class X509
         switch ($keyinfo['algorithm']['algorithm']) {
             case 'rsaEncryption':
                 $publicKey = new RSA();
-                $publicKey->loadKey($key);
+                $publicKey->load($key);
                 $publicKey->setPublicKey();
                 break;
             default:
@@ -2873,7 +2873,7 @@ class X509
         switch ($algorithm) {
             case 'rsaEncryption':
                 $this->publicKey = new RSA();
-                $this->publicKey->loadKey($key);
+                $this->publicKey->load($key);
                 $this->publicKey->setPublicKey();
                 break;
             default:
@@ -2996,7 +2996,7 @@ class X509
         switch ($algorithm) {
             case 'rsaEncryption':
                 $this->publicKey = new RSA();
-                $this->publicKey->loadKey($key);
+                $this->publicKey->load($key);
                 $this->publicKey->setPublicKey();
                 break;
             default:
@@ -3385,7 +3385,7 @@ class X509
         $origPublicKey = $this->publicKey;
         $class = get_class($this->privateKey);
         $this->publicKey = new $class();
-        $this->publicKey->loadKey($this->privateKey->getPublicKey());
+        $this->publicKey->load($this->privateKey->getPublicKey());
         $this->publicKey->setPublicKey();
         if (!($publicKey = $this->_formatSubjectPublicKey())) {
             return false;
@@ -3443,7 +3443,7 @@ class X509
         $origPublicKey = $this->publicKey;
         $class = get_class($this->privateKey);
         $this->publicKey = new $class();
-        $this->publicKey->loadKey($this->privateKey->getPublicKey());
+        $this->publicKey->load($this->privateKey->getPublicKey());
         $this->publicKey->setPublicKey();
         $publicKey = $this->_formatSubjectPublicKey();
         if (!$publicKey) {
@@ -4212,7 +4212,7 @@ class X509
                 $raw = base64_decode($raw);
                 // If the key is private, compute identifier from its corresponding public key.
                 $key = new RSA();
-                if (!$key->loadKey($raw)) {
+                if (!$key->load($raw)) {
                     return false;   // Not an unencrypted RSA key.
                 }
                 if ($key->getPrivateKey() !== false) {  // If private.

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -1301,7 +1301,7 @@ class SSH1
     {
         /*
         $rsa = new RSA();
-        $rsa->loadKey($key, RSA::PUBLIC_FORMAT_RAW);
+        $rsa->load($key, RSA::PUBLIC_FORMAT_RAW);
         $rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);
         return $rsa->encrypt($m);
         */

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -26,7 +26,7 @@
  *
  *    $key = new \phpseclib\Crypt\RSA();
  *    //$key->setPassword('whatever');
- *    $key->loadKey(file_get_contents('privatekey'));
+ *    $key->load(file_get_contents('privatekey'));
  *
  *    $ssh = new \phpseclib\Net\SSH2('www.domain.tld');
  *    if (!$ssh->login('username', $key)) {
@@ -4042,7 +4042,7 @@ class SSH2
 
                 $rsa = new RSA();
                 $rsa->setSignatureMode(RSA::SIGNATURE_PKCS1);
-                $rsa->loadKey(array('e' => $e, 'n' => $n), RSA::PUBLIC_FORMAT_RAW);
+                $rsa->load(array('e' => $e, 'n' => $n), RSA::PUBLIC_FORMAT_RAW);
                 if (!$rsa->verify($this->exchange_hash, $signature)) {
                     //user_error('Bad server signature');
                     return $this->_disconnect(NET_SSH2_DISCONNECT_HOST_KEY_NOT_VERIFIABLE);

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -178,7 +178,7 @@ class Agent
             switch ($key_type) {
                 case 'ssh-rsa':
                     $key = new RSA();
-                    $key->loadKey('ssh-rsa ' . base64_encode($key_blob) . ' ' . $key_comment);
+                    $key->load('ssh-rsa ' . base64_encode($key_blob) . ' ' . $key_comment);
                     break;
                 case 'ssh-dss':
                     // not currently supported

--- a/tests/Unit/Crypt/RSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/RSA/CreateKeyTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2015 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+use phpseclib\Crypt\RSA;
+
+class Unit_Crypt_RSA_CreateKeyTest extends PhpseclibTestCase
+{
+    public function testCreateKey()
+    {
+        extract(RSA::createKey(512));
+        $this->assertInstanceOf('\phpseclib\Crypt\RSA', $privatekey);
+        $this->assertInstanceOf('\phpseclib\Crypt\RSA', $publickey);
+        $this->assertNotEmpty("$privatekey");
+        $this->assertNotEmpty("$publickey");
+
+        return array($publickey, $privatekey);
+    }
+
+    /**
+     * @depends testCreateKey
+     */
+    public function testEncryptDecrypt($args)
+    {
+        list($publickey, $privatekey) = $args;
+        $ciphertext = $publickey->encrypt('zzz');
+        $this->assertInternalType('string', $ciphertext);
+        $plaintext = $privatekey->decrypt($ciphertext);
+        $this->assertSame($plaintext, 'zzz');
+    }
+}

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -15,7 +15,7 @@ class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
 
         $key = 'zzzzzzzzzzzzzz';
 
-        $this->assertFalse($rsa->loadKey($key));
+        $this->assertFalse($rsa->load($key));
     }
 
     public function testPKCS1Key()
@@ -36,7 +36,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=
 -----END RSA PRIVATE KEY-----';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -59,7 +59,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 -----END RSA PRIVATE KEY-----';
         $key = str_replace(array("\r", "\n", "\r\n"), ' ', $key);
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -79,7 +79,7 @@ X6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl
 U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -99,7 +99,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
                'U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ' .
                '37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -120,7 +120,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
                '37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=';
         $key = base64_decode($key);
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -159,7 +159,7 @@ GF/qoZyC1mbqdtyyeWgHtVbJVUORmpbNnXOII9duEqBUNDiO9VSZNn/8h/VsYeAB
 xryZaRDVmtMuf/OZBQ==
 -----END ENCRYPTED PRIVATE KEY-----';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPrivateKey());
     }
 
@@ -182,12 +182,12 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 -----END RSA PRIVATE KEY-----';
         $rsa->setPassword('password');
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
 
         $key = $rsa->getPrivateKey(RSA::PRIVATE_FORMAT_PKCS8);
         $this->assertInternalType('string', $key);
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
     }
 
     public function testPubKey1()
@@ -203,7 +203,7 @@ gPiUWOPatVkt7+Bs3h5Ramxh7XjBOXeulmCpGSynXNcpZ/06+vofGi/2MlpQZNhH
 Ao8eayMp6FcvNucIpUndo1X8dKMv3Y26ZQIDAQAB
 -----END RSA PUBLIC KEY-----';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPublicKey());
         $this->assertFalse($rsa->getPrivateKey());
     }
@@ -222,7 +222,7 @@ lmCpGSynXNcpZ/06+vofGi/2MlpQZNhHAo8eayMp6FcvNucIpUndo1X8dKMv3Y26
 ZQIDAQAB
 -----END PUBLIC KEY-----';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPublicKey());
         $this->assertFalse($rsa->getPrivateKey());
     }
@@ -236,7 +236,7 @@ ZQIDAQAB
                'GkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZw== ' .
                'phpseclib-generated-key';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertInternalType('string', $rsa->getPublicKey());
         $this->assertFalse($rsa->getPrivateKey());
     }
@@ -252,7 +252,7 @@ ZQIDAQAB
               'b6wYtY/q/WtUFr3nK+x0lgOtokhnJfRR/6fnmC1CztPnIT4BWK81VGKWONAxuhMyQ5XChyu6S9'.
               'mWG5tUlUI/5';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertSame($rsa->getPublicKeyFingerprint('md5'), 'bd:2c:2f:31:b9:ef:b8:f8:ad:fc:40:a6:94:4f:28:82');
         $this->assertSame($rsa->getPublicKeyFingerprint('sha256'), 'N9sV2uSNZEe8TITODku0pRI27l+Zk0IY0TrRTw3ozwM');
     }
@@ -270,7 +270,7 @@ gPiUWOPatVkt7+Bs3h5Ramxh7XjBOXeulmCpGSynXNcpZ/06+vofGi/2MlpQZNhH
 Ao8eayMp6FcvNucIpUndo1X8dKMv3Y26ZQIDAQAB
 -----END RSA PUBLIC KEY-----';
 
-        $this->assertTrue($rsa->loadKey($key));
+        $this->assertTrue($rsa->load($key));
         $this->assertTrue($rsa->setPrivateKey());
         $this->assertGreaterThanOrEqual(1, strlen("$rsa"));
         $this->assertFalse($rsa->getPublicKey());
@@ -290,7 +290,7 @@ Ao8eayMp6FcvNucIpUndo1X8dKMv3Y26ZQIDAQAB
   <Exponent>AQAB</Exponent>
 </RSAKeyValue>';
 
-        $rsa->loadKey($key);
+        $rsa->load($key);
         $rsa->setPublicKey();
         $newkey = $rsa->getPublicKey(RSA::PUBLIC_FORMAT_XML);
 
@@ -311,7 +311,7 @@ JWrQdxx/WNN+ABG426rgYYbeGcIlWLZCw6Bx/1HtN5ef6nVEoiGNChYKIRB4QFOi
 01smFxps1w8ZIQnD6wIDAQAB
 -----END PUBLIC KEY-----';
 
-        $rsa->loadKey($key);
+        $rsa->load($key);
         $rsa->setPublicKey();
         $newkey = $rsa->getPublicKey();
 

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -28,8 +28,8 @@ X6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl
 U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=
 -----END RSA PRIVATE KEY-----';
-        $rsa->loadKey($privatekey);
-        $rsa->loadKey($rsa->getPublicKey());
+        $rsa->load($privatekey);
+        $rsa->load($rsa->getPublicKey());
 
         $rsa->setEncryptionMode(RSA::ENCRYPTION_NONE);
         $expected = '105b92f59a87a8ad4da52c128b8c99491790ef5a54770119e0819060032fb9e772ed6772828329567f3d7e9472154c1530f8156ba7fd732f52ca1c06' .
@@ -40,7 +40,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
 
         $this->assertEquals($result, $expected);
 
-        $rsa->loadKey($privatekey);
+        $rsa->load($privatekey);
         $this->assertEquals(trim($rsa->decrypt($result), "\0"), $plaintext);
     }
 
@@ -50,7 +50,7 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
     public function testPSSSigs()
     {
         $rsa = new RSA();
-        $rsa->loadKey('-----BEGIN PUBLIC KEY-----
+        $rsa->load('-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVx
 wTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFnc
 CzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0T

--- a/tests/Unit/File/X509/SPKACTest.php
+++ b/tests/Unit/File/X509/SPKACTest.php
@@ -48,10 +48,9 @@ class Unit_File_X509_SPKACTest extends PhpseclibTestCase
     {
         $privKey = new RSA();
         extract($privKey->createKey());
-        $privKey->loadKey($privatekey);
 
         $x509 = new X509();
-        $x509->setPrivateKey($privKey);
+        $x509->setPrivateKey($privatekey);
         $x509->setChallenge('...');
 
         $spkac = $x509->signSPKAC();

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -154,7 +154,7 @@ IOkKcGQRCMha8X2e7GmlpdWC1ycenlbN0nbVeSv3JUMcafC4+Q==
     public function testSaveNullRSAParam()
     {
         $privKey = new RSA();
-        $privKey->loadKey('-----BEGIN RSA PRIVATE KEY-----
+        $privKey->load('-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQDMswfEpAgnUDWA74zZw5XcPsWh1ly1Vk99tsqwoFDkLF7jvXy1
 dDLHYfuquvfxCgcp8k/4fQhx4ubR8bbGgEq9B05YRnViK0R0iBB5Ui4IaxWYYhKE
 8xqAEH2fL+/7nsqqNFKkEN9KeFwc7WbMY49U2adlMrpBdRjk1DqIEW3QTwIDAQAB
@@ -171,7 +171,7 @@ aBtsWpliLSex/HHhtRW9AkBGcq67zKmEpJ9kXcYLEjJii3flFS+Ct/rNm+Hhm1l7
 -----END RSA PRIVATE KEY-----');
 
         $pubKey = new RSA();
-        $pubKey->loadKey($privKey->getPublicKey());
+        $pubKey->load($privKey->getPublicKey());
         $pubKey->setPublicKey();
 
         $subject = new X509();


### PR DESCRIPTION
Replaces #815. I renamed loadKey to load to make RSA have an API more similar to the API I have planned for X509 (and CSR and SPKAC and all the classes I plan to split X509 up into).

Next step for RSA: splitting out all the key format handling stuff into their own individual class files.