### PR TITLE
Removed the deprecated "--dev" argument from the recommended composer…

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@ date_default_timezone_set('UTC');
 $loader_path = __DIR__ . '/../vendor/autoload.php';
 if (!file_exists($loader_path)) {
     echo "Dependencies must be installed using composer:\n\n";
-    echo "php composer.phar install --dev\n\n";
+    echo "php composer.phar install\n\n";
     echo "See http://getcomposer.org for help with installing composer\n";
     exit(1);
 }


### PR DESCRIPTION
… command.  When that argument is specified, composer prints the following:

You are using the deprecated option "dev". Dev packages are installed by default now.

Replaces #862