### PR TITLE
Fixed PHP notice thrown by undefined key_comment variable

### DIFF
--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -169,6 +169,7 @@ class Agent
         $identities = array();
         $keyCount = current(unpack('N', fread($this->fsock, 4)));
         for ($i = 0; $i < $keyCount; $i++) {
+            $key_comment = '';
             $length = current(unpack('N', fread($this->fsock, 4)));
             $key_blob = fread($this->fsock, $length);
             $length = current(unpack('N', fread($this->fsock, 4)));


### PR DESCRIPTION
Variable key_comment should be predefined, otherwise there will be PHP notices if key_comment is undefined, cause its optional.