### PR TITLE
set publicExponent to false instead of unsetting

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -966,7 +966,7 @@ class RSA
         if (!$rsa->load($key, $type)) {
             return false;
         }
-        unset($rsa->publicExponent);
+        $rsa->publicExponent = false;
 
         // don't overwrite the old key if the new key is invalid
         $this->load($rsa);


### PR DESCRIPTION
using unset causes an error in $this->load():

Undefined property: phpseclib\Crypt\RSA::$publicExponent in phpseclib/phpseclib/Crypt/RSA.php on line 709