### PR TITLE
Updated README.md with example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ SSH into a server with a private key, execute two commands and print the result.
 include 'vendor/autoload.php';
 
 $key = new phpseclib\Crypt\RSA();
-$key->loadKey(file_get_contents('private key'));
+$key->loadKey(file_get_contents('private-key.txt'));
 
 // Domain can be an IP too
 $ssh = new phpseclib\Net\SSH2('www.domain.tld');

--- a/README.md
+++ b/README.md
@@ -63,3 +63,26 @@ Dependencies are managed via Composer.
     ```
 
 6. Send us a Pull Request
+
+
+## Examples
+
+SSH into a server with a private key, execute two commands and print the result.
+
+```
+<?php
+
+include 'vendor/autoload.php';
+
+$key = new \phpseclib\Crypt\RSA();
+$key->loadKey(file_get_contents('private key'));
+
+// Domain can be an IP too
+$ssh = new \phpseclib\Net\SSH2('www.domain.tld');
+if (!$ssh->login('username', $key)) {
+    exit('Login Failed');
+}
+
+echo $ssh->exec('pwd');
+echo $ssh->exec('ls -la');
+```

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ SSH into a server with a private key, execute two commands and print the result.
 
 include 'vendor/autoload.php';
 
-$key = new \phpseclib\Crypt\RSA();
+$key = new phpseclib\Crypt\RSA();
 $key->loadKey(file_get_contents('private key'));
 
 // Domain can be an IP too
-$ssh = new \phpseclib\Net\SSH2('www.domain.tld');
+$ssh = new phpseclib\Net\SSH2('www.domain.tld');
 if (!$ssh->login('username', $key)) {
     exit('Login Failed');
 }


### PR DESCRIPTION
Added a *working* example to the read me. The [docs](http://phpseclib.sourceforge.net/ssh/auth.html#rsakey) seems to be a bit outdated.

I really think you should have some example code in the readme so people easily can use this library. It took me ~15 minutes to figure out how to use the library.