### PR TITLE
Exclude some dirs and files from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 * text=auto
+/build/ export-ignore
+/tests/ export-ignore
+/travis/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
People that install phpseclib via composer don't need the build, test and other runtime useless files.
This PR removes these directories and files from the repository auto-generated ZIP archives.