### PR TITLE
Change PRIVATE_FORMAT_PKCS8 to unique value to fix conflict with PUBL…

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -188,7 +188,7 @@ class RSA
     /**
      * PKCS#8 formatted private key
      */
-    const PRIVATE_FORMAT_PKCS8 = 3;
+    const PRIVATE_FORMAT_PKCS8 = 8;
     /**#@-*/
 
     /**#@+


### PR DESCRIPTION
In ```Crypt\RSA``` class there were two constants with the same value, ```PUBLIC_FORMAT_RAW``` and ```PRIVATE_FORMAT_PKCS8```. This caused a bug in the ```_parseKey()``` method when ```$type``` was ```PRIVATE_FORMAT_PKCS8``` because the value would match the first case statement as if it was ```PUBLIC_FORMAT_RAW``` and it was unable to parse the key.

I picked the value of ```8``` because it was the next in series and was not already in use. 

Unit tests still pass for me so hopefully this is an easy PR to accept.