### PR TITLE
Replace extension_loaded('mhash')

### DIFF
--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -158,7 +158,7 @@ class Crypt_Hash
                 case extension_loaded('hash'):
                     define('CRYPT_HASH_MODE', CRYPT_HASH_MODE_HASH);
                     break;
-                case extension_loaded('mhash'):
+                case function_exists('mhash'):
                     define('CRYPT_HASH_MODE', CRYPT_HASH_MODE_MHASH);
                     break;
                 default:


### PR DESCRIPTION
In PHP 7, mhash is not an extension. See: https://github.com/php/php-src/blob/php-7.0.0RC2/UPGRADING