### PR TITLE
phpDoc changes for 1.0 branch

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -11,13 +11,13 @@
  * just a wrapper to Rijndael.php you may consider using Rijndael.php instead of
  * to save one include_once().
  *
- * If {@link Crypt_AES::setKeyLength() setKeyLength()} isn't called, it'll be calculated from
- * {@link Crypt_AES::setKey() setKey()}.  ie. if the key is 128-bits, the key length will be 128-bits.  If it's 136-bits
- * it'll be null-padded to 192-bits and 192 bits will be the key length until {@link Crypt_AES::setKey() setKey()}
+ * If {@link self::setKeyLength() setKeyLength()} isn't called, it'll be calculated from
+ * {@link self::setKey() setKey()}.  ie. if the key is 128-bits, the key length will be 128-bits.  If it's 136-bits
+ * it'll be null-padded to 192-bits and 192 bits will be the key length until {@link self::setKey() setKey()}
  * is called, again, at which point, it'll be recalculated.
  *
  * Since Crypt_AES extends Crypt_Rijndael, some functions are available to be called that, in the context of AES, don't
- * make a whole lot of sense.  {@link Crypt_AES::setBlockLength() setBlockLength()}, for instance.  Calling that function,
+ * make a whole lot of sense.  {@link self::setBlockLength() setBlockLength()}, for instance.  Calling that function,
  * however possible, won't do anything (AES has a fixed block length whereas Rijndael has a variable one).
  *
  * Here's a short example of how to use this library:
@@ -74,8 +74,8 @@ if (!class_exists('Crypt_Rijndael')) {
 
 /**#@+
  * @access public
- * @see Crypt_AES::encrypt()
- * @see Crypt_AES::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -296,9 +296,9 @@ class Crypt_Base
     /**
      * Does internal cipher state need to be (re)initialized?
      *
-     * @see setKey()
-     * @see setIV()
-     * @see disableContinuousBuffer()
+     * @see Crypt_Base::setKey()
+     * @see Crypt_Base::setIV()
+     * @see Crypt_Base::disableContinuousBuffer()
      * @var bool
      * @access private
      */
@@ -1726,9 +1726,9 @@ class Crypt_Base
      *
      * - First run of encrypt() / decrypt() with no init-settings
      *
-     * @see setKey()
-     * @see setIV()
-     * @see disableContinuousBuffer()
+     * @see Crypt_Base::setKey()
+     * @see Crypt_Base::setIV()
+     * @see Crypt_Base::disableContinuousBuffer()
      * @access private
      * @internal _setup() is always called before en/decryption.
      * @internal Could, but not must, extend by the child Crypt_* class
@@ -1760,9 +1760,9 @@ class Crypt_Base
      *
      * - First run of encrypt() / decrypt()
      *
-     * @see setKey()
-     * @see setIV()
-     * @see disableContinuousBuffer()
+     * @see Crypt_Base::setKey()
+     * @see Crypt_Base::setIV()
+     * @see Crypt_Base::disableContinuousBuffer()
      * @access private
      * @internal Could, but not must, extend by the child Crypt_* class
      */
@@ -2504,7 +2504,7 @@ class Crypt_Base
     /**
      * Generates a digest from $bytes
      *
-     * @see _setupInlineCrypt()
+     * @see Crypt_Base::_setupInlineCrypt()
      * @access private
      * @param $bytes
      * @return string

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -54,8 +54,8 @@
 
 /**#@+
  * @access public
- * @see Crypt_Base::encrypt()
- * @see Crypt_Base::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.
@@ -97,7 +97,7 @@ define('CRYPT_MODE_STREAM', 5);
 
 /**#@+
  * @access private
- * @see Crypt_Base::Crypt_Base()
+ * @see self::Crypt_Base()
  * @internal These constants are for internal use only
  */
 /**
@@ -127,7 +127,7 @@ class Crypt_Base
     /**
      * The Encryption Mode
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @var int
      * @access private
      */
@@ -144,7 +144,7 @@ class Crypt_Base
     /**
      * The Key
      *
-     * @see Crypt_Base::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -153,7 +153,7 @@ class Crypt_Base
     /**
      * The Initialization Vector
      *
-     * @see Crypt_Base::setIV()
+     * @see self::setIV()
      * @var string
      * @access private
      */
@@ -162,8 +162,8 @@ class Crypt_Base
     /**
      * A "sliding" Initialization Vector
      *
-     * @see Crypt_Base::enableContinuousBuffer()
-     * @see Crypt_Base::_clearBuffers()
+     * @see self::enableContinuousBuffer()
+     * @see self::_clearBuffers()
      * @var string
      * @access private
      */
@@ -172,8 +172,8 @@ class Crypt_Base
     /**
      * A "sliding" Initialization Vector
      *
-     * @see Crypt_Base::enableContinuousBuffer()
-     * @see Crypt_Base::_clearBuffers()
+     * @see self::enableContinuousBuffer()
+     * @see self::_clearBuffers()
      * @var string
      * @access private
      */
@@ -182,7 +182,7 @@ class Crypt_Base
     /**
      * Continuous Buffer status
      *
-     * @see Crypt_Base::enableContinuousBuffer()
+     * @see self::enableContinuousBuffer()
      * @var bool
      * @access private
      */
@@ -191,8 +191,8 @@ class Crypt_Base
     /**
      * Encryption buffer for CTR, OFB and CFB modes
      *
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::_clearBuffers()
+     * @see self::encrypt()
+     * @see self::_clearBuffers()
      * @var array
      * @access private
      */
@@ -201,8 +201,8 @@ class Crypt_Base
     /**
      * Decryption buffer for CTR, OFB and CFB modes
      *
-     * @see Crypt_Base::decrypt()
-     * @see Crypt_Base::_clearBuffers()
+     * @see self::decrypt()
+     * @see self::_clearBuffers()
      * @var array
      * @access private
      */
@@ -214,7 +214,7 @@ class Crypt_Base
      * The mcrypt resource can be recreated every time something needs to be created or it can be created just once.
      * Since mcrypt operates in continuous mode, by default, it'll need to be recreated when in non-continuous mode.
      *
-     * @see Crypt_Base::encrypt()
+     * @see self::encrypt()
      * @var resource
      * @access private
      */
@@ -226,7 +226,7 @@ class Crypt_Base
      * The mcrypt resource can be recreated every time something needs to be created or it can be created just once.
      * Since mcrypt operates in continuous mode, by default, it'll need to be recreated when in non-continuous mode.
      *
-     * @see Crypt_Base::decrypt()
+     * @see self::decrypt()
      * @var resource
      * @access private
      */
@@ -263,9 +263,9 @@ class Crypt_Base
      * use a separate ECB-mode mcrypt resource.
      *
      * @link http://phpseclib.sourceforge.net/cfb-demo.phps
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
-     * @see Crypt_Base::_setupMcrypt()
+     * @see self::encrypt()
+     * @see self::decrypt()
+     * @see self::_setupMcrypt()
      * @var resource
      * @access private
      */
@@ -287,7 +287,7 @@ class Crypt_Base
      * which, typically, depends on the complexity
      * on its internaly Key-expanding algorithm.
      *
-     * @see Crypt_Base::encrypt()
+     * @see self::encrypt()
      * @var int
      * @access private
      */
@@ -296,9 +296,9 @@ class Crypt_Base
     /**
      * Does internal cipher state need to be (re)initialized?
      *
-     * @see Crypt_Base::setKey()
-     * @see Crypt_Base::setIV()
-     * @see Crypt_Base::disableContinuousBuffer()
+     * @see self::setKey()
+     * @see self::setIV()
+     * @see self::disableContinuousBuffer()
      * @var bool
      * @access private
      */
@@ -307,7 +307,7 @@ class Crypt_Base
     /**
      * Padding status
      *
-     * @see Crypt_Base::enablePadding()
+     * @see self::enablePadding()
      * @var bool
      * @access private
      */
@@ -316,7 +316,7 @@ class Crypt_Base
     /**
      * Is the mode one that is paddable?
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @var bool
      * @access private
      */
@@ -331,9 +331,9 @@ class Crypt_Base
      * - CRYPT_ENGINE_MCRYPT   (fast, php-extension: mcrypt, extension_loaded('mcrypt') required)
      * - CRYPT_ENGINE_INTERNAL (slower, pure php-engine, no php-extension required)
      *
-     * @see Crypt_Base::_setEngine()
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
+     * @see self::_setEngine()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @var int
      * @access private
      */
@@ -342,8 +342,8 @@ class Crypt_Base
     /**
      * Holds the preferred crypt engine
      *
-     * @see Crypt_Base::_setEngine()
-     * @see Crypt_Base::setPreferredEngine()
+     * @see self::_setEngine()
+     * @see self::setPreferredEngine()
      * @var int
      * @access private
      */
@@ -356,7 +356,7 @@ class Crypt_Base
      *
      * @link http://www.php.net/mcrypt_module_open
      * @link http://www.php.net/mcrypt_list_algorithms
-     * @see Crypt_Base::_setupMcrypt()
+     * @see self::_setupMcrypt()
      * @var string
      * @access private
      */
@@ -388,7 +388,7 @@ class Crypt_Base
     /**
      * The default password key_size used by setPassword()
      *
-     * @see Crypt_Base::setPassword()
+     * @see self::setPassword()
      * @var int
      * @access private
      */
@@ -397,7 +397,7 @@ class Crypt_Base
     /**
      * The default salt used by setPassword()
      *
-     * @see Crypt_Base::setPassword()
+     * @see self::setPassword()
      * @var string
      * @access private
      */
@@ -420,7 +420,7 @@ class Crypt_Base
      * $aes = new Crypt_AES(CRYPT_AES_MODE_CFB); // $aes will operate in cfb mode
      * $aes = new Crypt_AES(CRYPT_MODE_CFB);     // identical
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @var string
      * @access private
      */
@@ -432,10 +432,10 @@ class Crypt_Base
      * Used by encrypt() / decrypt()
      * only if $engine == CRYPT_ENGINE_INTERNAL
      *
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
-     * @see Crypt_Base::_setupInlineCrypt()
-     * @see Crypt_Base::$use_inline_crypt
+     * @see self::encrypt()
+     * @see self::decrypt()
+     * @see self::_setupInlineCrypt()
+     * @see self::$use_inline_crypt
      * @var Callback
      * @access private
      */
@@ -444,9 +444,9 @@ class Crypt_Base
     /**
      * Holds whether performance-optimized $inline_crypt() can/should be used.
      *
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
-     * @see Crypt_Base::inline_crypt
+     * @see self::encrypt()
+     * @see self::decrypt()
+     * @see self::inline_crypt
      * @var mixed
      * @access private
      */
@@ -455,7 +455,7 @@ class Crypt_Base
     /**
      * If OpenSSL can be used in ECB but not in CTR we can emulate CTR
      *
-     * @see Crypt_Base::_openssl_ctr_process()
+     * @see self::_openssl_ctr_process()
      * @var bool
      * @access private
      */
@@ -464,7 +464,7 @@ class Crypt_Base
     /**
      * Determines what options are passed to openssl_encrypt/decrypt
      *
-     * @see Crypt_Base::isValidEngine()
+     * @see self::isValidEngine()
      * @var mixed
      * @access private
      */
@@ -670,7 +670,7 @@ class Crypt_Base
      * strlen($plaintext) will still need to be a multiple of the block size, however, arbitrary values can be added to make it that
      * length.
      *
-     * @see Crypt_Base::decrypt()
+     * @see self::decrypt()
      * @access public
      * @param string $plaintext
      * @return string $ciphertext
@@ -968,7 +968,7 @@ class Crypt_Base
      * If strlen($ciphertext) is not a multiple of the block size, null bytes will be added to the end of the string until
      * it is.
      *
-     * @see Crypt_Base::encrypt()
+     * @see self::encrypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext
@@ -1259,8 +1259,8 @@ class Crypt_Base
      * and Crypt_Base::decrypt(). Also, OpenSSL doesn't implement CTR for all of it's symmetric ciphers so this
      * function will emulate CTR with ECB when necesary.
      *
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @param string $plaintext
      * @param string $encryptIV
      * @param array $buffer
@@ -1353,8 +1353,8 @@ class Crypt_Base
      * for OFB is the same for both encrypting and decrypting this function is re-used by both Crypt_Base::encrypt()
      * and Crypt_Base::decrypt().
      *
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @param string $plaintext
      * @param string $encryptIV
      * @param array $buffer
@@ -1435,7 +1435,7 @@ class Crypt_Base
      * away characters that shouldn't be stripped away. (SSH knows how many bytes are added because the length is
      * transmitted separately)
      *
-     * @see Crypt_Base::disablePadding()
+     * @see self::disablePadding()
      * @access public
      */
     function enablePadding()
@@ -1446,7 +1446,7 @@ class Crypt_Base
     /**
      * Do not pad packets.
      *
-     * @see Crypt_Base::enablePadding()
+     * @see self::enablePadding()
      * @access public
      */
     function disablePadding()
@@ -1488,7 +1488,7 @@ class Crypt_Base
      * continuous buffers not be used.  They do offer better security and are, in fact, sometimes required (SSH uses them),
      * however, they are also less intuitive and more likely to cause you problems.
      *
-     * @see Crypt_Base::disableContinuousBuffer()
+     * @see self::disableContinuousBuffer()
      * @access public
      * @internal Could, but not must, extend by the child Crypt_* class
      */
@@ -1508,7 +1508,7 @@ class Crypt_Base
      *
      * The default behavior.
      *
-     * @see Crypt_Base::enableContinuousBuffer()
+     * @see self::enableContinuousBuffer()
      * @access public
      * @internal Could, but not must, extend by the child Crypt_* class
      */
@@ -1530,7 +1530,7 @@ class Crypt_Base
     /**
      * Test for engine validity
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @param int $engine
      * @access public
      * @return bool
@@ -1597,7 +1597,7 @@ class Crypt_Base
      *
      * If the preferred crypt engine is not available the fastest available one will be used
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @param int $engine
      * @access public
      */
@@ -1619,7 +1619,7 @@ class Crypt_Base
     /**
      * Returns the engine currently being utilized
      *
-     * @see Crypt_Base::_setEngine()
+     * @see self::_setEngine()
      * @access public
      */
     function getEngine()
@@ -1630,7 +1630,7 @@ class Crypt_Base
     /**
      * Sets the engine as appropriate
      *
-     * @see Crypt_Base::Crypt_Base()
+     * @see self::Crypt_Base()
      * @access private
      */
     function _setEngine()
@@ -1700,7 +1700,7 @@ class Crypt_Base
      *
      * Only used if $engine == CRYPT_ENGINE_INTERNAL
      *
-     * @see Crypt_Base::_setup()
+     * @see self::_setup()
      * @access private
      * @internal Must be extended by the child Crypt_* class
      */
@@ -1726,9 +1726,9 @@ class Crypt_Base
      *
      * - First run of encrypt() / decrypt() with no init-settings
      *
-     * @see Crypt_Base::setKey()
-     * @see Crypt_Base::setIV()
-     * @see Crypt_Base::disableContinuousBuffer()
+     * @see self::setKey()
+     * @see self::setIV()
+     * @see self::disableContinuousBuffer()
      * @access private
      * @internal _setup() is always called before en/decryption.
      * @internal Could, but not must, extend by the child Crypt_* class
@@ -1760,9 +1760,9 @@ class Crypt_Base
      *
      * - First run of encrypt() / decrypt()
      *
-     * @see Crypt_Base::setKey()
-     * @see Crypt_Base::setIV()
-     * @see Crypt_Base::disableContinuousBuffer()
+     * @see self::setKey()
+     * @see self::setIV()
+     * @see self::disableContinuousBuffer()
      * @access private
      * @internal Could, but not must, extend by the child Crypt_* class
      */
@@ -1807,7 +1807,7 @@ class Crypt_Base
      * If padding is disabled and $text is not a multiple of the blocksize, the string will be padded regardless
      * and padding will, hence forth, be enabled.
      *
-     * @see Crypt_Base::_unpad()
+     * @see self::_unpad()
      * @param string $text
      * @access private
      * @return string
@@ -1836,7 +1836,7 @@ class Crypt_Base
      * If padding is enabled and the reported padding length is invalid the encryption key will be assumed to be wrong
      * and false will be returned.
      *
-     * @see Crypt_Base::_pad()
+     * @see self::_pad()
      * @param string $text
      * @access private
      * @return string
@@ -1912,8 +1912,8 @@ class Crypt_Base
     /**
      * Increment the current string
      *
-     * @see Crypt_Base::decrypt()
-     * @see Crypt_Base::encrypt()
+     * @see self::decrypt()
+     * @see self::encrypt()
      * @param string $var
      * @access private
      */
@@ -1999,10 +1999,10 @@ class Crypt_Base
      *       - The callback function should not use the 'return' statement, but en/decrypt'ing the content of $in only
      *
      *
-     * @see Crypt_Base::_setup()
-     * @see Crypt_Base::_createInlineCryptFunction()
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
+     * @see self::_setup()
+     * @see self::_createInlineCryptFunction()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @access private
      * @internal If a Crypt_* class providing inline crypting it must extend _setupInlineCrypt()
      */
@@ -2121,9 +2121,9 @@ class Crypt_Base
      *    );
      *    </code>
      *
-     * @see Crypt_Base::_setupInlineCrypt()
-     * @see Crypt_Base::encrypt()
-     * @see Crypt_Base::decrypt()
+     * @see self::_setupInlineCrypt()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @param array $cipher_code
      * @access private
      * @return string (the name of the created callback function)
@@ -2504,7 +2504,7 @@ class Crypt_Base
     /**
      * Generates a digest from $bytes
      *
-     * @see Crypt_Base::_setupInlineCrypt()
+     * @see self::_setupInlineCrypt()
      * @access private
      * @param $bytes
      * @return string

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -64,8 +64,8 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access public
- * @see Crypt_Blowfish::encrypt()
- * @see Crypt_Blowfish::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -69,8 +69,8 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access private
- * @see Crypt_DES::_setupKey()
- * @see Crypt_DES::_processBlock()
+ * @see self::_setupKey()
+ * @see self::_processBlock()
  */
 /**
  * Contains $keys[CRYPT_DES_ENCRYPT]
@@ -84,8 +84,8 @@ define('CRYPT_DES_DECRYPT', 1);
 
 /**#@+
  * @access public
- * @see Crypt_DES::encrypt()
- * @see Crypt_DES::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.
@@ -206,8 +206,8 @@ class Crypt_DES extends Crypt_Base
      *
      * Used only if $engine == CRYPT_DES_MODE_INTERNAL
      *
-     * @see Crypt_DES::_setupKey()
-     * @see Crypt_DES::_processBlock()
+     * @see self::_setupKey()
+     * @see self::_processBlock()
      * @var int
      * @access private
      */
@@ -216,7 +216,7 @@ class Crypt_DES extends Crypt_Base
     /**
      * max possible size of $key
      *
-     * @see Crypt_DES::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -225,7 +225,7 @@ class Crypt_DES extends Crypt_Base
     /**
      * The Key Schedule
      *
-     * @see Crypt_DES::_setupKey()
+     * @see self::_setupKey()
      * @var array
      * @access private
      */
@@ -238,8 +238,8 @@ class Crypt_DES extends Crypt_Base
      * with each byte containing all bits in the same state as the
      * corresponding bit in the index value.
      *
-     * @see Crypt_DES::_processBlock()
-     * @see Crypt_DES::_setupKey()
+     * @see self::_processBlock()
+     * @see self::_setupKey()
      * @var array
      * @access private
      */
@@ -716,7 +716,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_Base::_encryptBlock()
      * @see Crypt_Base::encrypt()
-     * @see Crypt_DES::encrypt()
+     * @see self::encrypt()
      * @access private
      * @param string $in
      * @return string
@@ -731,7 +731,7 @@ class Crypt_DES extends Crypt_Base
      *
      * @see Crypt_Base::_decryptBlock()
      * @see Crypt_Base::decrypt()
-     * @see Crypt_DES::decrypt()
+     * @see self::decrypt()
      * @access private
      * @param string $in
      * @return string
@@ -748,8 +748,8 @@ class Crypt_DES extends Crypt_Base
      * {@link http://en.wikipedia.org/wiki/Image:Feistel.png Feistel.png} to get a general
      * idea of what this function does.
      *
-     * @see Crypt_DES::_encryptBlock()
-     * @see Crypt_DES::_decryptBlock()
+     * @see self::_encryptBlock()
+     * @see self::_decryptBlock()
      * @access private
      * @param string $block
      * @param int $mode

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -143,7 +143,7 @@ class Crypt_DES extends Crypt_Base
      * The Key
      *
      * @see Crypt_Base::key
-     * @see setKey()
+     * @see Crypt_Base::setKey()
      * @var string
      * @access private
      */

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -759,7 +759,7 @@ class Crypt_Hash
      * @access private
      * @param int $int
      * @param int $amt
-     * @see _sha256()
+     * @see Crypt_Hash::_sha256()
      * @return int
      */
     function _rightRotate($int, $amt)
@@ -775,7 +775,7 @@ class Crypt_Hash
      * @access private
      * @param int $int
      * @param int $amt
-     * @see _sha256()
+     * @see Crypt_Hash::_sha256()
      * @return int
      */
     function _rightShift($int, $amt)
@@ -789,7 +789,7 @@ class Crypt_Hash
      *
      * @access private
      * @param int $int
-     * @see _sha256()
+     * @see Crypt_Hash::_sha256()
      * @return int
      */
     function _not($int)
@@ -805,7 +805,7 @@ class Crypt_Hash
      *
      * @param int $...
      * @return int
-     * @see _sha256()
+     * @see Crypt_Hash::_sha256()
      * @access private
      */
     function _add()

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -7,7 +7,7 @@
  *
  * md2, md5, md5-96, sha1, sha1-96, sha256, sha256-96, sha384, and sha512, sha512-96
  *
- * If {@link Crypt_Hash::setKey() setKey()} is called, {@link Crypt_Hash::hash() hash()} will return the HMAC as opposed to
+ * If {@link self::setKey() setKey()} is called, {@link self::hash() hash()} will return the HMAC as opposed to
  * the hash.  If no valid algorithm is provided, sha1 will be used.
  *
  * PHP versions 4 and 5
@@ -56,7 +56,7 @@
 
 /**#@+
  * @access private
- * @see Crypt_Hash::Crypt_Hash()
+ * @see self::Crypt_Hash()
  */
 /**
  * Toggles the internal implementation
@@ -84,7 +84,7 @@ class Crypt_Hash
     /**
      * Hash Parameter
      *
-     * @see Crypt_Hash::setHash()
+     * @see self::setHash()
      * @var int
      * @access private
      */
@@ -93,7 +93,7 @@ class Crypt_Hash
     /**
      * Byte-length of compression blocks / key (Internal HMAC)
      *
-     * @see Crypt_Hash::setAlgorithm()
+     * @see self::setAlgorithm()
      * @var int
      * @access private
      */
@@ -102,7 +102,7 @@ class Crypt_Hash
     /**
      * Byte-length of hash output (Internal HMAC)
      *
-     * @see Crypt_Hash::setHash()
+     * @see self::setHash()
      * @var int
      * @access private
      */
@@ -111,7 +111,7 @@ class Crypt_Hash
     /**
      * Hash Algorithm
      *
-     * @see Crypt_Hash::setHash()
+     * @see self::setHash()
      * @var string
      * @access private
      */
@@ -120,7 +120,7 @@ class Crypt_Hash
     /**
      * Key
      *
-     * @see Crypt_Hash::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -129,7 +129,7 @@ class Crypt_Hash
     /**
      * Outer XOR (Internal HMAC)
      *
-     * @see Crypt_Hash::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -138,7 +138,7 @@ class Crypt_Hash
     /**
      * Inner XOR (Internal HMAC)
      *
-     * @see Crypt_Hash::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -759,7 +759,7 @@ class Crypt_Hash
      * @access private
      * @param int $int
      * @param int $amt
-     * @see Crypt_Hash::_sha256()
+     * @see self::_sha256()
      * @return int
      */
     function _rightRotate($int, $amt)
@@ -775,7 +775,7 @@ class Crypt_Hash
      * @access private
      * @param int $int
      * @param int $amt
-     * @see Crypt_Hash::_sha256()
+     * @see self::_sha256()
      * @return int
      */
     function _rightShift($int, $amt)
@@ -789,7 +789,7 @@ class Crypt_Hash
      *
      * @access private
      * @param int $int
-     * @see Crypt_Hash::_sha256()
+     * @see self::_sha256()
      * @return int
      */
     function _not($int)
@@ -805,7 +805,7 @@ class Crypt_Hash
      *
      * @param int $...
      * @return int
-     * @see Crypt_Hash::_sha256()
+     * @see self::_sha256()
      * @access private
      */
     function _add()

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -120,7 +120,7 @@ class Crypt_RC2 extends Crypt_Base
      * The Key
      *
      * @see Crypt_Base::key
-     * @see setKey()
+     * @see Crypt_RC2::setKey()
      * @var string
      * @access private
      */
@@ -130,9 +130,9 @@ class Crypt_RC2 extends Crypt_Base
      * The Original (unpadded) Key
      *
      * @see Crypt_Base::key
-     * @see setKey()
-     * @see encrypt()
-     * @see decrypt()
+     * @see Crypt_RC2::setKey()
+     * @see Crypt_RC2::encrypt()
+     * @see Crypt_RC2::decrypt()
      * @var string
      * @access private
      */
@@ -456,7 +456,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * Mostly a wrapper for Crypt_Base::encrypt, with some additional OpenSSL handling code
      *
-     * @see decrypt()
+     * @see Crypt_RC2::decrypt()
      * @access public
      * @param string $plaintext
      * @return string $ciphertext
@@ -479,7 +479,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * Mostly a wrapper for Crypt_Base::decrypt, with some additional OpenSSL handling code
      *
-     * @see encrypt()
+     * @see Crypt_RC2::encrypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -62,8 +62,8 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access public
- * @see Crypt_RC2::encrypt()
- * @see Crypt_RC2::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.
@@ -120,7 +120,7 @@ class Crypt_RC2 extends Crypt_Base
      * The Key
      *
      * @see Crypt_Base::key
-     * @see Crypt_RC2::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -130,9 +130,9 @@ class Crypt_RC2 extends Crypt_Base
      * The Original (unpadded) Key
      *
      * @see Crypt_Base::key
-     * @see Crypt_RC2::setKey()
-     * @see Crypt_RC2::encrypt()
-     * @see Crypt_RC2::decrypt()
+     * @see self::setKey()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @var string
      * @access private
      */
@@ -178,8 +178,8 @@ class Crypt_RC2 extends Crypt_Base
     /**
      * The key length in bits.
      *
-     * @see Crypt_RC2::setKeyLength()
-     * @see Crypt_RC2::setKey()
+     * @see self::setKeyLength()
+     * @see self::setKey()
      * @var int
      * @access private
      * @internal Should be in range [1..1024].
@@ -190,8 +190,8 @@ class Crypt_RC2 extends Crypt_Base
     /**
      * The key length in bits.
      *
-     * @see Crypt_RC2::isValidEnine()
-     * @see Crypt_RC2::setKey()
+     * @see self::isValidEnine()
+     * @see self::setKey()
      * @var int
      * @access private
      * @internal Should be in range [1..1024].
@@ -201,7 +201,7 @@ class Crypt_RC2 extends Crypt_Base
     /**
      * The Key Schedule
      *
-     * @see Crypt_RC2::_setupKey()
+     * @see self::_setupKey()
      * @var array
      * @access private
      */
@@ -211,7 +211,7 @@ class Crypt_RC2 extends Crypt_Base
      * Key expansion randomization table.
      * Twice the same 256-value sequence to save a modulus in key expansion.
      *
-     * @see Crypt_RC2::setKey()
+     * @see self::setKey()
      * @var array
      * @access private
      */
@@ -285,7 +285,7 @@ class Crypt_RC2 extends Crypt_Base
     /**
      * Inverse key expansion randomization table.
      *
-     * @see Crypt_RC2::setKey()
+     * @see self::setKey()
      * @var array
      * @access private
      */
@@ -456,7 +456,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * Mostly a wrapper for Crypt_Base::encrypt, with some additional OpenSSL handling code
      *
-     * @see Crypt_RC2::decrypt()
+     * @see self::decrypt()
      * @access public
      * @param string $plaintext
      * @return string $ciphertext
@@ -479,7 +479,7 @@ class Crypt_RC2 extends Crypt_Base
      *
      * Mostly a wrapper for Crypt_Base::decrypt, with some additional OpenSSL handling code
      *
-     * @see Crypt_RC2::encrypt()
+     * @see self::encrypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -71,7 +71,7 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access private
- * @see Crypt_RC4::_crypt()
+ * @see self::_crypt()
  */
 define('CRYPT_RC4_ENCRYPT', 0);
 define('CRYPT_RC4_DECRYPT', 1);
@@ -138,7 +138,7 @@ class Crypt_RC4 extends Crypt_Base
     /**
      * The Key
      *
-     * @see Crypt_RC4::setKey()
+     * @see self::setKey()
      * @var string
      * @access private
      */
@@ -147,7 +147,7 @@ class Crypt_RC4 extends Crypt_Base
     /**
      * The Key Stream for decryption and encryption
      *
-     * @see Crypt_RC4::setKey()
+     * @see self::setKey()
      * @var array
      * @access private
      */
@@ -215,7 +215,7 @@ class Crypt_RC4 extends Crypt_Base
      * {@link http://en.wikipedia.org/wiki/Related_key_attack http://en.wikipedia.org/wiki/Related_key_attack}
      *
      * @param string $iv
-     * @see Crypt_RC4::setKey()
+     * @see self::setKey()
      * @access public
      */
     function setIV($iv)
@@ -241,7 +241,7 @@ class Crypt_RC4 extends Crypt_Base
      * Encrypts a message.
      *
      * @see Crypt_Base::decrypt()
-     * @see Crypt_RC4::_crypt()
+     * @see self::_crypt()
      * @access public
      * @param string $plaintext
      * @return string $ciphertext
@@ -261,7 +261,7 @@ class Crypt_RC4 extends Crypt_Base
      * At least if the continuous buffer is disabled.
      *
      * @see Crypt_Base::encrypt()
-     * @see Crypt_RC4::_crypt()
+     * @see self::_crypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext
@@ -305,8 +305,8 @@ class Crypt_RC4 extends Crypt_Base
     /**
      * Encrypts or decrypts a message.
      *
-     * @see Crypt_RC4::encrypt()
-     * @see Crypt_RC4::decrypt()
+     * @see self::encrypt()
+     * @see self::decrypt()
      * @access private
      * @param string $text
      * @param int $mode

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -751,7 +751,7 @@ class Crypt_RSA
      * Convert a private key to the appropriate format.
      *
      * @access private
-     * @see setPrivateKeyFormat()
+     * @see Crypt_RSA::setPrivateKeyFormat()
      * @param string $RSAPrivateKey
      * @return string
      */
@@ -992,7 +992,7 @@ class Crypt_RSA
      * Convert a public key to the appropriate format
      *
      * @access private
-     * @see setPublicKeyFormat()
+     * @see Crypt_RSA::setPublicKeyFormat()
      * @param string $RSAPrivateKey
      * @return string
      */
@@ -1070,8 +1070,8 @@ class Crypt_RSA
      * Break a public or private key down into its constituant components
      *
      * @access private
-     * @see _convertPublicKey()
-     * @see _convertPrivateKey()
+     * @see Crypt_RSA::_convertPublicKey()
+     * @see Crypt_RSA::_convertPrivateKey()
      * @param string $key
      * @param int $type
      * @return array
@@ -1692,8 +1692,8 @@ class Crypt_RSA
      * Private keys can be encrypted with a password.  To unset the password, pass in the empty string or false.
      * Or rather, pass in $password such that empty($password) && !is_string($password) is true.
      *
-     * @see createKey()
-     * @see loadKey()
+     * @see Crypt_RSA::createKey()
+     * @see Crypt_RSA::loadKey()
      * @access public
      * @param string $password
      */
@@ -1717,7 +1717,7 @@ class Crypt_RSA
      *
      * Returns true on success, false on failure
      *
-     * @see getPublicKey()
+     * @see Crypt_RSA::getPublicKey()
      * @access public
      * @param string $key optional
      * @param int $type optional
@@ -1777,7 +1777,7 @@ class Crypt_RSA
      *
      * Returns true on success, false on failure
      *
-     * @see getPublicKey()
+     * @see Crypt_RSA::getPublicKey()
      * @access public
      * @param string $key optional
      * @param int $type optional
@@ -1808,7 +1808,7 @@ class Crypt_RSA
      * or if the public key was set via setPublicKey().  If the currently loaded key is supposed to be the public key this
      * function won't return it since this library, for the most part, doesn't distinguish between public and private keys.
      *
-     * @see getPublicKey()
+     * @see Crypt_RSA::getPublicKey()
      * @access public
      * @param string $key
      * @param int $type optional
@@ -1836,6 +1836,7 @@ class Crypt_RSA
      * @access public
      * @param string $algorithm The hashing algorithm to be used. Valid options are 'md5' and 'sha256'. False is returned
      * for invalid values.
+     * @return mixed
      */
     public function getPublicKeyFingerprint($algorithm = 'md5')
     {
@@ -1865,10 +1866,11 @@ class Crypt_RSA
      *
      * The private key is only returned if the currently loaded key contains the constituent prime numbers.
      *
-     * @see getPublicKey()
+     * @see Crypt_RSA::getPublicKey()
      * @access public
      * @param string $key
      * @param int $type optional
+     * @return mixed
      */
     function getPrivateKey($type = CRYPT_RSA_PUBLIC_FORMAT_PKCS1)
     {
@@ -1889,7 +1891,7 @@ class Crypt_RSA
      * Returns the private key without the prime number constituants.  Structurally identical to a public key that
      * hasn't been set as the public key
      *
-     * @see getPrivateKey()
+     * @see Crypt_RSA::getPrivateKey()
      * @access private
      * @param string $key
      * @param int $type optional
@@ -1911,6 +1913,7 @@ class Crypt_RSA
      *  __toString() magic method
      *
      * @access public
+     * @return string
      */
     function __toString()
     {
@@ -1926,6 +1929,7 @@ class Crypt_RSA
      *  __clone() magic method
      *
      * @access public
+     * @return Crypt_RSA
      */
     function __clone()
     {
@@ -2021,7 +2025,7 @@ class Crypt_RSA
     /**
      * Determines the private key format
      *
-     * @see createKey()
+     * @see Crypt_RSA::createKey()
      * @access public
      * @param int $format
      */
@@ -2033,7 +2037,7 @@ class Crypt_RSA
     /**
      * Determines the public key format
      *
-     * @see createKey()
+     * @see Crypt_RSA::createKey()
      * @access public
      * @param int $format
      */
@@ -2950,7 +2954,7 @@ class Crypt_RSA
      * If $plaintext exceeds those limits it will be broken up so that it does and the resultant ciphertext's will
      * be concatenated together.
      *
-     * @see decrypt()
+     * @see Crypt_RSA::decrypt()
      * @access public
      * @param string $plaintext
      * @return string
@@ -2996,7 +3000,7 @@ class Crypt_RSA
     /**
      * Decryption
      *
-     * @see encrypt()
+     * @see Crypt_RSA::encrypt()
      * @access public
      * @param string $plaintext
      * @return string
@@ -3038,7 +3042,7 @@ class Crypt_RSA
     /**
      * Create a signature
      *
-     * @see verify()
+     * @see Crypt_RSA::verify()
      * @access public
      * @param string $message
      * @return string
@@ -3061,7 +3065,7 @@ class Crypt_RSA
     /**
      * Verifies a signature
      *
-     * @see sign()
+     * @see Crypt_RSA::sign()
      * @access public
      * @param string $message
      * @param string $signature

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -87,8 +87,8 @@ if (!class_exists('Crypt_Hash')) {
 
 /**#@+
  * @access public
- * @see Crypt_RSA::encrypt()
- * @see Crypt_RSA::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Use {@link http://en.wikipedia.org/wiki/Optimal_Asymmetric_Encryption_Padding Optimal Asymmetric Encryption Padding}
@@ -96,8 +96,8 @@ if (!class_exists('Crypt_Hash')) {
  *
  * Uses sha1 by default.
  *
- * @see Crypt_RSA::setHash()
- * @see Crypt_RSA::setMGFHash()
+ * @see self::setHash()
+ * @see self::setMGFHash()
  */
 define('CRYPT_RSA_ENCRYPTION_OAEP',  1);
 /**
@@ -118,17 +118,17 @@ define('CRYPT_RSA_ENCRYPTION_NONE', 3);
 
 /**#@+
  * @access public
- * @see Crypt_RSA::sign()
- * @see Crypt_RSA::verify()
- * @see Crypt_RSA::setHash()
+ * @see self::sign()
+ * @see self::verify()
+ * @see self::setHash()
  */
 /**
  * Use the Probabilistic Signature Scheme for signing
  *
  * Uses sha1 by default.
  *
- * @see Crypt_RSA::setSaltLength()
- * @see Crypt_RSA::setMGFHash()
+ * @see self::setSaltLength()
+ * @see self::setMGFHash()
  */
 define('CRYPT_RSA_SIGNATURE_PSS',  1);
 /**
@@ -142,7 +142,7 @@ define('CRYPT_RSA_SIGNATURE_PKCS1', 2);
 
 /**#@+
  * @access private
- * @see Crypt_RSA::createKey()
+ * @see self::createKey()
  */
 /**
  * ASN1 Integer
@@ -168,7 +168,7 @@ define('CRYPT_RSA_ASN1_SEQUENCE',   48);
 
 /**#@+
  * @access private
- * @see Crypt_RSA::Crypt_RSA()
+ * @see self::Crypt_RSA()
  */
 /**
  * To use the pure-PHP implementation
@@ -189,8 +189,8 @@ define('CRYPT_RSA_OPENSSL_CONFIG', dirname(__FILE__) . '/../openssl.cnf');
 
 /**#@+
  * @access public
- * @see Crypt_RSA::createKey()
- * @see Crypt_RSA::setPrivateKeyFormat()
+ * @see self::createKey()
+ * @see self::setPrivateKeyFormat()
  */
 /**
  * PKCS#1 formatted private key
@@ -214,8 +214,8 @@ define('CRYPT_RSA_PRIVATE_FORMAT_PKCS8', 3);
 
 /**#@+
  * @access public
- * @see Crypt_RSA::createKey()
- * @see Crypt_RSA::setPublicKeyFormat()
+ * @see self::createKey()
+ * @see self::setPublicKeyFormat()
  */
 /**
  * Raw public key
@@ -445,7 +445,7 @@ class Crypt_RSA
      * For use with parsing XML formatted keys.  PHP's XML Parser functions use utilized - instead of PHP's DOM functions -
      * because PHP's XML Parser functions work on PHP4 whereas PHP's DOM functions - although surperior - don't.
      *
-     * @see Crypt_RSA::_start_element_handler()
+     * @see self::_start_element_handler()
      * @var array
      * @access private
      */
@@ -456,8 +456,8 @@ class Crypt_RSA
      *
      * For use with parsing XML formatted keys.
      *
-     * @see Crypt_RSA::_character_handler()
-     * @see Crypt_RSA::_stop_element_handler()
+     * @see self::_character_handler()
+     * @see self::_stop_element_handler()
      * @var mixed
      * @access private
      */
@@ -467,7 +467,7 @@ class Crypt_RSA
      * OpenSSL configuration file name.
      *
      * Set to null to use system configuration file.
-     * @see Crypt_RSA::createKey()
+     * @see self::createKey()
      * @var mixed
      * @Access public
      */
@@ -751,7 +751,7 @@ class Crypt_RSA
      * Convert a private key to the appropriate format.
      *
      * @access private
-     * @see Crypt_RSA::setPrivateKeyFormat()
+     * @see self::setPrivateKeyFormat()
      * @param string $RSAPrivateKey
      * @return string
      */
@@ -992,7 +992,7 @@ class Crypt_RSA
      * Convert a public key to the appropriate format
      *
      * @access private
-     * @see Crypt_RSA::setPublicKeyFormat()
+     * @see self::setPublicKeyFormat()
      * @param string $RSAPrivateKey
      * @return string
      */
@@ -1070,8 +1070,8 @@ class Crypt_RSA
      * Break a public or private key down into its constituant components
      *
      * @access private
-     * @see Crypt_RSA::_convertPublicKey()
-     * @see Crypt_RSA::_convertPrivateKey()
+     * @see self::_convertPublicKey()
+     * @see self::_convertPrivateKey()
      * @param string $key
      * @param int $type
      * @return array
@@ -1692,8 +1692,8 @@ class Crypt_RSA
      * Private keys can be encrypted with a password.  To unset the password, pass in the empty string or false.
      * Or rather, pass in $password such that empty($password) && !is_string($password) is true.
      *
-     * @see Crypt_RSA::createKey()
-     * @see Crypt_RSA::loadKey()
+     * @see self::createKey()
+     * @see self::loadKey()
      * @access public
      * @param string $password
      */
@@ -1717,7 +1717,7 @@ class Crypt_RSA
      *
      * Returns true on success, false on failure
      *
-     * @see Crypt_RSA::getPublicKey()
+     * @see self::getPublicKey()
      * @access public
      * @param string $key optional
      * @param int $type optional
@@ -1777,7 +1777,7 @@ class Crypt_RSA
      *
      * Returns true on success, false on failure
      *
-     * @see Crypt_RSA::getPublicKey()
+     * @see self::getPublicKey()
      * @access public
      * @param string $key optional
      * @param int $type optional
@@ -1808,7 +1808,7 @@ class Crypt_RSA
      * or if the public key was set via setPublicKey().  If the currently loaded key is supposed to be the public key this
      * function won't return it since this library, for the most part, doesn't distinguish between public and private keys.
      *
-     * @see Crypt_RSA::getPublicKey()
+     * @see self::getPublicKey()
      * @access public
      * @param string $key
      * @param int $type optional
@@ -1866,7 +1866,7 @@ class Crypt_RSA
      *
      * The private key is only returned if the currently loaded key contains the constituent prime numbers.
      *
-     * @see Crypt_RSA::getPublicKey()
+     * @see self::getPublicKey()
      * @access public
      * @param string $key
      * @param int $type optional
@@ -1891,7 +1891,7 @@ class Crypt_RSA
      * Returns the private key without the prime number constituants.  Structurally identical to a public key that
      * hasn't been set as the public key
      *
-     * @see Crypt_RSA::getPrivateKey()
+     * @see self::getPrivateKey()
      * @access private
      * @param string $key
      * @param int $type optional
@@ -2025,7 +2025,7 @@ class Crypt_RSA
     /**
      * Determines the private key format
      *
-     * @see Crypt_RSA::createKey()
+     * @see self::createKey()
      * @access public
      * @param int $format
      */
@@ -2037,7 +2037,7 @@ class Crypt_RSA
     /**
      * Determines the public key format
      *
-     * @see Crypt_RSA::createKey()
+     * @see self::createKey()
      * @access public
      * @param int $format
      */
@@ -2954,7 +2954,7 @@ class Crypt_RSA
      * If $plaintext exceeds those limits it will be broken up so that it does and the resultant ciphertext's will
      * be concatenated together.
      *
-     * @see Crypt_RSA::decrypt()
+     * @see self::decrypt()
      * @access public
      * @param string $plaintext
      * @return string
@@ -3000,7 +3000,7 @@ class Crypt_RSA
     /**
      * Decryption
      *
-     * @see Crypt_RSA::encrypt()
+     * @see self::encrypt()
      * @access public
      * @param string $plaintext
      * @return string
@@ -3042,7 +3042,7 @@ class Crypt_RSA
     /**
      * Create a signature
      *
-     * @see Crypt_RSA::verify()
+     * @see self::verify()
      * @access public
      * @param string $message
      * @return string
@@ -3065,7 +3065,7 @@ class Crypt_RSA
     /**
      * Verifies a signature
      *
-     * @see Crypt_RSA::sign()
+     * @see self::sign()
      * @access public
      * @param string $message
      * @param string $signature

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -7,11 +7,11 @@
  *
  * PHP versions 4 and 5
  *
- * If {@link Crypt_Rijndael::setBlockLength() setBlockLength()} isn't called, it'll be assumed to be 128 bits.  If
- * {@link Crypt_Rijndael::setKeyLength() setKeyLength()} isn't called, it'll be calculated from
- * {@link Crypt_Rijndael::setKey() setKey()}.  ie. if the key is 128-bits, the key length will be 128-bits.  If it's
+ * If {@link self::setBlockLength() setBlockLength()} isn't called, it'll be assumed to be 128 bits.  If
+ * {@link self::setKeyLength() setKeyLength()} isn't called, it'll be calculated from
+ * {@link self::setKey() setKey()}.  ie. if the key is 128-bits, the key length will be 128-bits.  If it's
  * 136-bits it'll be null-padded to 192-bits and 192 bits will be the key length until
- * {@link Crypt_Rijndael::setKey() setKey()} is called, again, at which point, it'll be recalculated.
+ * {@link self::setKey() setKey()} is called, again, at which point, it'll be recalculated.
  *
  * Not all Rijndael implementations may support 160-bits or 224-bits as the block length / key length.  mcrypt, for example,
  * does not.  AES, itself, only supports block lengths of 128 and key lengths of 128, 192, and 256.
@@ -81,8 +81,8 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access public
- * @see Crypt_Rijndael::encrypt()
- * @see Crypt_Rijndael::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.
@@ -156,7 +156,7 @@ class Crypt_Rijndael extends Crypt_Base
      *
      * @see Crypt_Base::cipher_name_mcrypt
      * @see Crypt_Base::engine
-     * @see Crypt_Rijndael::isValidEngine()
+     * @see self::isValidEngine()
      * @var string
      * @access private
      */
@@ -175,7 +175,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * Has the key length explicitly been set or should it be derived from the key, itself?
      *
-     * @see Crypt_Rijndael::setKeyLength()
+     * @see self::setKeyLength()
      * @var bool
      * @access private
      */
@@ -184,7 +184,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Schedule
      *
-     * @see Crypt_Rijndael::_setup()
+     * @see self::_setup()
      * @var array
      * @access private
      */
@@ -193,7 +193,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Inverse Key Schedule
      *
-     * @see Crypt_Rijndael::_setup()
+     * @see self::_setup()
      * @var array
      * @access private
      */
@@ -202,7 +202,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Block Length divided by 32
      *
-     * @see Crypt_Rijndael::setBlockLength()
+     * @see self::setBlockLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4.  Exists in conjunction with $block_size
@@ -215,7 +215,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Length
      *
-     * @see Crypt_Rijndael::setKeyLength()
+     * @see self::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 8 = 32, the min value is 128 / 8 = 16.  Exists in conjunction with $Nk
@@ -228,7 +228,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Length divided by 32
      *
-     * @see Crypt_Rijndael::setKeyLength()
+     * @see self::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4
@@ -301,7 +301,7 @@ class Crypt_Rijndael extends Crypt_Base
      * Note: 160/224-bit keys must explicitly set by setKeyLength(), otherwise they will be round/pad up to 192/256 bits.
      *
      * @see Crypt_Base:setKey()
-     * @see Crypt_Rijndael::setKeyLength()
+     * @see self::setKeyLength()
      * @access public
      * @param string $key
      */

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -156,7 +156,7 @@ class Crypt_Rijndael extends Crypt_Base
      *
      * @see Crypt_Base::cipher_name_mcrypt
      * @see Crypt_Base::engine
-     * @see isValidEngine()
+     * @see Crypt_Rijndael::isValidEngine()
      * @var string
      * @access private
      */
@@ -175,7 +175,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * Has the key length explicitly been set or should it be derived from the key, itself?
      *
-     * @see setKeyLength()
+     * @see Crypt_Rijndael::setKeyLength()
      * @var bool
      * @access private
      */
@@ -184,7 +184,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Schedule
      *
-     * @see _setup()
+     * @see Crypt_Rijndael::_setup()
      * @var array
      * @access private
      */
@@ -193,7 +193,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Inverse Key Schedule
      *
-     * @see _setup()
+     * @see Crypt_Rijndael::_setup()
      * @var array
      * @access private
      */
@@ -202,7 +202,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Block Length divided by 32
      *
-     * @see setBlockLength()
+     * @see Crypt_Rijndael::setBlockLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4.  Exists in conjunction with $block_size
@@ -215,7 +215,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Length
      *
-     * @see setKeyLength()
+     * @see Crypt_Rijndael::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 8 = 32, the min value is 128 / 8 = 16.  Exists in conjunction with $Nk
@@ -228,7 +228,7 @@ class Crypt_Rijndael extends Crypt_Base
     /**
      * The Key Length divided by 32
      *
-     * @see setKeyLength()
+     * @see Crypt_Rijndael::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 32 = 8, the min value is 128 / 32 = 4
@@ -301,7 +301,7 @@ class Crypt_Rijndael extends Crypt_Base
      * Note: 160/224-bit keys must explicitly set by setKeyLength(), otherwise they will be round/pad up to 192/256 bits.
      *
      * @see Crypt_Base:setKey()
-     * @see setKeyLength()
+     * @see Crypt_Rijndael::setKeyLength()
      * @access public
      * @param string $key
      */

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -61,7 +61,7 @@ if (!class_exists('Crypt_DES')) {
 
 /**#@+
  * @access public
- * @see Crypt_TripleDES::Crypt_TripleDES()
+ * @see self::Crypt_TripleDES()
  */
 /**
  * Encrypt / decrypt using inner chaining
@@ -147,7 +147,7 @@ class Crypt_TripleDES extends Crypt_DES
     /**
      * max possible size of $key
      *
-     * @see Crypt_TripleDES::setKey()
+     * @see self::setKey()
      * @see Crypt_DES::setKey()
      * @var string
      * @access private
@@ -392,7 +392,7 @@ class Crypt_TripleDES extends Crypt_DES
      * however, they are also less intuitive and more likely to cause you problems.
      *
      * @see Crypt_Base::enableContinuousBuffer()
-     * @see Crypt_TripleDES::disableContinuousBuffer()
+     * @see self::disableContinuousBuffer()
      * @access public
      */
     function enableContinuousBuffer()
@@ -411,7 +411,7 @@ class Crypt_TripleDES extends Crypt_DES
      * The default behavior.
      *
      * @see Crypt_Base::disableContinuousBuffer()
-     * @see Crypt_TripleDES::enableContinuousBuffer()
+     * @see self::enableContinuousBuffer()
      * @access public
      */
     function disableContinuousBuffer()

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -64,8 +64,8 @@ if (!class_exists('Crypt_Base')) {
 
 /**#@+
  * @access public
- * @see Crypt_Twofish::encrypt()
- * @see Crypt_Twofish::decrypt()
+ * @see self::encrypt()
+ * @see self::decrypt()
  */
 /**
  * Encrypt / decrypt using the Counter mode.

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -169,8 +169,8 @@ class File_ASN1
      *
      * @var array
      * @access private
-     * @see File_ASN1::setTimeFormat()
-     * @see File_ASN1::asn1map()
+     * @see self::setTimeFormat()
+     * @see self::asn1map()
      * @link http://php.net/class.datetime
      */
     var $encoded;
@@ -182,7 +182,7 @@ class File_ASN1
      *
      * @var array
      * @access private
-     * @see File_ASN1::_encode_der()
+     * @see self::_encode_der()
      */
     var $filters;
 

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -60,7 +60,7 @@ define('FILE_X509_VALIDATE_SIGNATURE_BY_CA', 1);
 
 /**#@+
  * @access public
- * @see File_X509::getDN()
+ * @see self::getDN()
  */
 /**
  * Return internal array representation
@@ -90,9 +90,9 @@ define('FILE_X509_DN_HASH', 5);
 
 /**#@+
  * @access public
- * @see File_X509::saveX509()
- * @see File_X509::saveCSR()
- * @see File_X509::saveCRL()
+ * @see self::saveX509()
+ * @see self::saveCSR()
+ * @see self::saveCRL()
  */
 /**
  * Save as PEM

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -72,27 +72,27 @@
  * Reduction constants
  *
  * @access private
- * @see Math_BigInteger::_reduce()
+ * @see self::_reduce()
  */
 /**
- * @see Math_BigInteger::_montgomery()
- * @see Math_BigInteger::_prepMontgomery()
+ * @see self::_montgomery()
+ * @see self::_prepMontgomery()
  */
 define('MATH_BIGINTEGER_MONTGOMERY', 0);
 /**
- * @see Math_BigInteger::_barrett()
+ * @see self::_barrett()
  */
 define('MATH_BIGINTEGER_BARRETT', 1);
 /**
- * @see Math_BigInteger::_mod2()
+ * @see self::_mod2()
  */
 define('MATH_BIGINTEGER_POWEROF2', 2);
 /**
- * @see Math_BigInteger::_remainder()
+ * @see self::_remainder()
  */
 define('MATH_BIGINTEGER_CLASSIC', 3);
 /**
- * @see Math_BigInteger::__clone()
+ * @see self::__clone()
  */
 define('MATH_BIGINTEGER_NONE', 4);
 /**#@-*/
@@ -117,8 +117,8 @@ define('MATH_BIGINTEGER_SIGN', 1);
 
 /**#@+
  * @access private
- * @see Math_BigInteger::_montgomery()
- * @see Math_BigInteger::_barrett()
+ * @see self::_montgomery()
+ * @see self::_barrett()
  */
 /**
  * Cache constants
@@ -136,7 +136,7 @@ define('MATH_BIGINTEGER_DATA', 1);
  * Mode constants.
  *
  * @access private
- * @see Math_BigInteger::Math_BigInteger()
+ * @see self::Math_BigInteger()
  */
 /**
  * To use the pure-PHP implementation
@@ -194,7 +194,7 @@ class Math_BigInteger
     /**
      * Precision
      *
-     * @see Math_BigInteger::setPrecision()
+     * @see self::setPrecision()
      * @access private
      */
     var $precision = -1;
@@ -202,7 +202,7 @@ class Math_BigInteger
     /**
      * Precision Bitmask
      *
-     * @see Math_BigInteger::setPrecision()
+     * @see self::setPrecision()
      * @access private
      */
     var $bitmask = false;
@@ -214,8 +214,8 @@ class Math_BigInteger
      * a variable that'll be serializable regardless of whether or not extensions are being used.  Unlike $this->value,
      * however, $this->hex is only calculated when $this->__sleep() is called.
      *
-     * @see Math_BigInteger::__sleep()
-     * @see Math_BigInteger::__wakeup()
+     * @see self::__sleep()
+     * @see self::__wakeup()
      * @var string
      * @access private
      */
@@ -730,7 +730,7 @@ class Math_BigInteger
      * {@link http://php.net/language.oop5.basic#51624}
      *
      * @access public
-     * @see Math_BigInteger::__clone()
+     * @see self::__clone()
      * @return Math_BigInteger
      */
     function copy()
@@ -766,7 +766,7 @@ class Math_BigInteger
      * call Math_BigInteger::copy(), instead.
      *
      * @access public
-     * @see Math_BigInteger::copy()
+     * @see self::copy()
      * @return Math_BigInteger
      */
     function __clone()
@@ -779,7 +779,7 @@ class Math_BigInteger
      *
      * Will be called, automatically, when serialize() is called on a Math_BigInteger object.
      *
-     * @see Math_BigInteger::__wakeup()
+     * @see self::__wakeup()
      * @access public
      */
     function __sleep()
@@ -797,7 +797,7 @@ class Math_BigInteger
      *
      * Will be called, automatically, when unserialize() is called on a Math_BigInteger object.
      *
-     * @see Math_BigInteger::__sleep()
+     * @see self::__sleep()
      * @access public
      */
     function __wakeup()
@@ -1863,7 +1863,7 @@ class Math_BigInteger
      *
      * For most $modes this will return the remainder.
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1900,7 +1900,7 @@ class Math_BigInteger
     /**
      * Modular reduction preperation
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1918,7 +1918,7 @@ class Math_BigInteger
     /**
      * Modular multiply
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $y
@@ -1938,7 +1938,7 @@ class Math_BigInteger
     /**
      * Modular square
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1959,7 +1959,7 @@ class Math_BigInteger
      * Calculates $x%$n, where $n = 2**$e, for some $e.  Since this is basically the same as doing $x & ($n-1),
      * we'll just use this function as a wrapper for doing that.
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param Math_BigInteger
      * @return Math_BigInteger
@@ -1989,7 +1989,7 @@ class Math_BigInteger
      * (x >> 1) + (x >> 1) != x / 2 + x / 2.  If x is even, they're the same, but if x is odd, they're not.  See the in-line
      * comments for details.
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $n
      * @param array $m
@@ -2086,7 +2086,7 @@ class Math_BigInteger
      * For numbers with more than four digits Math_BigInteger::_barrett() is faster.  The difference between that and this
      * is that this function does not fold the denominator into a smaller form.
      *
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2157,7 +2157,7 @@ class Math_BigInteger
      *
      * If you're going to be doing array_slice($product->value, 0, $stop), some cycles can be saved.
      *
-     * @see Math_BigInteger::_regularBarrett()
+     * @see self::_regularBarrett()
      * @param array $x_value
      * @param bool $x_negative
      * @param array $y_value
@@ -2238,8 +2238,8 @@ class Math_BigInteger
      * improved upon (basically, by using the comba method).  gcd($n, 2) must be equal to one for this function
      * to work correctly.
      *
-     * @see Math_BigInteger::_prepMontgomery()
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_prepMontgomery()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2285,8 +2285,8 @@ class Math_BigInteger
      * Interleaves the montgomery reduction and long multiplication algorithms together as described in
      * {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf#page=13 HAC 14.36}
      *
-     * @see Math_BigInteger::_prepMontgomery()
-     * @see Math_BigInteger::_montgomery()
+     * @see self::_prepMontgomery()
+     * @see self::_montgomery()
      * @access private
      * @param array $x
      * @param array $y
@@ -2337,8 +2337,8 @@ class Math_BigInteger
     /**
      * Prepare a number for use in Montgomery Modular Reductions
      *
-     * @see Math_BigInteger::_montgomery()
-     * @see Math_BigInteger::_slidingWindow()
+     * @see self::_montgomery()
+     * @see self::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2376,7 +2376,7 @@ class Math_BigInteger
      *
      * Thanks to Pedro Gimeno Fortea for input!
      *
-     * @see Math_BigInteger::_montgomery()
+     * @see self::_montgomery()
      * @access private
      * @param array $x
      * @return int
@@ -2663,7 +2663,7 @@ class Math_BigInteger
      * @param Math_BigInteger $y
      * @return int < 0 if $this is less than $y; > 0 if $this is greater than $y, and 0 if they are equal.
      * @access public
-     * @see Math_BigInteger::equals()
+     * @see self::equals()
      * @internal Could return $this->subtract($x), but that's not as fast as what we do do.
      */
     function compare($y)
@@ -2686,7 +2686,7 @@ class Math_BigInteger
      * @param array $y_value
      * @param bool $y_negative
      * @return int
-     * @see Math_BigInteger::compare()
+     * @see self::compare()
      * @access private
      */
     function _compare($x_value, $x_negative, $y_value, $y_negative)
@@ -2722,7 +2722,7 @@ class Math_BigInteger
      * @param Math_BigInteger $x
      * @return bool
      * @access public
-     * @see Math_BigInteger::compare()
+     * @see self::compare()
      */
     function equals($x)
     {
@@ -3284,7 +3284,7 @@ class Math_BigInteger
      *
      * If the current number is odd it'll be unchanged.  If it's even, one will be added to it.
      *
-     * @see Math_BigInteger::randomPrime()
+     * @see self::randomPrime()
      * @access private
      */
     function _make_odd()
@@ -3534,7 +3534,7 @@ class Math_BigInteger
      *
      * @param Math_BigInteger
      * @return Math_BigInteger
-     * @see Math_BigInteger::_trim()
+     * @see self::_trim()
      * @access private
      */
     function _normalize($result)
@@ -3714,7 +3714,7 @@ class Math_BigInteger
      *
      * The ability to DER-encode integers is needed to create RSA public keys for use with OpenSSL
      *
-     * @see Math_BigInteger::modPow()
+     * @see self::modPow()
      * @access private
      * @param int $length
      * @return string

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -192,17 +192,9 @@ class Math_BigInteger
     var $is_negative = false;
 
     /**
-     * Random number generator function
-     *
-     * @see setRandomGenerator()
-     * @access private
-     */
-    var $generator = 'mt_rand';
-
-    /**
      * Precision
      *
-     * @see setPrecision()
+     * @see Math_BigInteger::setPrecision()
      * @access private
      */
     var $precision = -1;
@@ -210,7 +202,7 @@ class Math_BigInteger
     /**
      * Precision Bitmask
      *
-     * @see setPrecision()
+     * @see Math_BigInteger::setPrecision()
      * @access private
      */
     var $bitmask = false;
@@ -222,8 +214,8 @@ class Math_BigInteger
      * a variable that'll be serializable regardless of whether or not extensions are being used.  Unlike $this->value,
      * however, $this->hex is only calculated when $this->__sleep() is called.
      *
-     * @see __sleep()
-     * @see __wakeup()
+     * @see Math_BigInteger::__sleep()
+     * @see Math_BigInteger::__wakeup()
      * @var string
      * @access private
      */
@@ -738,7 +730,7 @@ class Math_BigInteger
      * {@link http://php.net/language.oop5.basic#51624}
      *
      * @access public
-     * @see __clone()
+     * @see Math_BigInteger::__clone()
      * @return Math_BigInteger
      */
     function copy()
@@ -746,7 +738,6 @@ class Math_BigInteger
         $temp = new Math_BigInteger();
         $temp->value = $this->value;
         $temp->is_negative = $this->is_negative;
-        $temp->generator = $this->generator;
         $temp->precision = $this->precision;
         $temp->bitmask = $this->bitmask;
         return $temp;
@@ -775,7 +766,7 @@ class Math_BigInteger
      * call Math_BigInteger::copy(), instead.
      *
      * @access public
-     * @see copy()
+     * @see Math_BigInteger::copy()
      * @return Math_BigInteger
      */
     function __clone()
@@ -788,16 +779,13 @@ class Math_BigInteger
      *
      * Will be called, automatically, when serialize() is called on a Math_BigInteger object.
      *
-     * @see __wakeup()
+     * @see Math_BigInteger::__wakeup()
      * @access public
      */
     function __sleep()
     {
         $this->hex = $this->toHex(true);
         $vars = array('hex');
-        if ($this->generator != 'mt_rand') {
-            $vars[] = 'generator';
-        }
         if ($this->precision > 0) {
             $vars[] = 'precision';
         }
@@ -809,7 +797,7 @@ class Math_BigInteger
      *
      * Will be called, automatically, when unserialize() is called on a Math_BigInteger object.
      *
-     * @see __sleep()
+     * @see Math_BigInteger::__sleep()
      * @access public
      */
     function __wakeup()
@@ -817,7 +805,6 @@ class Math_BigInteger
         $temp = new Math_BigInteger($this->hex, -16);
         $this->value = $temp->value;
         $this->is_negative = $temp->is_negative;
-        $this->setRandomGenerator($this->generator);
         if ($this->precision > 0) {
             // recalculate $this->bitmask
             $this->setPrecision($this->precision);
@@ -1876,7 +1863,7 @@ class Math_BigInteger
      *
      * For most $modes this will return the remainder.
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1913,7 +1900,7 @@ class Math_BigInteger
     /**
      * Modular reduction preperation
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1931,7 +1918,7 @@ class Math_BigInteger
     /**
      * Modular multiply
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $y
@@ -1951,7 +1938,7 @@ class Math_BigInteger
     /**
      * Modular square
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -1972,7 +1959,7 @@ class Math_BigInteger
      * Calculates $x%$n, where $n = 2**$e, for some $e.  Since this is basically the same as doing $x & ($n-1),
      * we'll just use this function as a wrapper for doing that.
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param Math_BigInteger
      * @return Math_BigInteger
@@ -2002,7 +1989,7 @@ class Math_BigInteger
      * (x >> 1) + (x >> 1) != x / 2 + x / 2.  If x is even, they're the same, but if x is odd, they're not.  See the in-line
      * comments for details.
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $n
      * @param array $m
@@ -2099,7 +2086,7 @@ class Math_BigInteger
      * For numbers with more than four digits Math_BigInteger::_barrett() is faster.  The difference between that and this
      * is that this function does not fold the denominator into a smaller form.
      *
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2170,7 +2157,7 @@ class Math_BigInteger
      *
      * If you're going to be doing array_slice($product->value, 0, $stop), some cycles can be saved.
      *
-     * @see _regularBarrett()
+     * @see Math_BigInteger::_regularBarrett()
      * @param array $x_value
      * @param bool $x_negative
      * @param array $y_value
@@ -2251,8 +2238,8 @@ class Math_BigInteger
      * improved upon (basically, by using the comba method).  gcd($n, 2) must be equal to one for this function
      * to work correctly.
      *
-     * @see _prepMontgomery()
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_prepMontgomery()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2298,8 +2285,8 @@ class Math_BigInteger
      * Interleaves the montgomery reduction and long multiplication algorithms together as described in
      * {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf#page=13 HAC 14.36}
      *
-     * @see _prepMontgomery()
-     * @see _montgomery()
+     * @see Math_BigInteger::_prepMontgomery()
+     * @see Math_BigInteger::_montgomery()
      * @access private
      * @param array $x
      * @param array $y
@@ -2350,8 +2337,8 @@ class Math_BigInteger
     /**
      * Prepare a number for use in Montgomery Modular Reductions
      *
-     * @see _montgomery()
-     * @see _slidingWindow()
+     * @see Math_BigInteger::_montgomery()
+     * @see Math_BigInteger::_slidingWindow()
      * @access private
      * @param array $x
      * @param array $n
@@ -2389,7 +2376,7 @@ class Math_BigInteger
      *
      * Thanks to Pedro Gimeno Fortea for input!
      *
-     * @see _montgomery()
+     * @see Math_BigInteger::_montgomery()
      * @access private
      * @param array $x
      * @return int
@@ -2676,7 +2663,7 @@ class Math_BigInteger
      * @param Math_BigInteger $y
      * @return int < 0 if $this is less than $y; > 0 if $this is greater than $y, and 0 if they are equal.
      * @access public
-     * @see equals()
+     * @see Math_BigInteger::equals()
      * @internal Could return $this->subtract($x), but that's not as fast as what we do do.
      */
     function compare($y)
@@ -2699,7 +2686,7 @@ class Math_BigInteger
      * @param array $y_value
      * @param bool $y_negative
      * @return int
-     * @see compare()
+     * @see Math_BigInteger::compare()
      * @access private
      */
     function _compare($x_value, $x_negative, $y_value, $y_negative)
@@ -2735,7 +2722,7 @@ class Math_BigInteger
      * @param Math_BigInteger $x
      * @return bool
      * @access public
-     * @see compare()
+     * @see Math_BigInteger::compare()
      */
     function equals($x)
     {
@@ -3297,7 +3284,7 @@ class Math_BigInteger
      *
      * If the current number is odd it'll be unchanged.  If it's even, one will be added to it.
      *
-     * @see randomPrime()
+     * @see Math_BigInteger::randomPrime()
      * @access private
      */
     function _make_odd()
@@ -3547,7 +3534,7 @@ class Math_BigInteger
      *
      * @param Math_BigInteger
      * @return Math_BigInteger
-     * @see _trim()
+     * @see Math_BigInteger::_trim()
      * @access private
      */
     function _normalize($result)
@@ -3727,7 +3714,7 @@ class Math_BigInteger
      *
      * The ability to DER-encode integers is needed to create RSA public keys for use with OpenSSL
      *
-     * @see modPow()
+     * @see Math_BigInteger::modPow()
      * @access private
      * @param int $length
      * @return string

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -51,7 +51,7 @@
 
 /**#@+
  * @access public
- * @see Net_SCP::put()
+ * @see self::put()
  */
 /**
  * Reads data from a local file.
@@ -65,8 +65,8 @@ define('NET_SCP_STRING',  2);
 
 /**#@+
  * @access private
- * @see Net_SCP::_send()
- * @see Net_SCP::_receive()
+ * @see self::_send()
+ * @see self::_receive()
  */
 /**
  * SSH1 is being used.

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -62,7 +62,7 @@ if (!class_exists('Net_SSH2')) {
 
 /**#@+
  * @access public
- * @see Net_SFTP::getLog()
+ * @see self::getLog()
  */
 /**
  * Returns the message numbers
@@ -91,7 +91,7 @@ define('NET_SFTP_CHANNEL', 0x100);
 
 /**#@+
  * @access public
- * @see Net_SFTP::put()
+ * @see self::put()
  */
 /**
  * Reads data from a local file.
@@ -129,7 +129,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Packet Types
      *
-     * @see Net_SFTP::Net_SFTP()
+     * @see self::Net_SFTP()
      * @var array
      * @access private
      */
@@ -138,7 +138,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Status Codes
      *
-     * @see Net_SFTP::Net_SFTP()
+     * @see self::Net_SFTP()
      * @var array
      * @access private
      */
@@ -151,7 +151,7 @@ class Net_SFTP extends Net_SSH2
      * concurrent actions, so it's somewhat academic, here.
      *
      * @var int
-     * @see Net_SFTP::_send_sftp_packet()
+     * @see self::_send_sftp_packet()
      * @access private
      */
     var $request_id = false;
@@ -163,7 +163,7 @@ class Net_SFTP extends Net_SSH2
      * concurrent actions, so it's somewhat academic, here.
      *
      * @var int
-     * @see Net_SFTP::_get_sftp_packet()
+     * @see self::_get_sftp_packet()
      * @access private
      */
     var $packet_type = -1;
@@ -172,7 +172,7 @@ class Net_SFTP extends Net_SSH2
      * Packet Buffer
      *
      * @var string
-     * @see Net_SFTP::_get_sftp_packet()
+     * @see self::_get_sftp_packet()
      * @access private
      */
     var $packet_buffer = '';
@@ -181,7 +181,7 @@ class Net_SFTP extends Net_SSH2
      * Extensions supported by the server
      *
      * @var array
-     * @see Net_SFTP::_initChannel()
+     * @see self::_initChannel()
      * @access private
      */
     var $extensions = array();
@@ -190,7 +190,7 @@ class Net_SFTP extends Net_SSH2
      * Server SFTP version
      *
      * @var int
-     * @see Net_SFTP::_initChannel()
+     * @see self::_initChannel()
      * @access private
      */
     var $version;
@@ -199,8 +199,8 @@ class Net_SFTP extends Net_SSH2
      * Current working directory
      *
      * @var string
-     * @see Net_SFTP::_realpath()
-     * @see Net_SFTP::chdir()
+     * @see self::_realpath()
+     * @see self::chdir()
      * @access private
      */
     var $pwd = false;
@@ -208,7 +208,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Packet Type Log
      *
-     * @see Net_SFTP::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -217,7 +217,7 @@ class Net_SFTP extends Net_SSH2
     /**
      * Packet Log
      *
-     * @see Net_SFTP::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -226,8 +226,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Error information
      *
-     * @see Net_SFTP::getSFTPErrors()
-     * @see Net_SFTP::getLastSFTPError()
+     * @see self::getSFTPErrors()
+     * @see self::getLastSFTPError()
      * @var string
      * @access private
      */
@@ -239,9 +239,9 @@ class Net_SFTP extends Net_SSH2
      * Rather than always having to open a directory and close it immediately there after to see if a file is a directory
      * we'll cache the results.
      *
-     * @see Net_SFTP::_update_stat_cache()
-     * @see Net_SFTP::_remove_from_stat_cache()
-     * @see Net_SFTP::_query_stat_cache()
+     * @see self::_update_stat_cache()
+     * @see self::_remove_from_stat_cache()
+     * @see self::_query_stat_cache()
      * @var array
      * @access private
      */
@@ -250,8 +250,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Max SFTP Packet Size
      *
-     * @see Net_SFTP::Net_SFTP()
-     * @see Net_SFTP::get()
+     * @see self::Net_SFTP()
+     * @see self::get()
      * @var array
      * @access private
      */
@@ -260,8 +260,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Stat Cache Flag
      *
-     * @see Net_SFTP::disableStatCache()
-     * @see Net_SFTP::enableStatCache()
+     * @see self::disableStatCache()
+     * @see self::enableStatCache()
      * @var bool
      * @access private
      */
@@ -270,8 +270,8 @@ class Net_SFTP extends Net_SSH2
     /**
      * Sort Options
      *
-     * @see Net_SFTP::_comparator()
-     * @see Net_SFTP::setListOrder()
+     * @see self::_comparator()
+     * @see self::setListOrder()
      * @var array
      * @access private
      */
@@ -647,7 +647,7 @@ class Net_SFTP extends Net_SSH2
      * SFTP doesn't provide a mechanism by which the current working directory can be changed, so we'll emulate it.  Returns
      * the absolute (canonicalized) path.
      *
-     * @see Net_SFTP::chdir()
+     * @see self::chdir()
      * @param string $path
      * @return mixed
      * @access private
@@ -2699,7 +2699,7 @@ class Net_SFTP extends Net_SSH2
      *
      * @param int $type
      * @param string $data
-     * @see Net_SFTP::_get_sftp_packet()
+     * @see self::_get_sftp_packet()
      * @see Net_SSH2::_send_channel_packet()
      * @return bool
      * @access private
@@ -2741,7 +2741,7 @@ class Net_SFTP extends Net_SSH2
      * There can be one SSH_MSG_CHANNEL_DATA messages containing two SFTP packets or there can be two SSH_MSG_CHANNEL_DATA
      * messages containing one SFTP packet.
      *
-     * @see Net_SFTP::_send_sftp_packet()
+     * @see self::_send_sftp_packet()
      * @return string
      * @access private
      */

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -437,7 +437,7 @@ class Net_SSH1
     /**
      * Log Boundary
      *
-     * @see Net_SSH1::_format_log
+     * @see Net_SSH1::_format_log()
      * @access private
      */
     var $log_boundary = ':';
@@ -445,7 +445,7 @@ class Net_SSH1
     /**
      * Log Long Width
      *
-     * @see Net_SSH1::_format_log
+     * @see Net_SSH1::_format_log()
      * @access private
      */
     var $log_long_width = 65;
@@ -453,7 +453,7 @@ class Net_SSH1
     /**
      * Log Short Width
      *
-     * @see Net_SSH1::_format_log
+     * @see Net_SSH1::_format_log()
      * @access private
      */
     var $log_short_width = 16;

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -67,7 +67,7 @@
 /**#@+
  * Encryption Methods
  *
- * @see Net_SSH1::getSupportedCiphers()
+ * @see self::getSupportedCiphers()
  * @access public
  */
 /**
@@ -127,7 +127,7 @@ define('NET_SSH1_CIPHER_BLOWFISH',   6);
 /**#@+
  * Authentication Methods
  *
- * @see Net_SSH1::getSupportedAuthentications()
+ * @see self::getSupportedAuthentications()
  * @access public
  */
 /**
@@ -162,7 +162,7 @@ define('NET_SSH1_TTY_OP_END',  0);
 /**
  * The Response Type
  *
- * @see Net_SSH1::_get_binary_packet()
+ * @see self::_get_binary_packet()
  * @access private
  */
 define('NET_SSH1_RESPONSE_TYPE', 1);
@@ -170,7 +170,7 @@ define('NET_SSH1_RESPONSE_TYPE', 1);
 /**
  * The Response Data
  *
- * @see Net_SSH1::_get_binary_packet()
+ * @see self::_get_binary_packet()
  * @access private
  */
 define('NET_SSH1_RESPONSE_DATA', 2);
@@ -178,7 +178,7 @@ define('NET_SSH1_RESPONSE_DATA', 2);
 /**#@+
  * Execution Bitmap Masks
  *
- * @see Net_SSH1::bitmap
+ * @see self::bitmap
  * @access private
  */
 define('NET_SSH1_MASK_CONSTRUCTOR', 0x00000001);
@@ -189,7 +189,7 @@ define('NET_SSH1_MASK_SHELL',       0x00000008);
 
 /**#@+
  * @access public
- * @see Net_SSH1::getLog()
+ * @see self::getLog()
  */
 /**
  * Returns the message numbers
@@ -211,7 +211,7 @@ define('NET_SSH1_LOG_REALTIME_FILE', 4);
 
 /**#@+
  * @access public
- * @see Net_SSH1::read()
+ * @see self::read()
  */
 /**
  * Returns when a string matching $expect exactly is found
@@ -272,7 +272,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getServerKeyPublicExponent()
+     * @see self::getServerKeyPublicExponent()
      * @var string
      * @access private
      */
@@ -283,7 +283,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getServerKeyPublicModulus()
+     * @see self::getServerKeyPublicModulus()
      * @var string
      * @access private
      */
@@ -294,7 +294,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getHostKeyPublicExponent()
+     * @see self::getHostKeyPublicExponent()
      * @var string
      * @access private
      */
@@ -305,7 +305,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getHostKeyPublicModulus()
+     * @see self::getHostKeyPublicModulus()
      * @var string
      * @access private
      */
@@ -316,7 +316,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getSupportedCiphers()
+     * @see self::getSupportedCiphers()
      * @var array
      * @access private
      */
@@ -335,7 +335,7 @@ class Net_SSH1
      *
      * Logged for debug purposes
      *
-     * @see Net_SSH1::getSupportedAuthentications()
+     * @see self::getSupportedAuthentications()
      * @var array
      * @access private
      */
@@ -349,7 +349,7 @@ class Net_SSH1
     /**
      * Server Identification
      *
-     * @see Net_SSH1::getServerIdentification()
+     * @see self::getServerIdentification()
      * @var string
      * @access private
      */
@@ -358,7 +358,7 @@ class Net_SSH1
     /**
      * Protocol Flags
      *
-     * @see Net_SSH1::Net_SSH1()
+     * @see self::Net_SSH1()
      * @var array
      * @access private
      */
@@ -367,7 +367,7 @@ class Net_SSH1
     /**
      * Protocol Flag Log
      *
-     * @see Net_SSH1::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -376,7 +376,7 @@ class Net_SSH1
     /**
      * Message Log
      *
-     * @see Net_SSH1::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -385,7 +385,7 @@ class Net_SSH1
     /**
      * Real-time log file pointer
      *
-     * @see Net_SSH1::_append_log()
+     * @see self::_append_log()
      * @var resource
      * @access private
      */
@@ -394,7 +394,7 @@ class Net_SSH1
     /**
      * Real-time log file size
      *
-     * @see Net_SSH1::_append_log()
+     * @see self::_append_log()
      * @var int
      * @access private
      */
@@ -403,7 +403,7 @@ class Net_SSH1
     /**
      * Real-time log file wrap boolean
      *
-     * @see Net_SSH1::_append_log()
+     * @see self::_append_log()
      * @var bool
      * @access private
      */
@@ -412,7 +412,7 @@ class Net_SSH1
     /**
      * Interactive Buffer
      *
-     * @see Net_SSH1::read()
+     * @see self::read()
      * @var array
      * @access private
      */
@@ -421,7 +421,7 @@ class Net_SSH1
     /**
      * Timeout
      *
-     * @see Net_SSH1::setTimeout()
+     * @see self::setTimeout()
      * @access private
      */
     var $timeout;
@@ -429,7 +429,7 @@ class Net_SSH1
     /**
      * Current Timeout
      *
-     * @see Net_SSH1::_get_channel_packet()
+     * @see self::_get_channel_packet()
      * @access private
      */
     var $curTimeout;
@@ -437,7 +437,7 @@ class Net_SSH1
     /**
      * Log Boundary
      *
-     * @see Net_SSH1::_format_log()
+     * @see self::_format_log()
      * @access private
      */
     var $log_boundary = ':';
@@ -445,7 +445,7 @@ class Net_SSH1
     /**
      * Log Long Width
      *
-     * @see Net_SSH1::_format_log()
+     * @see self::_format_log()
      * @access private
      */
     var $log_long_width = 65;
@@ -453,7 +453,7 @@ class Net_SSH1
     /**
      * Log Short Width
      *
-     * @see Net_SSH1::_format_log()
+     * @see self::_format_log()
      * @access private
      */
     var $log_short_width = 16;
@@ -461,8 +461,8 @@ class Net_SSH1
     /**
      * Hostname
      *
-     * @see Net_SSH1::Net_SSH1()
-     * @see Net_SSH1::_connect()
+     * @see self::Net_SSH1()
+     * @see self::_connect()
      * @var string
      * @access private
      */
@@ -471,8 +471,8 @@ class Net_SSH1
     /**
      * Port Number
      *
-     * @see Net_SSH1::Net_SSH1()
-     * @see Net_SSH1::_connect()
+     * @see self::Net_SSH1()
+     * @see self::_connect()
      * @var int
      * @access private
      */
@@ -486,8 +486,8 @@ class Net_SSH1
      * however, is non-optional. There will be a timeout, whether or not you set it. If you don't it'll be
      * 10 seconds. It is used by fsockopen() in that function.
      *
-     * @see Net_SSH1::Net_SSH1()
-     * @see Net_SSH1::_connect()
+     * @see self::Net_SSH1()
+     * @see self::_connect()
      * @var int
      * @access private
      */
@@ -496,8 +496,8 @@ class Net_SSH1
     /**
      * Default cipher
      *
-     * @see Net_SSH1::Net_SSH1()
-     * @see Net_SSH1::_connect()
+     * @see self::Net_SSH1()
+     * @see self::_connect()
      * @var int
      * @access private
      */
@@ -821,8 +821,8 @@ class Net_SSH1
      *
      * Returns false on failure and the output, otherwise.
      *
-     * @see Net_SSH1::interactiveRead()
-     * @see Net_SSH1::interactiveWrite()
+     * @see self::interactiveRead()
+     * @see self::interactiveWrite()
      * @param string $cmd
      * @return mixed
      * @access public
@@ -871,8 +871,8 @@ class Net_SSH1
     /**
      * Creates an interactive shell
      *
-     * @see Net_SSH1::interactiveRead()
-     * @see Net_SSH1::interactiveWrite()
+     * @see self::interactiveRead()
+     * @see self::interactiveWrite()
      * @return bool
      * @access private
      */
@@ -915,7 +915,7 @@ class Net_SSH1
     /**
      * Inputs a command into an interactive shell.
      *
-     * @see Net_SSH1::interactiveWrite()
+     * @see self::interactiveWrite()
      * @param string $cmd
      * @return bool
      * @access public
@@ -931,7 +931,7 @@ class Net_SSH1
      * $expect can take the form of a string literal or, if $mode == NET_SSH1_READ_REGEX,
      * a regular expression.
      *
-     * @see Net_SSH1::write()
+     * @see self::write()
      * @param string $expect
      * @param int $mode
      * @return bool
@@ -971,7 +971,7 @@ class Net_SSH1
     /**
      * Inputs a command into an interactive shell.
      *
-     * @see Net_SSH1::interactiveRead()
+     * @see self::interactiveRead()
      * @param string $cmd
      * @return bool
      * @access public
@@ -1007,7 +1007,7 @@ class Net_SSH1
      * does not support ANSI escape sequences in Win32 Console applications", so if you're a Windows user,
      * there's not going to be much recourse.
      *
-     * @see Net_SSH1::interactiveRead()
+     * @see self::interactiveRead()
      * @return string
      * @access public
      */
@@ -1096,7 +1096,7 @@ class Net_SSH1
      * Also, this function could be improved upon by adding detection for the following exploit:
      * http://www.securiteam.com/securitynews/5LP042K3FY.html
      *
-     * @see Net_SSH1::_send_binary_packet()
+     * @see self::_send_binary_packet()
      * @return array
      * @access private
      */
@@ -1172,7 +1172,7 @@ class Net_SSH1
      *
      * Returns true on success, false on failure.
      *
-     * @see Net_SSH1::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @param string $data
      * @return bool
      * @access private
@@ -1219,8 +1219,8 @@ class Net_SSH1
      * we've reimplemented it. A more detailed discussion of the differences can be found after
      * $crc_lookup_table's initialization.
      *
-     * @see Net_SSH1::_get_binary_packet()
-     * @see Net_SSH1::_send_binary_packet()
+     * @see self::_get_binary_packet()
+     * @see self::_send_binary_packet()
      * @param string $data
      * @return int
      * @access private
@@ -1336,7 +1336,7 @@ class Net_SSH1
      * should be a number with the property that gcd($e, ($p - 1) * ($q - 1)) == 1.  Could just make anything that
      * calls this call modexp, instead, but I think this makes things clearer, maybe...
      *
-     * @see Net_SSH1::Net_SSH1()
+     * @see self::Net_SSH1()
      * @param Math_BigInteger $m
      * @param array $key
      * @return Math_BigInteger

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1942,7 +1942,7 @@ class Net_SSH2
      * @param mixed $password
      * @param mixed $...
      * @return bool
-     * @see _login
+     * @see Net_SSH2::_login()
      * @access public
      */
     function login($username)
@@ -1958,7 +1958,7 @@ class Net_SSH2
      * @param mixed $password
      * @param mixed $...
      * @return bool
-     * @see _login_helper
+     * @see Net_SSH2::_login_helper()
      * @access private
      */
     function _login($username)

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -69,7 +69,7 @@
 /**#@+
  * Execution Bitmap Masks
  *
- * @see Net_SSH2::bitmap
+ * @see self::bitmap
  * @access private
  */
 define('NET_SSH2_MASK_CONSTRUCTOR',   0x00000001);
@@ -92,8 +92,8 @@ define('NET_SSH2_MASK_WINDOW_ADJUST', 0x00000020);
  *     open request, and 'sender channel' is the channel number allocated by
  *     the other side.
  *
- * @see Net_SSH2::_send_channel_packet()
- * @see Net_SSH2::_get_channel_packet()
+ * @see self::_send_channel_packet()
+ * @see self::_get_channel_packet()
  * @access private
  */
 define('NET_SSH2_CHANNEL_EXEC',      0); // PuTTy uses 0x100
@@ -104,7 +104,7 @@ define('NET_SSH2_CHANNEL_AGENT_FORWARD', 3);
 
 /**#@+
  * @access public
- * @see Net_SSH2::getLog()
+ * @see self::getLog()
  */
 /**
  * Returns the message numbers
@@ -126,7 +126,7 @@ define('NET_SSH2_LOG_REALTIME_FILE', 4);
 
 /**#@+
  * @access public
- * @see Net_SSH2::read()
+ * @see self::read()
  */
 /**
  * Returns when a string matching $expect exactly is found
@@ -181,8 +181,8 @@ class Net_SSH2
     /**
      * Error information
      *
-     * @see Net_SSH2::getErrors()
-     * @see Net_SSH2::getLastError()
+     * @see self::getErrors()
+     * @see self::getLastError()
      * @var string
      * @access private
      */
@@ -191,7 +191,7 @@ class Net_SSH2
     /**
      * Server Identifier
      *
-     * @see Net_SSH2::getServerIdentification()
+     * @see self::getServerIdentification()
      * @var array|false
      * @access private
      */
@@ -200,7 +200,7 @@ class Net_SSH2
     /**
      * Key Exchange Algorithms
      *
-     * @see Net_SSH2::getKexAlgorithims()
+     * @see self::getKexAlgorithims()
      * @var array|false
      * @access private
      */
@@ -209,7 +209,7 @@ class Net_SSH2
     /**
      * Minimum Diffie-Hellman Group Bit Size in RFC 4419 Key Exchange Methods
      *
-     * @see Net_SSH2::_key_exchange()
+     * @see self::_key_exchange()
      * @var int
      * @access private
      */
@@ -218,7 +218,7 @@ class Net_SSH2
     /**
      * Preferred Diffie-Hellman Group Bit Size in RFC 4419 Key Exchange Methods
      *
-     * @see Net_SSH2::_key_exchange()
+     * @see self::_key_exchange()
      * @var int
      * @access private
      */
@@ -227,7 +227,7 @@ class Net_SSH2
     /**
      * Maximum Diffie-Hellman Group Bit Size in RFC 4419 Key Exchange Methods
      *
-     * @see Net_SSH2::_key_exchange()
+     * @see self::_key_exchange()
      * @var int
      * @access private
      */
@@ -236,7 +236,7 @@ class Net_SSH2
     /**
      * Server Host Key Algorithms
      *
-     * @see Net_SSH2::getServerHostKeyAlgorithms()
+     * @see self::getServerHostKeyAlgorithms()
      * @var array|false
      * @access private
      */
@@ -245,7 +245,7 @@ class Net_SSH2
     /**
      * Encryption Algorithms: Client to Server
      *
-     * @see Net_SSH2::getEncryptionAlgorithmsClient2Server()
+     * @see self::getEncryptionAlgorithmsClient2Server()
      * @var array|false
      * @access private
      */
@@ -254,7 +254,7 @@ class Net_SSH2
     /**
      * Encryption Algorithms: Server to Client
      *
-     * @see Net_SSH2::getEncryptionAlgorithmsServer2Client()
+     * @see self::getEncryptionAlgorithmsServer2Client()
      * @var array|false
      * @access private
      */
@@ -263,7 +263,7 @@ class Net_SSH2
     /**
      * MAC Algorithms: Client to Server
      *
-     * @see Net_SSH2::getMACAlgorithmsClient2Server()
+     * @see self::getMACAlgorithmsClient2Server()
      * @var array|false
      * @access private
      */
@@ -272,7 +272,7 @@ class Net_SSH2
     /**
      * MAC Algorithms: Server to Client
      *
-     * @see Net_SSH2::getMACAlgorithmsServer2Client()
+     * @see self::getMACAlgorithmsServer2Client()
      * @var array|false
      * @access private
      */
@@ -281,7 +281,7 @@ class Net_SSH2
     /**
      * Compression Algorithms: Client to Server
      *
-     * @see Net_SSH2::getCompressionAlgorithmsClient2Server()
+     * @see self::getCompressionAlgorithmsClient2Server()
      * @var array|false
      * @access private
      */
@@ -290,7 +290,7 @@ class Net_SSH2
     /**
      * Compression Algorithms: Server to Client
      *
-     * @see Net_SSH2::getCompressionAlgorithmsServer2Client()
+     * @see self::getCompressionAlgorithmsServer2Client()
      * @var array|false
      * @access private
      */
@@ -299,7 +299,7 @@ class Net_SSH2
     /**
      * Languages: Server to Client
      *
-     * @see Net_SSH2::getLanguagesServer2Client()
+     * @see self::getLanguagesServer2Client()
      * @var array|false
      * @access private
      */
@@ -308,7 +308,7 @@ class Net_SSH2
     /**
      * Languages: Client to Server
      *
-     * @see Net_SSH2::getLanguagesClient2Server()
+     * @see self::getLanguagesClient2Server()
      * @var array|false
      * @access private
      */
@@ -324,8 +324,8 @@ class Net_SSH2
      *
      *  -- http://tools.ietf.org/html/rfc4253#section-6
      *
-     * @see Net_SSH2::Net_SSH2()
-     * @see Net_SSH2::_send_binary_packet()
+     * @see self::Net_SSH2()
+     * @see self::_send_binary_packet()
      * @var int
      * @access private
      */
@@ -334,8 +334,8 @@ class Net_SSH2
     /**
      * Block Size for Client to Server Encryption
      *
-     * @see Net_SSH2::Net_SSH2()
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::Net_SSH2()
+     * @see self::_get_binary_packet()
      * @var int
      * @access private
      */
@@ -344,7 +344,7 @@ class Net_SSH2
     /**
      * Server to Client Encryption Object
      *
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @var object
      * @access private
      */
@@ -353,7 +353,7 @@ class Net_SSH2
     /**
      * Client to Server Encryption Object
      *
-     * @see Net_SSH2::_send_binary_packet()
+     * @see self::_send_binary_packet()
      * @var object
      * @access private
      */
@@ -362,7 +362,7 @@ class Net_SSH2
     /**
      * Client to Server HMAC Object
      *
-     * @see Net_SSH2::_send_binary_packet()
+     * @see self::_send_binary_packet()
      * @var object
      * @access private
      */
@@ -371,7 +371,7 @@ class Net_SSH2
     /**
      * Server to Client HMAC Object
      *
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @var object
      * @access private
      */
@@ -384,7 +384,7 @@ class Net_SSH2
      * For the client to server side, the HMAC object will make the HMAC as long as it needs to be.  All we need to do is
      * append it.
      *
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @var int
      * @access private
      */
@@ -393,7 +393,7 @@ class Net_SSH2
     /**
      * Server Public Host Key
      *
-     * @see Net_SSH2::getServerPublicHostKey()
+     * @see self::getServerPublicHostKey()
      * @var string
      * @access private
      */
@@ -408,7 +408,7 @@ class Net_SSH2
      *
      *  -- http://tools.ietf.org/html/rfc4253#section-7.2
      *
-     * @see Net_SSH2::_key_exchange()
+     * @see self::_key_exchange()
      * @var string
      * @access private
      */
@@ -419,7 +419,7 @@ class Net_SSH2
      *
      * The current exchange hash
      *
-     * @see Net_SSH2::_key_exchange()
+     * @see self::_key_exchange()
      * @var string
      * @access private
      */
@@ -428,7 +428,7 @@ class Net_SSH2
     /**
      * Message Numbers
      *
-     * @see Net_SSH2::Net_SSH2()
+     * @see self::Net_SSH2()
      * @var array
      * @access private
      */
@@ -437,7 +437,7 @@ class Net_SSH2
     /**
      * Disconnection Message 'reason codes' defined in RFC4253
      *
-     * @see Net_SSH2::Net_SSH2()
+     * @see self::Net_SSH2()
      * @var array
      * @access private
      */
@@ -446,7 +446,7 @@ class Net_SSH2
     /**
      * SSH_MSG_CHANNEL_OPEN_FAILURE 'reason codes', defined in RFC4254
      *
-     * @see Net_SSH2::Net_SSH2()
+     * @see self::Net_SSH2()
      * @var array
      * @access private
      */
@@ -456,7 +456,7 @@ class Net_SSH2
      * Terminal Modes
      *
      * @link http://tools.ietf.org/html/rfc4254#section-8
-     * @see Net_SSH2::Net_SSH2()
+     * @see self::Net_SSH2()
      * @var array
      * @access private
      */
@@ -466,7 +466,7 @@ class Net_SSH2
      * SSH_MSG_CHANNEL_EXTENDED_DATA's data_type_codes
      *
      * @link http://tools.ietf.org/html/rfc4254#section-5.2
-     * @see Net_SSH2::Net_SSH2()
+     * @see self::Net_SSH2()
      * @var array
      * @access private
      */
@@ -477,7 +477,7 @@ class Net_SSH2
      *
      * See 'Section 6.4.  Data Integrity' of rfc4253 for more info.
      *
-     * @see Net_SSH2::_send_binary_packet()
+     * @see self::_send_binary_packet()
      * @var int
      * @access private
      */
@@ -488,7 +488,7 @@ class Net_SSH2
      *
      * See 'Section 6.4.  Data Integrity' of rfc4253 for more info.
      *
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @var int
      * @access private
      */
@@ -499,8 +499,8 @@ class Net_SSH2
      *
      * Maps client channels to server channels
      *
-     * @see Net_SSH2::_get_channel_packet()
-     * @see Net_SSH2::exec()
+     * @see self::_get_channel_packet()
+     * @see self::exec()
      * @var array
      * @access private
      */
@@ -512,8 +512,8 @@ class Net_SSH2
      * If a client requests a packet from one channel but receives two packets from another those packets should
      * be placed in a buffer
      *
-     * @see Net_SSH2::_get_channel_packet()
-     * @see Net_SSH2::exec()
+     * @see self::_get_channel_packet()
+     * @see self::exec()
      * @var array
      * @access private
      */
@@ -524,7 +524,7 @@ class Net_SSH2
      *
      * Contains the type of the last sent message
      *
-     * @see Net_SSH2::_get_channel_packet()
+     * @see self::_get_channel_packet()
      * @var array
      * @access private
      */
@@ -535,7 +535,7 @@ class Net_SSH2
      *
      * Maximum packet size indexed by channel
      *
-     * @see Net_SSH2::_send_channel_packet()
+     * @see self::_send_channel_packet()
      * @var array
      * @access private
      */
@@ -544,7 +544,7 @@ class Net_SSH2
     /**
      * Message Number Log
      *
-     * @see Net_SSH2::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -553,7 +553,7 @@ class Net_SSH2
     /**
      * Message Log
      *
-     * @see Net_SSH2::getLog()
+     * @see self::getLog()
      * @var array
      * @access private
      */
@@ -565,8 +565,8 @@ class Net_SSH2
      * Bytes the other party can send before it must wait for the window to be adjusted (0x7FFFFFFF = 2GB)
      *
      * @var int
-     * @see Net_SSH2::_send_channel_packet()
-     * @see Net_SSH2::exec()
+     * @see self::_send_channel_packet()
+     * @see self::exec()
      * @access private
      */
     var $window_size = 0x7FFFFFFF;
@@ -576,7 +576,7 @@ class Net_SSH2
      *
      * Window size indexed by channel
      *
-     * @see Net_SSH2::_send_channel_packet()
+     * @see self::_send_channel_packet()
      * @var array
      * @access private
      */
@@ -587,7 +587,7 @@ class Net_SSH2
      *
      * Window size indexed by channel
      *
-     * @see Net_SSH2::_get_channel_packet()
+     * @see self::_get_channel_packet()
      * @var array
      * @access private
      */
@@ -598,7 +598,7 @@ class Net_SSH2
      *
      * Verified against $this->session_id
      *
-     * @see Net_SSH2::getServerPublicHostKey()
+     * @see self::getServerPublicHostKey()
      * @var string
      * @access private
      */
@@ -609,7 +609,7 @@ class Net_SSH2
      *
      * ssh-rsa or ssh-dss.
      *
-     * @see Net_SSH2::getServerPublicHostKey()
+     * @see self::getServerPublicHostKey()
      * @var string
      * @access private
      */
@@ -618,7 +618,7 @@ class Net_SSH2
     /**
      * Interactive Buffer
      *
-     * @see Net_SSH2::read()
+     * @see self::read()
      * @var array
      * @access private
      */
@@ -629,8 +629,8 @@ class Net_SSH2
      *
      * Should never exceed NET_SSH2_LOG_MAX_SIZE
      *
-     * @see Net_SSH2::_send_binary_packet()
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_send_binary_packet()
+     * @see self::_get_binary_packet()
      * @var int
      * @access private
      */
@@ -639,7 +639,7 @@ class Net_SSH2
     /**
      * Timeout
      *
-     * @see Net_SSH2::setTimeout()
+     * @see self::setTimeout()
      * @access private
      */
     var $timeout;
@@ -647,7 +647,7 @@ class Net_SSH2
     /**
      * Current Timeout
      *
-     * @see Net_SSH2::_get_channel_packet()
+     * @see self::_get_channel_packet()
      * @access private
      */
     var $curTimeout;
@@ -655,7 +655,7 @@ class Net_SSH2
     /**
      * Real-time log file pointer
      *
-     * @see Net_SSH2::_append_log()
+     * @see self::_append_log()
      * @var resource
      * @access private
      */
@@ -664,7 +664,7 @@ class Net_SSH2
     /**
      * Real-time log file size
      *
-     * @see Net_SSH2::_append_log()
+     * @see self::_append_log()
      * @var int
      * @access private
      */
@@ -673,7 +673,7 @@ class Net_SSH2
     /**
      * Has the signature been validated?
      *
-     * @see Net_SSH2::getServerPublicHostKey()
+     * @see self::getServerPublicHostKey()
      * @var bool
      * @access private
      */
@@ -682,7 +682,7 @@ class Net_SSH2
     /**
      * Real-time log file wrap boolean
      *
-     * @see Net_SSH2::_append_log()
+     * @see self::_append_log()
      * @access private
      */
     var $realtime_log_wrap;
@@ -690,7 +690,7 @@ class Net_SSH2
     /**
      * Flag to suppress stderr from output
      *
-     * @see Net_SSH2::enableQuietMode()
+     * @see self::enableQuietMode()
      * @access private
      */
     var $quiet_mode = false;
@@ -715,7 +715,7 @@ class Net_SSH2
      * Flag to request a PTY when using exec()
      *
      * @var bool
-     * @see Net_SSH2::enablePTY()
+     * @see self::enablePTY()
      * @access private
      */
     var $request_pty = false;
@@ -747,7 +747,7 @@ class Net_SSH2
     /**
      * The Last Interactive Response
      *
-     * @see Net_SSH2::_keyboard_interactive_process()
+     * @see self::_keyboard_interactive_process()
      * @var string
      * @access private
      */
@@ -756,7 +756,7 @@ class Net_SSH2
     /**
      * Keyboard Interactive Request / Responses
      *
-     * @see Net_SSH2::_keyboard_interactive_process()
+     * @see self::_keyboard_interactive_process()
      * @var array
      * @access private
      */
@@ -768,8 +768,8 @@ class Net_SSH2
      * Quoting from the RFC, "in some jurisdictions, sending a warning message before
      * authentication may be relevant for getting legal protection."
      *
-     * @see Net_SSH2::_filter()
-     * @see Net_SSH2::getBannerMessage()
+     * @see self::_filter()
+     * @see self::getBannerMessage()
      * @var string
      * @access private
      */
@@ -778,7 +778,7 @@ class Net_SSH2
     /**
      * Did read() timeout or return normally?
      *
-     * @see Net_SSH2::isTimeout()
+     * @see self::isTimeout()
      * @var bool
      * @access private
      */
@@ -787,7 +787,7 @@ class Net_SSH2
     /**
      * Log Boundary
      *
-     * @see Net_SSH2::_format_log()
+     * @see self::_format_log()
      * @var string
      * @access private
      */
@@ -796,7 +796,7 @@ class Net_SSH2
     /**
      * Log Long Width
      *
-     * @see Net_SSH2::_format_log()
+     * @see self::_format_log()
      * @var int
      * @access private
      */
@@ -805,7 +805,7 @@ class Net_SSH2
     /**
      * Log Short Width
      *
-     * @see Net_SSH2::_format_log()
+     * @see self::_format_log()
      * @var int
      * @access private
      */
@@ -814,8 +814,8 @@ class Net_SSH2
     /**
      * Hostname
      *
-     * @see Net_SSH2::Net_SSH2()
-     * @see Net_SSH2::_connect()
+     * @see self::Net_SSH2()
+     * @see self::_connect()
      * @var string
      * @access private
      */
@@ -824,8 +824,8 @@ class Net_SSH2
     /**
      * Port Number
      *
-     * @see Net_SSH2::Net_SSH2()
-     * @see Net_SSH2::_connect()
+     * @see self::Net_SSH2()
+     * @see self::_connect()
      * @var int
      * @access private
      */
@@ -834,9 +834,9 @@ class Net_SSH2
     /**
      * Number of columns for terminal window size
      *
-     * @see Net_SSH2::getWindowColumns()
-     * @see Net_SSH2::setWindowColumns()
-     * @see Net_SSH2::setWindowSize()
+     * @see self::getWindowColumns()
+     * @see self::setWindowColumns()
+     * @see self::setWindowSize()
      * @var int
      * @access private
      */
@@ -845,9 +845,9 @@ class Net_SSH2
     /**
      * Number of columns for terminal window size
      *
-     * @see Net_SSH2::getWindowRows()
-     * @see Net_SSH2::setWindowRows()
-     * @see Net_SSH2::setWindowSize()
+     * @see self::getWindowRows()
+     * @see self::setWindowRows()
+     * @see self::setWindowSize()
      * @var int
      * @access private
      */
@@ -856,8 +856,8 @@ class Net_SSH2
     /**
      * Crypto Engine
      *
-     * @see Net_SSH2::setCryptoEngine()
-     * @see Net_SSH2::_key_exchange()
+     * @see self::setCryptoEngine()
+     * @see self::_key_exchange()
      * @var int
      * @access private
      */
@@ -879,7 +879,7 @@ class Net_SSH2
      * @param mixed $host
      * @param int $port
      * @param int $timeout
-     * @see Net_SSH2::login()
+     * @see self::login()
      * @return Net_SSH2
      * @access public
      */
@@ -1942,7 +1942,7 @@ class Net_SSH2
      * @param mixed $password
      * @param mixed $...
      * @return bool
-     * @see Net_SSH2::_login()
+     * @see self::_login()
      * @access public
      */
     function login($username)
@@ -1958,7 +1958,7 @@ class Net_SSH2
      * @param mixed $password
      * @param mixed $...
      * @return bool
-     * @see Net_SSH2::_login_helper()
+     * @see self::_login_helper()
      * @access private
      */
     function _login($username)
@@ -2609,8 +2609,8 @@ class Net_SSH2
     /**
      * Creates an interactive shell
      *
-     * @see Net_SSH2::read()
-     * @see Net_SSH2::write()
+     * @see self::read()
+     * @see self::write()
      * @return bool
      * @access private
      */
@@ -2713,8 +2713,8 @@ class Net_SSH2
     /**
      * Return the channel to be used with read() / write()
      *
-     * @see Net_SSH2::read()
-     * @see Net_SSH2::write()
+     * @see self::read()
+     * @see self::write()
      * @return int
      * @access public
      */
@@ -2754,7 +2754,7 @@ class Net_SSH2
      * Returns when there's a match for $expect, which can take the form of a string literal or,
      * if $mode == NET_SSH2_READ_REGEX, a regular expression.
      *
-     * @see Net_SSH2::write()
+     * @see self::write()
      * @param string $expect
      * @param int $mode
      * @return string
@@ -2800,7 +2800,7 @@ class Net_SSH2
     /**
      * Inputs a command into an interactive shell.
      *
-     * @see Net_SSH2::read()
+     * @see self::read()
      * @param string $cmd
      * @return bool
      * @access public
@@ -2829,7 +2829,7 @@ class Net_SSH2
      * returns that and then that that was passed into stopSubsystem() but that'll be saved for a future date and implemented
      * if there's sufficient demand for such a feature.
      *
-     * @see Net_SSH2::stopSubsystem()
+     * @see self::stopSubsystem()
      * @param string $subsystem
      * @return bool
      * @access public
@@ -2892,7 +2892,7 @@ class Net_SSH2
     /**
      * Stops a subsystem.
      *
-     * @see Net_SSH2::startSubsystem()
+     * @see self::startSubsystem()
      * @return bool
      * @access public
      */
@@ -2969,7 +2969,7 @@ class Net_SSH2
      *
      * See '6. Binary Packet Protocol' of rfc4253 for more info.
      *
-     * @see Net_SSH2::_send_binary_packet()
+     * @see self::_send_binary_packet()
      * @return string
      * @access private
      */
@@ -3062,7 +3062,7 @@ class Net_SSH2
      *
      * Because some binary packets need to be ignored...
      *
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @return string
      * @access private
      */
@@ -3211,8 +3211,8 @@ class Net_SSH2
     /**
      * Returns whether Quiet Mode is enabled or not
      *
-     * @see Net_SSH2::enableQuietMode()
-     * @see Net_SSH2::disableQuietMode()
+     * @see self::enableQuietMode()
+     * @see self::disableQuietMode()
      *
      * @access public
      * @return bool
@@ -3245,8 +3245,8 @@ class Net_SSH2
     /**
      * Returns whether request-pty is enabled or not
      *
-     * @see Net_SSH2::enablePTY()
-     * @see Net_SSH2::disablePTY()
+     * @see self::enablePTY()
+     * @see self::disablePTY()
      *
      * @access public
      * @return bool
@@ -3479,7 +3479,7 @@ class Net_SSH2
      *
      * @param string $data
      * @param string $logged
-     * @see Net_SSH2::_get_binary_packet()
+     * @see self::_get_binary_packet()
      * @return bool
      * @access private
      */

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -101,7 +101,7 @@ class System_SSH_Agent_Identity
      *
      * @var Crypt_RSA
      * @access private
-     * @see System_SSH_Agent_Identity::getPublicKey()
+     * @see self::getPublicKey()
      */
     var $key;
 
@@ -110,7 +110,7 @@ class System_SSH_Agent_Identity
      *
      * @var string
      * @access private
-     * @see System_SSH_Agent_Identity::sign()
+     * @see self::sign()
      */
     var $key_blob;
 
@@ -119,7 +119,7 @@ class System_SSH_Agent_Identity
      *
      * @var resource
      * @access private
-     * @see System_SSH_Agent_Identity::sign()
+     * @see self::sign()
      */
     var $fsock;
 


### PR DESCRIPTION
A lot of the in-line comments for #827 had to do with the phpDoc syntax so this makes all current phpDoc calls consistent.

It also adds missing @return statements to four functions in Crypt/RSA.php.