### PR TITLE
Hash: throw exceptions if hash isn't explicitly supported

### DIFF
--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -166,7 +166,9 @@ class Hash
             case 'md2-96':
             case 'md5-96':
             case 'sha1-96':
+            case 'sha224-96':
             case 'sha256-96':
+            case 'sha384-96':
             case 'sha512-96':
             case 'sha512/224-96':
             case 'sha512/256-96':
@@ -195,22 +197,6 @@ class Hash
                 $this->length = 64;
                 break;
             default:
-                // see if the hash isn't "officially" supported see if it can
-                // be "unofficially" supported and calculate the length
-                // accordingly.
-                if (in_array($hash, hash_algos())) {
-                    $this->length = strlen(hash($hash, '', true));
-                    break;
-                }
-                // if the hash algorithm doens't exist maybe it's a truncated
-                // hash, e.g. whirlpool-12 or some such.
-                if (preg_match('#(-\d+)$#', $hash, $matches)) {
-                    $hash = substr($hash, 0, -strlen($matches[1]));
-                    if (in_array($hash, hash_algos())) {
-                        $this->length = abs($matches[1]) >> 3;
-                        break;
-                    }
-                }
                 throw new UnsupportedAlgorithmException(
                     "$hash is not a supported algorithm"
                 );

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -85,11 +85,6 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
                 'The quick brown fox jumps over the lazy dog.',
                 '91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed',
             ),
-            array(
-                'whirlpool',
-                'The quick brown fox jumps over the lazy dog.',
-                '87a7ff096082e3ffeb86db10feb91c5af36c2c71bc426fe310ce662e0338223e217def0eab0b02b80eecf875657802bc5965e48f5c0a05467756f0d3f396faba'
-            ),
             // from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
             array(
                 'sha512/224',
@@ -147,13 +142,6 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
         return array(
             array('md5', '', '', '74e6f7298a9c2d168935f58c001bad88'),
             array('md5', 'key', 'The quick brown fox jumps over the lazy dog', '80070713463e7749b90c2dc24911e275'),
-
-            array(
-                'whirlpool',
-                'abcd',
-                'The quick brown fox jumps over the lazy dog',
-                'e71aabb2588d789292fa6fef00b35cc269ec3ea912b1c1cd7127daf95f004a5df5392ee563d322bac7e19d9eab161932fe9c257d63e0d09eca0d91ab4010125e',
-            ),
 
             // from https://tools.ietf.org/rfc/rfc4231.txt
             // test case 1
@@ -364,12 +352,6 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
         new Hash('abcdefghijklmnopqrst');
     }
 
-    public function testConstructorArgumentValid()
-    {
-        $hash = new Hash('whirlpool');
-        $this->assertSame($hash->getHash(), 'whirlpool');
-    }
-
     /**
      * @expectedException \phpseclib\Exception\UnsupportedAlgorithmException
      */
@@ -406,8 +388,6 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
             array('sha256', 32),
             array('sha384', 48),
             array('sha512', 64),
-            // unknown
-            array('whirlpool', 64),
         );
     }
 }


### PR DESCRIPTION
The motivation for this PR is as follows:

https://github.com/phpseclib/phpseclib/pull/956#issuecomment-209115492