### PR TITLE
TravisCI: dont use openssl with composer for PHP 5.3.3

### DIFF
--- a/travis/setup-composer.sh
+++ b/travis/setup-composer.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
-composer self-update --no-interaction
+if [ "$TRAVIS_PHP_VERSION" == "5.3.3" ]
+then
+    # openssl is disabled on travis ci on 5.3.3:
+    # https://docs.travis-ci.com/user/languages/php#PHP-installation
+    composer self-update --no-interaction --disable-tls
+else
+    composer self-update --no-interaction
+fi
 composer install --no-interaction


### PR DESCRIPTION
See https://travis-ci.org/phpseclib/phpseclib/jobs/102928259 and https://docs.travis-ci.com/user/languages/php#PHP-installation