### PR TITLE
SFTP.php : prevent endless loop when upload completed with non-zero $start or $local_start

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1877,10 +1877,12 @@ class SFTP extends SSH2
 
             if ($local_start >= 0) {
                 fseek($fp, $local_start);
+                $size -= $local_start;
             } elseif ($mode & self::RESUME_START) {
                 // do nothing
             } else {
                 fseek($fp, $offset);
+                $size -= $offset;
             }
         } elseif ($dataCallback) {
             $size = 0;


### PR DESCRIPTION
in SFTP::put(), if either of the $start or $local_start parameters is non-zero, and $data is not a callable, then the while {} loop which sends data to the remote server will never terminate, even when the end-of-file on the file being read has been reached. This is because the conidition $sent < $size is never satisfied - because it does not take into account the non-zero start. As a result, when the end of the file has been reached, an endless loop of inactivity will result - the method will never return.

The same issue exists in both the 1.0 and 2.0 branches, as well as master.