### PR TITLE
implement sha512/224 and sha512/256

### DIFF
--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -33,6 +33,7 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Math\BigInteger;
 use phpseclib\Exception\UnsupportedAlgorithmException;
 
 /**
@@ -80,6 +81,39 @@ class Hash
     var $key = false;
 
     /**
+     * Initial Hash
+     *
+     * Used only for sha512/*
+     *
+     * @see self::_sha512()
+     * @var array
+     * @access private
+     */
+    var $initial = false;
+
+    /**
+     * Outer XOR (Internal HMAC)
+     *
+     * Used only for sha512/*
+     *
+     * @see self::hash()
+     * @var string
+     * @access private
+     */
+    var $opad;
+
+    /**
+     * Inner XOR (Internal HMAC)
+     *
+     * Used only for sha512/*
+     *
+     * @see self::hash()
+     * @var string
+     * @access private
+     */
+    var $ipad;
+
+    /**
      * Default Constructor.
      *
      * @param string $hash
@@ -88,6 +122,9 @@ class Hash
     function __construct($hash = 'sha256')
     {
         $this->setHash($hash);
+
+        $this->ipad = str_repeat(chr(0x36), 128);
+        $this->opad = str_repeat(chr(0x5C), 128);
     }
 
     /**
@@ -126,10 +163,13 @@ class Hash
     {
         $this->hashParam = $hash = strtolower($hash);
         switch ($hash) {
+            case 'md2-96':
             case 'md5-96':
             case 'sha1-96':
             case 'sha256-96':
             case 'sha512-96':
+            case 'sha512/224-96':
+            case 'sha512/256-96':
                 $hash = substr($hash, 0, -3);
                 $this->length = 12; // 96 / 8 = 12
                 break;
@@ -140,7 +180,11 @@ class Hash
             case 'sha1':
                 $this->length = 20;
                 break;
+            case 'sha512/224':
+                $this->length = 28;
+                break;
             case 'sha256':
+            case 'sha512/256':
                 $this->length = 32;
                 break;
             case 'sha384':
@@ -171,6 +215,23 @@ class Hash
                 );
         }
 
+        if ($hash == 'sha512/224' || $hash == 'sha512/256') {
+            // from http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#page=24
+            $this->initial = $hash == 'sha512/256' ?
+                array(
+                    '22312194FC2BF72C', '9F555FA3C84C64C2', '2393B86B6F53B151', '963877195940EABD',
+                    '96283EE2A88EFFE3', 'BE5E1E2553863992', '2B0199FC2C85B8AA', '0EB72DDC81C52CA2'
+                ) :
+                array(
+                    '8C3D37C819544DA2', '73E1996689DCD4D6', '1DFAB7AE32FF9C82', '679DD514582F9FCF',
+                    '0F6D2B697BD44DA8', '77E36F7304C48942', '3F9D85A86A1D36C8', '1112E6AD91D692A1'
+                );
+            for ($i = 0; $i < 8; $i++) {
+                $this->initial[$i] = new BigInteger($this->initial[$i], 16);
+                $this->initial[$i]->setPrecision(64);
+            }
+        }
+
         $this->hash = $hash;
     }
 
@@ -183,6 +244,28 @@ class Hash
      */
     function hash($text)
     {
+        switch ($this->hash) {
+            case 'sha512/224':
+            case 'sha512/256':
+                if (empty($this->key) || !is_string($this->key)) {
+                    return substr(self::_sha512($text, $this->initial), 0, $this->length);
+                }
+                /* "Applications that use keys longer than B bytes will first hash the key using H and then use the
+                    resultant L byte string as the actual key to HMAC."
+
+                    -- http://tools.ietf.org/html/rfc2104#section-2 */
+                $key = strlen($this->key) > $this->b ? self::_sha512($this->key, $this->initial) : $this->key;
+
+                $key    = str_pad($this->key, 128, chr(0));       // step 1
+                $temp   = $this->ipad ^ $this->key;               // step 2
+                $temp  .= $text;                                  // step 3
+                $temp   = self::_sha512($temp, $this->initial);   // step 4
+                $output = $this->opad ^ $this->key;               // step 5
+                $output.= $temp;                                  // step 6
+                $output = self::_sha512($output, $this->initial); // step 7
+
+                return substr($output, 0, $this->length);
+        }
         $output = !empty($this->key) || is_string($this->key) ?
             hash_hmac($this->hash, $text, $this->key, true) :
             hash($this->hash, $text, true);
@@ -201,5 +284,179 @@ class Hash
     function getLength()
     {
         return $this->length;
+    }
+
+    /**
+     * Pure-PHP implementation of SHA512
+     *
+     * @access private
+     * @param string $m
+     */
+    static function _sha512($m, $hash)
+    {
+        static $k;
+
+        if (!isset($k)) {
+            // Initialize table of round constants
+            // (first 64 bits of the fractional parts of the cube roots of the first 80 primes 2..409)
+            $k = array(
+                '428a2f98d728ae22', '7137449123ef65cd', 'b5c0fbcfec4d3b2f', 'e9b5dba58189dbbc',
+                '3956c25bf348b538', '59f111f1b605d019', '923f82a4af194f9b', 'ab1c5ed5da6d8118',
+                'd807aa98a3030242', '12835b0145706fbe', '243185be4ee4b28c', '550c7dc3d5ffb4e2',
+                '72be5d74f27b896f', '80deb1fe3b1696b1', '9bdc06a725c71235', 'c19bf174cf692694',
+                'e49b69c19ef14ad2', 'efbe4786384f25e3', '0fc19dc68b8cd5b5', '240ca1cc77ac9c65',
+                '2de92c6f592b0275', '4a7484aa6ea6e483', '5cb0a9dcbd41fbd4', '76f988da831153b5',
+                '983e5152ee66dfab', 'a831c66d2db43210', 'b00327c898fb213f', 'bf597fc7beef0ee4',
+                'c6e00bf33da88fc2', 'd5a79147930aa725', '06ca6351e003826f', '142929670a0e6e70',
+                '27b70a8546d22ffc', '2e1b21385c26c926', '4d2c6dfc5ac42aed', '53380d139d95b3df',
+                '650a73548baf63de', '766a0abb3c77b2a8', '81c2c92e47edaee6', '92722c851482353b',
+                'a2bfe8a14cf10364', 'a81a664bbc423001', 'c24b8b70d0f89791', 'c76c51a30654be30',
+                'd192e819d6ef5218', 'd69906245565a910', 'f40e35855771202a', '106aa07032bbd1b8',
+                '19a4c116b8d2d0c8', '1e376c085141ab53', '2748774cdf8eeb99', '34b0bcb5e19b48a8',
+                '391c0cb3c5c95a63', '4ed8aa4ae3418acb', '5b9cca4f7763e373', '682e6ff3d6b2b8a3',
+                '748f82ee5defb2fc', '78a5636f43172f60', '84c87814a1f0ab72', '8cc702081a6439ec',
+                '90befffa23631e28', 'a4506cebde82bde9', 'bef9a3f7b2c67915', 'c67178f2e372532b',
+                'ca273eceea26619c', 'd186b8c721c0c207', 'eada7dd6cde0eb1e', 'f57d4f7fee6ed178',
+                '06f067aa72176fba', '0a637dc5a2c898a6', '113f9804bef90dae', '1b710b35131c471b',
+                '28db77f523047d84', '32caab7b40c72493', '3c9ebe0a15c9bebc', '431d67c49c100d4c',
+                '4cc5d4becb3e42b6', '597f299cfc657e2a', '5fcb6fab3ad6faec', '6c44198c4a475817'
+            );
+
+            for ($i = 0; $i < 80; $i++) {
+                $k[$i] = new BigInteger($k[$i], 16);
+            }
+        }
+
+        // Pre-processing
+        $length = strlen($m);
+        // to round to nearest 112 mod 128, we'll add 128 - (length + (128 - 112)) % 128
+        $m.= str_repeat(chr(0), 128 - (($length + 16) & 0x7F));
+        $m[$length] = chr(0x80);
+        // we don't support hashing strings 512MB long
+        $m.= pack('N4', 0, 0, 0, $length << 3);
+
+        // Process the message in successive 1024-bit chunks
+        $chunks = str_split($m, 128);
+        foreach ($chunks as $chunk) {
+            $w = array();
+            for ($i = 0; $i < 16; $i++) {
+                $temp = new BigInteger(self::_string_shift($chunk, 8), 256);
+                $temp->setPrecision(64);
+                $w[] = $temp;
+            }
+
+            // Extend the sixteen 32-bit words into eighty 32-bit words
+            for ($i = 16; $i < 80; $i++) {
+                $temp = array(
+                          $w[$i - 15]->bitwise_rightRotate(1),
+                          $w[$i - 15]->bitwise_rightRotate(8),
+                          $w[$i - 15]->bitwise_rightShift(7)
+                );
+                $s0 = $temp[0]->bitwise_xor($temp[1]);
+                $s0 = $s0->bitwise_xor($temp[2]);
+                $temp = array(
+                          $w[$i - 2]->bitwise_rightRotate(19),
+                          $w[$i - 2]->bitwise_rightRotate(61),
+                          $w[$i - 2]->bitwise_rightShift(6)
+                );
+                $s1 = $temp[0]->bitwise_xor($temp[1]);
+                $s1 = $s1->bitwise_xor($temp[2]);
+                $w[$i] = clone $w[$i - 16];
+                $w[$i] = $w[$i]->add($s0);
+                $w[$i] = $w[$i]->add($w[$i - 7]);
+                $w[$i] = $w[$i]->add($s1);
+            }
+
+            // Initialize hash value for this chunk
+            $a = clone $hash[0];
+            $b = clone $hash[1];
+            $c = clone $hash[2];
+            $d = clone $hash[3];
+            $e = clone $hash[4];
+            $f = clone $hash[5];
+            $g = clone $hash[6];
+            $h = clone $hash[7];
+
+            // Main loop
+            for ($i = 0; $i < 80; $i++) {
+                $temp = array(
+                    $a->bitwise_rightRotate(28),
+                    $a->bitwise_rightRotate(34),
+                    $a->bitwise_rightRotate(39)
+                );
+                $s0 = $temp[0]->bitwise_xor($temp[1]);
+                $s0 = $s0->bitwise_xor($temp[2]);
+                $temp = array(
+                    $a->bitwise_and($b),
+                    $a->bitwise_and($c),
+                    $b->bitwise_and($c)
+                );
+                $maj = $temp[0]->bitwise_xor($temp[1]);
+                $maj = $maj->bitwise_xor($temp[2]);
+                $t2 = $s0->add($maj);
+
+                $temp = array(
+                    $e->bitwise_rightRotate(14),
+                    $e->bitwise_rightRotate(18),
+                    $e->bitwise_rightRotate(41)
+                );
+                $s1 = $temp[0]->bitwise_xor($temp[1]);
+                $s1 = $s1->bitwise_xor($temp[2]);
+                $temp = array(
+                    $e->bitwise_and($f),
+                    $g->bitwise_and($e->bitwise_not())
+                );
+                $ch = $temp[0]->bitwise_xor($temp[1]);
+                $t1 = $h->add($s1);
+                $t1 = $t1->add($ch);
+                $t1 = $t1->add($k[$i]);
+                $t1 = $t1->add($w[$i]);
+
+                $h = clone $g;
+                $g = clone $f;
+                $f = clone $e;
+                $e = $d->add($t1);
+                $d = clone $c;
+                $c = clone $b;
+                $b = clone $a;
+                $a = $t1->add($t2);
+            }
+
+            // Add this chunk's hash to result so far
+            $hash = array(
+                $hash[0]->add($a),
+                $hash[1]->add($b),
+                $hash[2]->add($c),
+                $hash[3]->add($d),
+                $hash[4]->add($e),
+                $hash[5]->add($f),
+                $hash[6]->add($g),
+                $hash[7]->add($h)
+            );
+        }
+
+        // Produce the final hash value (big-endian)
+        // (\phpseclib\Crypt\Hash::hash() trims the output for hashes but not for HMACs.  as such, we trim the output here)
+        $temp = $hash[0]->toBytes() . $hash[1]->toBytes() . $hash[2]->toBytes() . $hash[3]->toBytes() .
+                $hash[4]->toBytes() . $hash[5]->toBytes() . $hash[6]->toBytes() . $hash[7]->toBytes();
+
+        return $temp;
+    }
+
+    /**
+     * String Shift
+     *
+     * Inspired by array_shift
+     *
+     * @param string $string
+     * @param int $index
+     * @return string
+     * @access private
+     */
+    static function _string_shift(&$string, $index = 1)
+    {
+        $substr = substr($string, 0, $index);
+        $string = substr($string, $index);
+        return $substr;
     }
 }

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1232,6 +1232,8 @@ class RSA
             case 'sha256':
             case 'sha384':
             case 'sha512':
+            case 'sha512/224':
+            case 'sha512/256':
                 $this->hash = new Hash($hash);
                 $this->hashName = $hash;
                 break;
@@ -1261,6 +1263,8 @@ class RSA
             case 'sha256':
             case 'sha384':
             case 'sha512':
+            case 'sha512/224':
+            case 'sha512/256':
                 $this->mgfHash = new Hash($hash);
                 break;
             default:
@@ -1961,6 +1965,13 @@ class RSA
                 break;
             case 'sha512':
                 $t = pack('H*', '3051300d060960864801650304020305000440');
+                break;
+            // from https://www.emc.com/collateral/white-papers/h11300-pkcs-1v2-2-rsa-cryptography-standard-wp.pdf#page=40
+            case 'sha512/224':
+                $t = pack('H*', '302d300d06096086480165030402050500041c');
+                break;
+            case 'sha512/256':
+                $t = pack('H*', '3031300d060960864801650304020605000420');
         }
         $t.= $h;
         $tLen = strlen($t);
@@ -2132,8 +2143,8 @@ class RSA
             '2.16.840.1.101.3.4.2.2' => 'sha384',
             '2.16.840.1.101.3.4.2.3' => 'sha512',
             // from PKCS1 v2.2
-            //'2.16.840.1.101.3.4.2.5' => 'sha512/224',
-            //'2.16.840.1.101.3.4.2.6' => 'sha512/256',
+            '2.16.840.1.101.3.4.2.5' => 'sha512/224',
+            '2.16.840.1.101.3.4.2.6' => 'sha512/256',
         );
 
         $asn1->loadOIDs($oids);

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1232,6 +1232,7 @@ class RSA
             case 'sha256':
             case 'sha384':
             case 'sha512':
+            case 'sha224':
             case 'sha512/224':
             case 'sha512/256':
                 $this->hash = new Hash($hash);
@@ -1263,6 +1264,7 @@ class RSA
             case 'sha256':
             case 'sha384':
             case 'sha512':
+            case 'sha224':
             case 'sha512/224':
             case 'sha512/256':
                 $this->mgfHash = new Hash($hash);
@@ -1967,6 +1969,9 @@ class RSA
                 $t = pack('H*', '3051300d060960864801650304020305000440');
                 break;
             // from https://www.emc.com/collateral/white-papers/h11300-pkcs-1v2-2-rsa-cryptography-standard-wp.pdf#page=40
+            case 'sha224':
+                $t = pack('H*', '302d300d06096086480165030402040500041c');
+                break;
             case 'sha512/224':
                 $t = pack('H*', '302d300d06096086480165030402050500041c');
                 break;
@@ -2143,6 +2148,7 @@ class RSA
             '2.16.840.1.101.3.4.2.2' => 'sha384',
             '2.16.840.1.101.3.4.2.3' => 'sha512',
             // from PKCS1 v2.2
+            '2.16.840.1.101.3.4.2.4' => 'sha224',
             '2.16.840.1.101.3.4.2.5' => 'sha512/224',
             '2.16.840.1.101.3.4.2.6' => 'sha512/256',
         );

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -157,106 +157,189 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
         return array(
             array('md5', '', '', '74e6f7298a9c2d168935f58c001bad88'),
             array('md5', 'key', 'The quick brown fox jumps over the lazy dog', '80070713463e7749b90c2dc24911e275'),
-            // RFC 4231
-            // Test Case 1
-            array(
-                'sha256',
-                pack('H*', '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'),
-                pack('H*', '4869205468657265'),
-                'b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7',
-            ),
-            // Test Case 2
-            array(
-                'sha256',
-                pack('H*', '4a656665'),
-                pack('H*', '7768617420646f2079612077616e7420666f72206e6f7468696e673f'),
-                '5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843',
-            ),
-            // Test Case 3
-            array(
-                'sha256',
-                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
-                '773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe',
-            ),
-            // Test Case 4
-            array(
-                'sha256',
-                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
-                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
-                '82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b',
-            ),
-            // RFC 4231
-            // Test Case 1
-            array(
-                'sha512',
-                pack('H*', '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b'),
-                pack('H*', '4869205468657265'),
-                '87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854',
-            ),
-            // Test Case 2
-            array(
-                'sha512',
-                pack('H*', '4a656665'),
-                pack('H*', '7768617420646f2079612077616e7420666f72206e6f7468696e673f'),
-                '164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737',
-            ),
-            // Test Case 3
-            array(
-                'sha512',
-                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
-                'fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb',
-            ),
-            // Test Case 4
-            array(
-                'sha512',
-                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
-                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
-                'b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd',
-            ),
+
             array(
                 'whirlpool',
                 'abcd',
                 'The quick brown fox jumps over the lazy dog',
                 'e71aabb2588d789292fa6fef00b35cc269ec3ea912b1c1cd7127daf95f004a5df5392ee563d322bac7e19d9eab161932fe9c257d63e0d09eca0d91ab4010125e',
             ),
+
             // from https://tools.ietf.org/rfc/rfc4231.txt
+            // test case 1
             array(
                 'sha224',
                 str_repeat("\x0b", 20),
                 'Hi There',
                 '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
             ),
+            // test case 2
             array(
                 'sha224',
                 'Jefe',
                 'what do ya want for nothing?',
                 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
             ),
+            // test case 3
             array(
                 'sha224',
                 pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
                 pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
                 '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
             ),
+            // test case 4
             array(
                 'sha224',
                 pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
                 pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
                 '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
             ),
+            // skip test case 5; truncation is only supported to 96 bits (eg. sha1-96) and that's already unit tested
+            // test case 6
             array(
                 'sha224',
                 pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
                 'Test Using Larger Than Block-Size Key - Hash Key First',
                 '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
             ),
+            // test case 7
             array(
                 'sha224',
                 pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
                 'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.',
                 '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1'
+            ),
+
+            // test case 1
+            array(
+                'sha256',
+                str_repeat("\x0b", 20),
+                'Hi There',
+                'b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7',
+            ),
+            // test case 2
+            array(
+                'sha256',
+                'Jefe',
+                'what do ya want for nothing?',
+                '5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843',
+            ),
+            // test case 3
+            array(
+                'sha256',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
+                '773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe',
+            ),
+            // test case 4
+            array(
+                'sha256',
+                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
+                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
+                '82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b',
+            ),
+            // skip test case 5; truncation is only supported to 96 bits (eg. sha1-96) and that's already unit tested
+            // test case 6
+            array(
+                'sha256',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'Test Using Larger Than Block-Size Key - Hash Key First',
+                '60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54',
+            ),
+            // test case 7
+            array(
+                'sha256',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.',
+                '9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2'
+            ),
+
+            // test case 1
+            array(
+                'sha384',
+                str_repeat("\x0b", 20),
+                'Hi There',
+                'afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6',
+            ),
+            // test case 2
+            array(
+                'sha384',
+                'Jefe',
+                'what do ya want for nothing?',
+                'af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649',
+            ),
+            // test case 3
+            array(
+                'sha384',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
+                '88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27',
+            ),
+            // test case 4
+            array(
+                'sha384',
+                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
+                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
+                '3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb',
+            ),
+            // skip test case 5; truncation is only supported to 96 bits (eg. sha1-96) and that's already unit tested
+            // test case 6
+            array(
+                'sha384',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'Test Using Larger Than Block-Size Key - Hash Key First',
+                '4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c60c2ef6ab4030fe8296248df163f44952',
+            ),
+            // test case 7
+            array(
+                'sha384',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.',
+                '6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e'
+            ),
+
+            // test case 1
+            array(
+                'sha512',
+                str_repeat("\x0b", 20),
+                'Hi There',
+                '87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854',
+            ),
+            // test case 2
+            array(
+                'sha512',
+                'Jefe',
+                'what do ya want for nothing?',
+                '164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737',
+            ),
+            // test case 3
+            array(
+                'sha512',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
+                'fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb',
+            ),
+            // test case 4
+            array(
+                'sha512',
+                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
+                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
+                'b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd',
+            ),
+            // skip test case 5; truncation is only supported to 96 bits (eg. sha1-96) and that's already unit tested
+            // test case 6
+            array(
+                'sha512',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'Test Using Larger Than Block-Size Key - Hash Key First',
+                '80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598',
+            ),
+            // test case 7
+            array(
+                'sha512',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.',
+                'e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58'
             ),
         );
     }

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -95,6 +95,33 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
                 'The quick brown fox jumps over the lazy dog.',
                 '87a7ff096082e3ffeb86db10feb91c5af36c2c71bc426fe310ce662e0338223e217def0eab0b02b80eecf875657802bc5965e48f5c0a05467756f0d3f396faba'
             ),
+            array(
+                'whirlpool',
+                'The quick brown fox jumps over the lazy dog.',
+                '87a7ff096082e3ffeb86db10feb91c5af36c2c71bc426fe310ce662e0338223e217def0eab0b02b80eecf875657802bc5965e48f5c0a05467756f0d3f396faba'
+            ),
+            // from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
+            array(
+                'sha512/224',
+                'abc',
+                '4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa'
+            ),
+            array(
+                'sha512/224',
+                'abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu',
+                '23fec5bb94d60b23308192640b0c453335d664734fe40e7268674af9'
+            ),
+            // from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf
+            array(
+                'sha512/256',
+                'abc',
+                '53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23'
+            ),
+            array(
+                'sha512/256',
+                'abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu',
+                '3928e184fb8690f840da3988121d31be65cb9d3ef83ee6146feac861e19b563a'
+            ),
         );
     }
 

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -122,6 +122,17 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
                 'abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu',
                 '3928e184fb8690f840da3988121d31be65cb9d3ef83ee6146feac861e19b563a'
             ),
+            // from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA224.pdf
+            array(
+                'sha224',
+                'abc',
+                '23097D223405D8228642A477BDA255B32AADBCE4BDA0B3F7E36C9DA7'
+            ),
+            array(
+                'sha224',
+                'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq',
+                '75388B16512776CC5DBA5DA1FD890150B0C6455CB4F58B1952522525'
+            ),
         );
     }
 
@@ -209,6 +220,43 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
                 'abcd',
                 'The quick brown fox jumps over the lazy dog',
                 'e71aabb2588d789292fa6fef00b35cc269ec3ea912b1c1cd7127daf95f004a5df5392ee563d322bac7e19d9eab161932fe9c257d63e0d09eca0d91ab4010125e',
+            ),
+            // from https://tools.ietf.org/rfc/rfc4231.txt
+            array(
+                'sha224',
+                str_repeat("\x0b", 20),
+                'Hi There',
+                '896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22',
+            ),
+            array(
+                'sha224',
+                'Jefe',
+                'what do ya want for nothing?',
+                'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
+            ),
+            array(
+                'sha224',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                pack('H*', 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'),
+                '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
+            ),
+            array(
+                'sha224',
+                pack('H*', '0102030405060708090a0b0c0d0e0f10111213141516171819'),
+                pack('H*', 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'),
+                '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
+            ),
+            array(
+                'sha224',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'Test Using Larger Than Block-Size Key - Hash Key First',
+                '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
+            ),
+            array(
+                'sha224',
+                pack('H*', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                'This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.',
+                '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1'
             ),
         );
     }


### PR DESCRIPTION
This PR implements sha512/224 and sha512/256 and makes RSA.php fully PKCS1 v2.2 compliant.

A feature request exists to bring these hash algorithms to PHP but has yet to be acted upon: https://bugs.php.net/71177

I did not add unit tests for the HMAC'd version of those because I could not find any official test vectors for those.