### PR TITLE
SFTP.php : prevent endless loop when upload completed with non-zero $start or $local_start for 1.0

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1917,10 +1917,12 @@ class Net_SFTP extends Net_SSH2
 
             if ($local_start >= 0) {
                 fseek($fp, $local_start);
+                $size-= $local_start;
             } elseif ($mode & NET_SFTP_RESUME_START) {
                 // do nothing
             } else {
                 fseek($fp, $offset);
+                $size-= $offset;
             }
         } elseif ($dataCallback) {
             $size = 0;

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1918,11 +1918,6 @@ class Net_SFTP extends Net_SSH2
             if ($local_start >= 0) {
                 fseek($fp, $local_start);
                 $size-= $local_start;
-            } elseif ($mode & NET_SFTP_RESUME_START) {
-                // do nothing
-            } else {
-                fseek($fp, $offset);
-                $size-= $offset;
             }
         } elseif ($dataCallback) {
             $size = 0;

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -649,5 +649,18 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         $this->assertSame($stat['type'], NET_SFTP_TYPE_SYMLINK);
 
         $sftp->enableStatCache();
+
+        //$sftp->chdir('..');
+
+        return $sftp;
+    }
+
+    /**
+     * @depends testStatVsLstat
+     * @group github735
+     */
+    public function testEndlessLoopOnUpload($sftp)
+    {
+        $sftp->put('endless.txt', 'res.txt', NET_SFTP_LOCAL_FILE, 0, 10);
     }
 }

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -657,14 +657,20 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      * @depends testStatVsLstat
      * @group github830
      */
-    public function testEndlessLoopOnUpload($sftp)
+    public function testUploadOffsets($sftp)
     {
-        $sftp->put('endless.txt', 'res.txt', NET_SFTP_LOCAL_FILE, 0, 10);
-
+        $sftp->put('offset.txt', 'res.txt', NET_SFTP_LOCAL_FILE, 0, 10);
         $this->assertSame(
             substr(self::$exampleData, 10),
-            $sftp->get('endless.txt'),
+            $sftp->get('offset.txt'),
             'Failed asserting that portions of a file could be uploaded.'
+        );
+
+        $sftp->put('offset.txt', 'res.txt', NET_SFTP_LOCAL_FILE, self::$exampleDataLength - 100);
+        $this->assertSame(
+            substr(self::$exampleData, 10, -90) . self::$exampleData,
+            $sftp->get('offset.txt'),
+            'Failed asserting that you could upload into the middle of a file.'
         );
     }
 }

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -650,17 +650,21 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 
         $sftp->enableStatCache();
 
-        //$sftp->chdir('..');
-
         return $sftp;
     }
 
     /**
      * @depends testStatVsLstat
-     * @group github735
+     * @group github830
      */
     public function testEndlessLoopOnUpload($sftp)
     {
         $sftp->put('endless.txt', 'res.txt', NET_SFTP_LOCAL_FILE, 0, 10);
+
+        $this->assertSame(
+            substr(self::$exampleData, 10),
+            $sftp->get('endless.txt'),
+            'Failed asserting that portions of a file could be uploaded.'
+        );
     }
 }


### PR DESCRIPTION
Replaces #830.

#830 is for the master branch but the issue is present in the 1.0 branch as well. I've also added a unit test that demonstrates the issue.