### PR TITLE
RSA: changes to how encryption / signatures work

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -402,7 +402,7 @@ class RSA
      * @param int $timeout
      * @param array $p
      */
-    static function createKey($bits = 1024, $timeout = false, $partial = array())
+    static function createKey($bits = 2048, $timeout = false, $partial = array())
     {
         self::_initialize_static_variables();
 

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -2149,8 +2149,7 @@ class X509
                     case 'sha384WithRSAEncryption':
                     case 'sha512WithRSAEncryption':
                         $rsa->setHash(preg_replace('#WithRSAEncryption$#', '', $signatureAlgorithm));
-                        $rsa->setSignatureMode(RSA::SIGNATURE_PKCS1);
-                        if (!@$rsa->verify($signatureSubject, $signature)) {
+                        if (!@$rsa->verify($signatureSubject, $signature, RSA::PADDING_PKCS1)) {
                             return false;
                         }
                         break;
@@ -3671,9 +3670,8 @@ class X509
                 case 'sha384WithRSAEncryption':
                 case 'sha512WithRSAEncryption':
                     $key->setHash(preg_replace('#WithRSAEncryption$#', '', $signatureAlgorithm));
-                    $key->setSignatureMode(RSA::SIGNATURE_PKCS1);
 
-                    $this->currentCert['signature'] = base64_encode("\0" . $key->sign($this->signatureSubject));
+                    $this->currentCert['signature'] = base64_encode("\0" . $key->sign($this->signatureSubject, RSA::PADDING_PKCS1));
                     return $this->currentCert;
                 default:
                     throw new UnsupportedAlgorithmException('Signature algorithm unsupported');

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -1302,8 +1302,7 @@ class SSH1
         /*
         $rsa = new RSA();
         $rsa->load($key, 'raw');
-        $rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);
-        return $rsa->encrypt($m);
+        return $rsa->encrypt($m, RSA::PADDING_PKCS1);
         */
 
         // To quote from protocol-1.5.txt:

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2306,8 +2306,7 @@ class SSH2
         }
 
         $packet = $part1 . chr(1) . $part2;
-        $privatekey->setSignatureMode(RSA::SIGNATURE_PKCS1);
-        $signature = $privatekey->sign(pack('Na*a*', strlen($this->session_id), $this->session_id, $packet));
+        $signature = $privatekey->sign(pack('Na*a*', strlen($this->session_id), $this->session_id, $packet), RSA::PADDING_PKCS1);
         $signature = pack('Na*Na*', strlen('ssh-rsa'), 'ssh-rsa', strlen($signature), $signature);
         $packet.= pack('Na*', strlen($signature), $signature);
 
@@ -4054,9 +4053,8 @@ class SSH2
                 $signature = $this->_string_shift($signature, $temp['length']);
 
                 $rsa = new RSA();
-                $rsa->setSignatureMode(RSA::SIGNATURE_PKCS1);
                 $rsa->load(array('e' => $e, 'n' => $n), 'raw');
-                if (!$rsa->verify($this->exchange_hash, $signature)) {
+                if (!$rsa->verify($this->exchange_hash, $signature, RSA::PADDING_PKCS1)) {
                     //user_error('Bad server signature');
                     return $this->_disconnect(NET_SSH2_DISCONNECT_HOST_KEY_NOT_VERIFIABLE);
                 }

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -16,6 +16,8 @@
 namespace phpseclib\System\SSH\Agent;
 
 use phpseclib\System\SSH\Agent;
+use phpseclib\Crypt\RSA;
+use phpseclib\Exception\UnsupportedAlgorithmException;
 
 /**
  * Pure-PHP ssh-agent client identity object
@@ -122,10 +124,15 @@ class Identity
      * @param int|bool $padding
      * @return string
      * @throws \RuntimeException on connection errors
+     * @throws \phpseclib\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
      * @access public
      */
-    function sign($message, $padding = false)
+    function sign($message, $padding = RSA::PADDING_PSS)
     {
+        if ($padding != RSA::PADDING_PKCS1 && $padding != RSA::PADDING_RELAXED_PKCS1) {
+            throw new \UnsupportedAlgorithmException('ssh-agent can only create PKCS1 signatures');
+        }
+
         // the last parameter (currently 0) is for flags and ssh-agent only defines one flag (for ssh-dss): SSH_AGENT_OLD_SIGNATURE
         $packet = pack('CNa*Na*N', Agent::SSH_AGENTC_SIGN_REQUEST, strlen($this->key_blob), $this->key_blob, strlen($message), $message, 0);
         $packet = pack('Na*', strlen($packet), $packet);

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -106,13 +106,13 @@ class Identity
      *
      * Wrapper for $this->key->getPublicKey()
      *
-     * @param int $format optional
+     * @param int $type optional
      * @return mixed
      * @access public
      */
-    function getPublicKey($format = null)
+    function getPublicKey($type = 'PKCS8')
     {
-        return !isset($format) ? $this->key->getPublicKey() : $this->key->getPublicKey($format);
+        return $this->key->getPublicKey($type);
     }
 
     /**
@@ -121,13 +121,13 @@ class Identity
      * See "2.6.2 Protocol 2 private key signature request"
      *
      * @param string $message
-     * @param int|bool $padding
+     * @param int $padding optional
      * @return string
      * @throws \RuntimeException on connection errors
      * @throws \phpseclib\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
      * @access public
      */
-    function sign($message, $padding = RSA::PADDING_PSS)
+    function sign($message, $padding = RSA::PADDING_PKCS1)
     {
         if ($padding != RSA::PADDING_PKCS1 && $padding != RSA::PADDING_RELAXED_PKCS1) {
             throw new \UnsupportedAlgorithmException('ssh-agent can only create PKCS1 signatures');

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -23,9 +23,8 @@ use phpseclib\System\SSH\Agent;
  * Instantiation should only be performed by \phpseclib\System\SSH\Agent class.
  * This could be thought of as implementing an interface that phpseclib\Crypt\RSA
  * implements. ie. maybe a Net_SSH_Auth_PublicKey interface or something.
- * The methods in this interface would be getPublicKey, setSignatureMode
- * and sign since those are the methods phpseclib looks for to perform
- * public key authentication.
+ * The methods in this interface would be getPublicKey and sign since those are the
+ * methods phpseclib looks for to perform public key authentication.
  *
  * @package SSH\Agent
  * @author  Jim Wigginton <terrafrost@php.net>
@@ -115,29 +114,17 @@ class Identity
     }
 
     /**
-     * Set Signature Mode
-     *
-     * Doesn't do anything as ssh-agent doesn't let you pick and choose the signature mode. ie.
-     * ssh-agent's only supported mode is \phpseclib\Crypt\RSA::SIGNATURE_PKCS1
-     *
-     * @param int $mode
-     * @access public
-     */
-    function setSignatureMode($mode)
-    {
-    }
-
-    /**
      * Create a signature
      *
      * See "2.6.2 Protocol 2 private key signature request"
      *
      * @param string $message
+     * @param int|bool $padding
      * @return string
      * @throws \RuntimeException on connection errors
      * @access public
      */
-    function sign($message)
+    function sign($message, $padding = false)
     {
         // the last parameter (currently 0) is for flags and ssh-agent only defines one flag (for ssh-dss): SSH_AGENT_OLD_SIGNATURE
         $packet = pack('CNa*Na*N', Agent::SSH_AGENTC_SIGN_REQUEST, strlen($this->key_blob), $this->key_blob, strlen($message), $message, 0);

--- a/tests/Unit/Crypt/RSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/RSA/CreateKeyTest.php
@@ -11,7 +11,7 @@ class Unit_Crypt_RSA_CreateKeyTest extends PhpseclibTestCase
 {
     public function testCreateKey()
     {
-        extract(RSA::createKey(512));
+        extract(RSA::createKey(768));
         $this->assertInstanceOf('\phpseclib\Crypt\RSA', $privatekey);
         $this->assertInstanceOf('\phpseclib\Crypt\RSA', $publickey);
         $this->assertNotEmpty("$privatekey");

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -32,17 +32,16 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
         $rsa->load($privatekey);
         $rsa->load($rsa->getPublicKey());
 
-        $rsa->setEncryptionMode(RSA::ENCRYPTION_NONE);
         $expected = '105b92f59a87a8ad4da52c128b8c99491790ef5a54770119e0819060032fb9e772ed6772828329567f3d7e9472154c1530f8156ba7fd732f52ca1c06' .
             '5a3f5ed8a96c442e4662e0464c97f133aed31262170201993085a589565d67cc9e727e0d087e3b225c8965203b271e38a499c92fc0d6502297eca712' .
             '4d04bd467f6f1e7c';
         $expected = pack('H*', $expected);
-        $result = $rsa->encrypt($plaintext);
+        $result = $rsa->encrypt($plaintext, RSA::PADDING_NONE);
 
         $this->assertEquals($result, $expected);
 
         $rsa->load($privatekey);
-        $this->assertEquals(trim($rsa->decrypt($result), "\0"), $plaintext);
+        $this->assertEquals(trim($rsa->decrypt($result, RSA::PADDING_NONE), "\0"), $plaintext);
     }
 
     /**
@@ -51,6 +50,8 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
     public function testPSSSigs()
     {
         $rsa = new RSA();
+        $rsa->setHash('sha1');
+        $rsa->setMGFHash('sha1');
         $rsa->load('-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVx
 wTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFnc
@@ -77,5 +78,25 @@ p0GbMJDyR4e9T04ZZwIDAQAB
         $rsa = new RSA();
         $rsa->load(array('n' => $n, 'e' => $e));
         $rsa->encrypt($plaintext);
+    }
+
+    public function testPKCS1LooseVerify()
+    {
+        $rsa = new RSA();
+        $rsa->load('-----BEGIN RSA PUBLIC KEY-----
+MIGJAoGBAMuqkz8ij+ESAaNvgocVGmapjlrIldmhRo4h2NX4e6IXiCLTSxASQtY4
+iqRnmyxqQSfaan2okTfQ6sP95bl8Qz8lgneW3ClC6RXG/wpJgsx7TXQ2kodlcKBF
+m4k72G75QXhZ+I40ZG7cjBf1/9egakR0a0X0MpeOrKCzMBLv9+mpAgMBAAE=
+-----END RSA PUBLIC KEY-----');
+
+        $message = base64_decode('MYIBLjAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0xNDA1MTUxNDM4MzRaMC8GCSqGSIb3DQEJBDEiBCBLzLIBGdOf0L2WRrIY' .
+            '9KTwiHnReBW48S9C7LNRaPp5mDCBwgYLKoZIhvcNAQkQAi8xgbIwga8wgawwgakEIJDB9ZGwihf+TaiwrHQNkNHkqbN8Nuws0e77QNObkvFZMIGEMHCkbjBs' .
+            'MQswCQYDVQQGEwJJVDEYMBYGA1UECgwPQXJ1YmFQRUMgUy5wLkEuMSEwHwYDVQQLDBhDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eUMxIDAeBgNVBAMMF0FydWJh' .
+            'UEVDIFMucC5BLiBORyBDQSAzAhAv4L3QcFssQNLDYN/Vu40R');
+
+        $sig = base64_decode('XDSZWw6IcUj8ICxRJf04HzF8stzoiFAZSR2a0Rw3ziZxTOT0/NVUYJO5+9TaaREXEgxuCLpgmA+6W2SWrrGoxbbNfaI90ZoKeOAws4IX+9RfiWuooibjKcvt' .
+            'GJYVVOCcjvQYxUUNbQ4EjCUonk3h7ECXfCCmWqbeq2LsyXeeYGE=');
+
+        $this->assertTrue($rsa->verify($message, $sig, RSA::PADDING_RELAXED_PKCS1));
     }
 }


### PR DESCRIPTION
- setEncryptionMode() / setSignatureMode() methods have been removed.
  instead you'll do `$rsa->verify($message, $signature, RSA::PADDING_PKCS1)` or whatever. the defaults remain the same as before. ie. `$rsa->verify($message, $signature)` still does PSS signatures (altho it now does them with sha256 for the hash and MGF). i thought about making it so that `$rsa->verify($message, $signature)` would try both `RSA::PADDING_PSS` and `RSA_PADDING_PKCS` in the same way that RSA.php brute forces key formats but decided against it. the reason being that a lot of the success of `verify()` and `decrypt()` depend on the hash algorithms being used and i don't want to brute force those as well.

- added a new signature verification mode - RSA::PADDING_RELAXED_PKCS1.
  in rare cases it might succeed where RSA_PADDING_PKCS1 doesn't. see the comments in RSA.php and the unit test for more info.

- added a new encryption mode - RSA::PADDING_PKCS15_COMPAT.
  replaces `define('CRYPT_RSA_PKCS15_COMPAT', true)`.

- the default hash algorithm is now sha256.
  i had considered making the MGF1 hash algorithm still stay as sha1 since that's [kinda what Java does](http://stackoverflow.com/questions/32161720/breaking-down-rsa-ecb-oaepwithsha-256andmgf1padding) with `RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING` but i ultimately decided against it since that's [not what OpenSSL does for PSS signatures](http://crypto.stackexchange.com/questions/31430/setting-the-mgf-hash-to-a-different-value-other-than-the-regular-hash-with-opens). if you want to be compatable with `RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING` you'll need to manually change the MGF hash instead of having it work out of the box.

- return false instead of throwing exceptions on errors.
  http://tools.ietf.org/html/rfc3447#page-32 says to "output 'invalid signature' and stop" on various errors, hence the throwing of exceptions. however, it also says to "output 'invalid signature'" or   "valid signature" depending on the output of EMSA-PSS-VERIFY. so, pretty much, anytime only "invalid signature" is being thrown we're now instead returning false. if a different message other than "invalid signature" is to be output we'll continue to use exceptions.

- PKCS1 v2.2 remains unsupported.
  the difference between v2.1 and v2.2 is that v2.2 adds support for sha512/224 and sha512/256 as hashes. the problem is that PHP's built-in hash algorithm does not support them. a bug ticket exists for this:
  https://bugs.php.net/71177
  phpseclib's Hash class, in the 1.0 and 2.0 branches, has pure-PHP implementations of sha256 and sha512, which it uses if the hash extension (or mhash) is unavailable. PHP 5.3 included the hash extension by default, which kinda rendered the pure-PHP implementations moot and thus they were removed in the master branch, but maybe we could go back to this approach for sha512/224 and sha512/256. but that can be done in another PR too if there's sufficient interest in it.