### PR TITLE
Remove the dependency on phpinfo()

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -416,37 +416,17 @@ class RSA
                     break;
                 case extension_loaded('openssl') && file_exists(self::$configFile):
                     // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
-                    ob_start();
-                    @phpinfo();
-                    $content = ob_get_contents();
-                    ob_end_clean();
-
-                    preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
-
-                    $versions = array();
-                    if (!empty($matches[1])) {
-                        for ($i = 0; $i < count($matches[1]); $i++) {
-                            $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
-
-                            // Remove letter part in OpenSSL version
-                            if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
-                                $versions[$matches[1][$i]] = $fullVersion;
-                            } else {
-                                $versions[$matches[1][$i]] = $m[0];
-                            }
-                        }
-                    }
-
-                    // it doesn't appear that OpenSSL versions were reported upon until PHP 5.3+
-                    switch (true) {
-                        case !isset($versions['Header']):
-                        case !isset($versions['Library']):
-                        case $versions['Header'] == $versions['Library']:
-                            define('CRYPT_RSA_MODE', self::MODE_OPENSSL);
-                            break;
-                        default:
-                            define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
-                            define('MATH_BIGINTEGER_OPENSSL_DISABLE', true);
+                    // This used to rely on phpinfo, but that is disabled in
+                    // common secure environments. Instead, assume that if the
+                    // library version is high enough we'll be fine (which we
+                    // will).  The first 1.0.1 heartbleed fixed level is picked
+                    // here, as users shouldn't be running lower anyway. 1.0.0
+                    // and below are no longer supported.
+                    if (OPENSSL_VERSION_NUMBER >= 0x1000107f) {
+                        define('CRYPT_RSA_MODE', self::MODE_OPENSSL);
+                    } else {
+                        define('CRYPT_RSA_MODE', self::MODE_INTERNAL);
+                        define('MATH_BIGINTEGER_OPENSSL_DISABLE', true);
                     }
                     break;
                 default:

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -266,36 +266,16 @@ class BigInteger
 
         if (extension_loaded('openssl') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
             // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
-            ob_start();
-            @phpinfo();
-            $content = ob_get_contents();
-            ob_end_clean();
-
-            preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
-
-            $versions = array();
-            if (!empty($matches[1])) {
-                for ($i = 0; $i < count($matches[1]); $i++) {
-                    $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
-
-                    // Remove letter part in OpenSSL version
-                    if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
-                        $versions[$matches[1][$i]] = $fullVersion;
-                    } else {
-                        $versions[$matches[1][$i]] = $m[0];
-                    }
-                }
-            }
-
-            // it doesn't appear that OpenSSL versions were reported upon until PHP 5.3+
-            switch (true) {
-                case !isset($versions['Header']):
-                case !isset($versions['Library']):
-                case $versions['Header'] == $versions['Library']:
-                    define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
-                    break;
-                default:
-                    define('MATH_BIGINTEGER_OPENSSL_DISABLE', true);
+            // This used to rely on phpinfo, but that is disabled in
+            // common secure environments. Instead, assume that if the
+            // library version is high enough we'll be fine (which we
+            // will).  The first 1.0.1 heartbleed fixed level is picked
+            // here, as users shouldn't be running lower anyway. 1.0.0
+            // and below are no longer supported.
+            if (OPENSSL_VERSION_NUMBER >= 0x1000107f) {
+                define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
+            } else {
+                define('MATH_BIGINTEGER_OPENSSL_DISABLE', true);
             }
         }
 


### PR DESCRIPTION
The code now looks for a supported openssl version with at least the heartbleed patch level.

There may be contention as to whether this solves the original XAMPP issues. I don't have a good way of testing this. The problems for which this was introduced existed back in 2013. Unless a user system is horribly insecure, header<->library mismatches should no longer result in behavior broken as the original kludge was trying to avoid.

The core goal here is to remove the reliance on phpinfo. If other methods are preferred, I'm all ears.