### PR TITLE
Mark the conflict with Math_BigInteger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,10 @@
         "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
         "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations."
     },
+    "conflict": {
+      "pear-pear.php.net/Math_BigInteger": "*",
+      "pear/math_biginteger": "*"
+    },
     "autoload": {
         "files": [
             "phpseclib/bootstrap.php"


### PR DESCRIPTION
phpseclib contains a diverged fork of PEAR's Math_BigInteger in the global namespace, causing a conflict if both are installed.  This change request marks them as conflicting.  Ideally, the phpseclib variant would be contained in its own namespace.