### PR TITLE
Cleanup of `use` operator usage

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -49,8 +49,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Rijndael;
-
 /**
  * Pure-PHP implementation of AES.
  *

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -36,8 +36,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Hash;
-
 /**
  * Base Class for all \phpseclib\Crypt\* cipher classes
  *

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -37,8 +37,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Blowfish.
  *

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -42,8 +42,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of DES.
  *

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -35,8 +35,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of RC2.
  *

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -44,8 +44,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of RC4.
  *

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -45,8 +45,8 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Math\BigInteger;
 use phpseclib\File\ASN1;
+use phpseclib\Math\BigInteger;
 
 /**
  * Pure-PHP PKCS#1 compliant implementation of RSA.

--- a/phpseclib/Crypt/RSA/PKCS.php
+++ b/phpseclib/Crypt/RSA/PKCS.php
@@ -14,10 +14,10 @@
 
 namespace phpseclib\Crypt\RSA;
 
-use phpseclib\Crypt\Base;
 use phpseclib\Crypt\AES;
-use phpseclib\Crypt\TripleDES;
+use phpseclib\Crypt\Base;
 use phpseclib\Crypt\DES;
+use phpseclib\Crypt\TripleDES;
 use phpseclib\Math\BigInteger;
 
 /**

--- a/phpseclib/Crypt/RSA/PKCS1.php
+++ b/phpseclib/Crypt/RSA/PKCS1.php
@@ -22,12 +22,11 @@
 
 namespace phpseclib\Crypt\RSA;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\RSA\PKCS;
-use phpseclib\Crypt\Random;
 use phpseclib\Crypt\AES;
-use phpseclib\Crypt\TripleDES;
 use phpseclib\Crypt\DES;
+use phpseclib\Crypt\Random;
+use phpseclib\Crypt\TripleDES;
+use phpseclib\Math\BigInteger;
 
 /**
  * PKCS#1 Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/PKCS8.php
+++ b/phpseclib/Crypt/RSA/PKCS8.php
@@ -24,10 +24,9 @@
 
 namespace phpseclib\Crypt\RSA;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\RSA\PKCS;
-use phpseclib\Crypt\Random;
 use phpseclib\Crypt\DES;
+use phpseclib\Crypt\Random;
+use phpseclib\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/PuTTY.php
+++ b/phpseclib/Crypt/RSA/PuTTY.php
@@ -14,10 +14,9 @@
 
 namespace phpseclib\Crypt\RSA;
 
-use phpseclib\Math\BigInteger;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\RSA\OpenSSH;
+use phpseclib\Math\BigInteger;
 
 /**
  * PuTTY Formatted RSA Key Handler

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -24,14 +24,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Base;
-use phpseclib\Crypt\Blowfish;
-use phpseclib\Crypt\DES;
-use phpseclib\Crypt\RC4;
-use phpseclib\Crypt\TripleDES;
-use phpseclib\Crypt\Twofish;
-
 /**
  * Pure-PHP Random Number Generator
  *

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -54,8 +54,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Rijndael.
  *

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -36,9 +36,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-use phpseclib\Crypt\DES;
-
 /**
  * Pure-PHP implementation of Triple DES.
  *

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -37,8 +37,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Twofish.
  *

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -27,12 +27,11 @@
 namespace phpseclib\File;
 
 use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\RSA;
 use phpseclib\Crypt\Random;
-use phpseclib\File\ASN1;
+use phpseclib\Crypt\RSA;
+use phpseclib\Exception\UnsupportedAlgorithmException;
 use phpseclib\File\ASN1\Element;
 use phpseclib\Math\BigInteger;
-use phpseclib\Exception\UnsupportedAlgorithmException;
 
 /**
  * Pure-PHP X.509 Parser

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -32,8 +32,6 @@
 
 namespace phpseclib\Net;
 
-use phpseclib\Net\SSH1;
-use phpseclib\Net\SSH2;
 use phpseclib\Exception\FileNotFoundException;
 
 /**

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -37,7 +37,6 @@
 
 namespace phpseclib\Net;
 
-use phpseclib\Net\SSH2;
 use phpseclib\Exception\FileNotFoundException;
 
 /**

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -34,8 +34,8 @@
 namespace phpseclib\System\SSH;
 
 use phpseclib\Crypt\RSA;
-use phpseclib\System\SSH\Agent\Identity;
 use phpseclib\Exception\BadConfigurationException;
+use phpseclib\System\SSH\Agent\Identity;
 
 /**
  * Pure-PHP ssh-agent client identity factory

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -15,9 +15,9 @@
 
 namespace phpseclib\System\SSH\Agent;
 
-use phpseclib\System\SSH\Agent;
 use phpseclib\Crypt\RSA;
 use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib\System\SSH\Agent;
 
 /**
  * Pure-PHP ssh-agent client identity object


### PR DESCRIPTION
This does the following:

1. Removes superfluous usage of the `use` operator. Specifically, that operator is not needed to use classes in the same `namespace` (see https://secure.php.net/manual/en/language.namespaces.rules.php). E.g.:

  ```php
  namespace some\namespace;

  use some\namespace\SomeClass; // this is not needed

  class MyClass
  {
      $a = new SomeClass;
  }
  ```

  It would only be needed, if "aliasing" was used (see https://secure.php.net/manual/en/language.namespaces.importing.php), e.g.:

  ```php
  namespace some\namespace;

  use some\other\namespace\SomeClass;
  use some\namespace\SomeClass as MySomeClass; // aliased due to name clash (e.g. introduced at a later time, aliased to not have to adapt the code if aliasing the above class instead)

  class MyClass
  {
      $a = new SomeClass;    // this is some\other\namespace\SomeClass
      $b = new MySomeClass;  // this is some\namespace\SomeClass
  }
  ```

2. While at it, also sorted the `use` operators alphabetically, for a better overview.