### PR TITLE
RSA: error out when encrypting strings that are too long

### DIFF
--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -67,7 +67,7 @@ p0GbMJDyR4e9T04ZZwIDAQAB
     }
 
     /**
-     * @expectedException \LengthException
+     * @expectedException \OutOfBoundsException
      */
     public function testSmallModulo()
     {


### PR DESCRIPTION
Currently, when you pass a string longer than the modulo to either encrypt or decrypt phpseclib splits the message up into smaller chunks and encrypts each chunk. I still stand by it as being a perfectly valid thing to be doing (see https://github.com/phpseclib/phpseclib/issues/135#issuecomment-21660586). Further, I think it's kinda the "PHP way" to silently deal with errors. But, that said, if I'm going to be [throwing IVs when none are provided](https://github.com/phpseclib/phpseclib/issues/907#issuecomment-168563911) (instead of using a "null string"), then maybe other "silent errors" ought to be handled differently as well.

For BC purposes the 1.0 and 2.0 branches will never do this.

(I was reminded of this by considering whether or not the `\LengthException` thrown in `encrypt` ought to be thrown since, for example, `_rsaes_pkcs1_v1_5_encrypt` does length checking as well; the answer is that it does need to be thrown still - if it's too small `str_pad` will it's second parameter be negative, which'll result in warnings)