### PR TITLE
RSA: fix PKCS8 key handling (again)

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -188,7 +188,7 @@ class RSA
     /**
      * PKCS#8 formatted private key
      */
-    const PRIVATE_FORMAT_PKCS8 = 3;
+    const PRIVATE_FORMAT_PKCS8 = 8;
     /**#@-*/
 
     /**#@+


### PR DESCRIPTION
Fixes #879 for 2.0 branch

This was fixed with #866 but I guess that commit got overwritten with a bad merge.

I note that #866 had a ton of extra commits. My guess is that did `git checkout -b rsa-pkcs8-fix-2.0` while in `rsa-pkcs8-fix-1.0` and then merged `2.0` into `rsa-pkcs8-fix-2.0`, instead of the other way around. That still doesn't explain why the commit just disappeared but it would explain all the extra commits in #866.