### PR TITLE
fixed sending stream resulting in a zero byte file

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1893,7 +1893,7 @@ class SFTP extends SSH2
         // make the SFTP packet be exactly 4096 bytes by including the bytes in the NET_SFTP_WRITE packets "header"
         $sftp_packet_size-= strlen($handle) + 25;
         $i = 0;
-        while ($dataCallback || $sent < $size) {
+        while ($dataCallback || ($size === 0 || $sent < $size))  {
             if ($dataCallback) {
                 $temp = call_user_func($dataCallback, $sftp_packet_size);
                 if (is_null($temp)) {
@@ -1901,7 +1901,11 @@ class SFTP extends SSH2
                 }
             } else {
                 $temp = isset($fp) ? fread($fp, $sftp_packet_size) : substr($data, $sent, $sftp_packet_size);
+                if ($temp === false) {
+                    break;
+                }
             }
+
             $subtemp = $offset + $sent;
             $packet = pack('Na*N3a*', strlen($handle), $handle, $subtemp / 4294967296, $subtemp, strlen($temp), $temp);
             if (!$this->_send_sftp_packet(NET_SFTP_WRITE, $packet)) {

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1893,7 +1893,7 @@ class SFTP extends SSH2
         // make the SFTP packet be exactly 4096 bytes by including the bytes in the NET_SFTP_WRITE packets "header"
         $sftp_packet_size-= strlen($handle) + 25;
         $i = 0;
-        while ($dataCallback || ($size === 0 || $sent < $size))  {
+        while ($dataCallback || ($size === 0 || $sent < $size)) {
             if ($dataCallback) {
                 $temp = call_user_func($dataCallback, $sftp_packet_size);
                 if (is_null($temp)) {


### PR DESCRIPTION

When using SFTP `put()` with the STDIN file descriptor and the content is *piped* (and not redirected, see [this](https://bugs.php.net/bug.php?id=23424)), fstat (see [here](https://github.com/phpseclib/phpseclib/blob/master/phpseclib/Net/SFTP.php#L1876)) returns a size of 0. Consequently an empty file is created on the remote system, even if the local file descriptor provides a non-empty stream.

This PR provides a solution by reading the stream even if size is equal to zero, and letting fread detect the end of file.

Let me know if anything more can be done to get this PR merged

Thanks !