### PR TITLE
RSA: don't attempt to use the CRT when zero value components exist

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -2163,8 +2163,14 @@ class Crypt_RSA
      */
     function _exponentiate($x)
     {
-        if (empty($this->primes) || empty($this->coefficients) || empty($this->exponents)) {
-            return $x->modPow($this->exponent, $this->modulus);
+        switch (true) {
+            case empty($this->primes):
+            case $this->primes[1]->equals($this->zero):
+            case empty($this->coefficients):
+            case $this->coefficients[2]->equals($this->zero):
+            case empty($this->exponents):
+            case $this->exponents[1]->equals($this->zero):
+                return $x->modPow($this->exponent, $this->modulus);
         }
 
         $num_primes = count($this->primes);

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -379,4 +379,25 @@ Private-MAC: 35134b7434bf828b21404099861d455e660e8740';
         $rsa->setPrivateKey();
         $rsa->loadKey($rsa);
     }
+
+    /**
+     * @group github980
+     */
+    public function testZeroComponents()
+    {
+        $key = '-----BEGIN RSA PRIVATE KEY-----
+MIGaAgEAAkEAt5yrcHAAjhglnCEn6yecMWPeUXcMyo0+itXrLlkpcKIIyqPw546b
+GThhlb1ppX1ySX/OUA4jSakHekNP5eWPawIBAAJAW6/aVD05qbsZHMvZuS2Aa5Fp
+NNj0BDlf38hOtkhDzz/hkYb+EBYLLvldhgsD0OvRNy8yhz7EjaUqLCB0juIN4QIB
+AAIBAAIBAAIBAAIBAA==
+-----END RSA PRIVATE KEY-----';
+
+        $rsa = new Crypt_RSA();
+        $rsa->loadKey($key);
+        $rsa->setSignatureMode(CRYPT_RSA_SIGNATURE_PKCS1);
+        $rsa->setHash('md5');
+        $rsa->setMGFHash('md5');
+
+        $rsa->sign('zzzz');
+    }
 }


### PR DESCRIPTION
Fixes #980