### PR TITLE
Fix SFTP::chmod not using realpath on the filepath

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1454,6 +1454,7 @@ class Net_SFTP extends Net_SSH2
             return true;
         }
 
+        $filename = $this->_realPath($filename);
         // rather than return what the permissions *should* be, we'll return what they actually are.  this will also
         // tell us if the file actually exists.
         // incidentally, SFTPv4+ adds an additional 32-bit integer field - flags - to the following:

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -238,6 +238,20 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 
     /**
      * @depends testTruncate
+     * @group github850
+     */
+    public function testChModOnFile($sftp)
+    {
+        $this->assertNotFalse(
+            $sftp->chmod(0755, 'file1.txt'),
+            'Failed asserting that chmod() was successful.'
+        );
+
+        return $sftp;
+    }
+
+    /**
+     * @depends testChModOnFile
      */
     public function testChDirOnFile($sftp)
     {


### PR DESCRIPTION
Replaces #850 