### PR TITLE
Removed the deprecated "--dev" argument from the recommended composer…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Dependencies are managed via Composer.
 2. Install Dependencies
 
     ``` sh
-    php composer.phar install --dev
+    php composer.phar install
     ```
 
 ## Contributing


### PR DESCRIPTION
… command.  When that argument is specified, composer prints the following:

You are using the deprecated option "dev". Dev packages are installed by default now.