### PR TITLE
Enhanced disconnect on login failure handling

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2051,15 +2051,15 @@ class SSH2
                         $this->bitmap |= self::MASK_LOGIN;
                         return true;
                     }
-                    return false;
+                    return $this->_disconnect(NET_SSH2_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE);
                 }
-                return false;
+                return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
             case NET_SSH2_MSG_USERAUTH_SUCCESS:
                 $this->bitmap |= self::MASK_LOGIN;
                 return true;
         }
 
-        return false;
+        return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
     }
 
     /**


### PR DESCRIPTION
added disconnects to failure returns in _login_helper because otherwise MASK::CONNECTED will stay set (since it automatically calls _connect), although credentials are invalid or all supported authentication methods have been tried already.

I discovered this issue while using thephpleague/flysystem-sftp since they use isConnected() to check if a login is necessary. The first time this lib throws an exception while at the second attempt no exception will be thrown anymore and this is caused by Net/SFTP because it does not disconnect properly.

If you don't see this fix is a fix to be made inside your lib because it is not generic enough, please let me know so I possibly may implement a workaround calling disconnect for that specific case. 