### PR TITLE
Correct Sodium check

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1171,7 +1171,7 @@ class SSH2
             'diffie-hellman-group-exchange-sha1', // RFC 4419
             'diffie-hellman-group-exchange-sha256', // RFC 4419
         );
-        if (!class_exists('\Sodium')) {
+        if (!function_exists('\\Sodium\\library_version_major')) {
             $kex_algorithms = array_diff(
                 $kex_algorithms,
                 array('curve25519-sha256@libssh.org')


### PR DESCRIPTION
PECL Libsodium 1.0.x uses `\Sodium\function_name` instead of `\Sodium::method_name`.

https://paragonie.com/book/pecl-libsodium/read/03-utilities-helpers.md#version