### PR TITLE
Taking over cleanup of `use` operator usage to the 2.0 branch

### DIFF
--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -49,8 +49,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Rijndael;
-
 /**
  * Pure-PHP implementation of AES.
  *

--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -36,8 +36,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Hash;
-
 /**
  * Base Class for all \phpseclib\Crypt\* cipher classes
  *

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -37,8 +37,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Blowfish.
  *

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -42,8 +42,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of DES.
  *

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -35,8 +35,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of RC2.
  *

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -44,8 +44,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of RC4.
  *

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -51,13 +51,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Base;
-use phpseclib\Crypt\DES;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\TripleDES;
 use phpseclib\Math\BigInteger;
 
 /**

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -24,14 +24,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Base;
-use phpseclib\Crypt\Blowfish;
-use phpseclib\Crypt\DES;
-use phpseclib\Crypt\RC4;
-use phpseclib\Crypt\TripleDES;
-use phpseclib\Crypt\Twofish;
-
 /**
  * Pure-PHP Random Number Generator
  *

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -54,8 +54,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Rijndael.
  *

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -36,9 +36,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-use phpseclib\Crypt\DES;
-
 /**
  * Pure-PHP implementation of Triple DES.
  *

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -37,8 +37,6 @@
 
 namespace phpseclib\Crypt;
 
-use phpseclib\Crypt\Base;
-
 /**
  * Pure-PHP implementation of Twofish.
  *

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -27,9 +27,8 @@
 namespace phpseclib\File;
 
 use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\RSA;
 use phpseclib\Crypt\Random;
-use phpseclib\File\ASN1;
+use phpseclib\Crypt\RSA;
 use phpseclib\File\ASN1\Element;
 use phpseclib\Math\BigInteger;
 

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -32,9 +32,6 @@
 
 namespace phpseclib\Net;
 
-use phpseclib\Net\SSH1;
-use phpseclib\Net\SSH2;
-
 /**
  * Pure-PHP implementations of SCP.
  *

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -37,8 +37,6 @@
 
 namespace phpseclib\Net;
 
-use phpseclib\Net\SSH2;
-
 /**
  * Pure-PHP implementations of SFTP.
  *


### PR DESCRIPTION
As per https://github.com/phpseclib/phpseclib/pull/928#issuecomment-173621562: Taking over the `use` operator usage clean-up to the 2.0 branch:

1. Cherry-picked c9a80ff748d6b64a66cb3fc20db4608305279af2 to the 2.0 branch and resolved conflicts.
2. Checked if other files of the 2.0 branch are affected - none found.