### PR TITLE
remove a few calls to paragonie/constant_time_encoding

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -35,9 +35,6 @@
  */
 
 namespace phpseclib\Crypt;
-use ParagonIE\ConstantTime\Hex;
-
-use ParagonIE\ConstantTime\Hex;
 
 /**
  * Base Class for all \phpseclib\Crypt\* cipher classes
@@ -2581,10 +2578,10 @@ abstract class Base
                 $len = strlen($bytes);
                 for ($i = 0; $i < $len; $i+=20) {
                     $t = substr($bytes, $i, 20);
-                    $hash = Hex::decode($hash);
+                    $hash = sha1($hash, trie);
                     $result .= $t ^ $hash;
                 }
-                return $result . Hex::decode(sha1($hash));
+                return $result . sha1($hash, true);
         }
     }
 }

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -46,7 +46,6 @@
 namespace phpseclib\Crypt;
 
 use ParagonIE\ConstantTime\Base64;
-use ParagonIE\ConstantTime\Hex;
 use phpseclib\File\ASN1;
 use phpseclib\Math\BigInteger;
 
@@ -1953,32 +1952,32 @@ class RSA
         // see http://tools.ietf.org/html/rfc3447#page-43
         switch ($this->hashName) {
             case 'md2':
-                $t = Hex::decode('3020300c06082a864886f70d020205000410');
+                $t = "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x02\x05\x00\x04\x10";
                 break;
             case 'md5':
-                $t = Hex::decode('3020300c06082a864886f70d020505000410');
+                $t = "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10";
                 break;
             case 'sha1':
-                $t = Hex::decode('3021300906052b0e03021a05000414');
+                $t = "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14";
                 break;
             case 'sha256':
-                $t = Hex::decode('3031300d060960864801650304020105000420');
+                $t = "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20";
                 break;
             case 'sha384':
-                $t = Hex::decode('3041300d060960864801650304020205000430');
+                $t = "\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30";
                 break;
             case 'sha512':
-                $t = Hex::decode('3051300d060960864801650304020305000440');
+                $t = "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40";
                 break;
             // from https://www.emc.com/collateral/white-papers/h11300-pkcs-1v2-2-rsa-cryptography-standard-wp.pdf#page=40
             case 'sha224':
-                $t = Hex::decode('302d300d06096086480165030402040500041c');
+                $t = "\x30\x2d\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x04\x05\x00\x04\x1c";
                 break;
             case 'sha512/224':
-                $t = Hex::decode('302d300d06096086480165030402050500041c');
+                $t = "\x30\x2d\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x05\x05\x00\x04\x1c";
                 break;
             case 'sha512/256':
-                $t = Hex::decode('3031300d060960864801650304020605000420');
+                $t = "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x06\x05\x00\x04\x20";
         }
         $t.= $h;
         $tLen = strlen($t);

--- a/phpseclib/Crypt/RSA/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/MSBLOB.php
@@ -19,7 +19,6 @@
 namespace phpseclib\Crypt\RSA;
 
 use ParagonIE\ConstantTime\Base64;
-use ParagonIE\ConstantTime\Binary;
 use phpseclib\Math\BigInteger;
 
 /**

--- a/phpseclib/Crypt/RSA/PKCS.php
+++ b/phpseclib/Crypt/RSA/PKCS.php
@@ -146,7 +146,7 @@ abstract class PKCS
         $symkey = '';
         $iv = substr($iv, 0, 8);
         while (strlen($symkey) < $length) {
-            $symkey.= Hex::decode(md5($symkey . $password . $iv));
+            $symkey.= md5($symkey . $password . $iv, true);
         }
         return substr($symkey, 0, $length);
     }

--- a/phpseclib/Crypt/RSA/PKCS1.php
+++ b/phpseclib/Crypt/RSA/PKCS1.php
@@ -25,7 +25,6 @@ namespace phpseclib\Crypt\RSA;
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
 use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Base;
 use phpseclib\Crypt\DES;
 use phpseclib\Crypt\Random;
 use phpseclib\Crypt\TripleDES;

--- a/phpseclib/Crypt/RSA/PKCS8.php
+++ b/phpseclib/Crypt/RSA/PKCS8.php
@@ -25,7 +25,6 @@
 namespace phpseclib\Crypt\RSA;
 
 use ParagonIE\ConstantTime\Base64;
-use ParagonIE\ConstantTime\Hex;
 use phpseclib\Crypt\DES;
 use phpseclib\Crypt\Random;
 use phpseclib\Math\BigInteger;
@@ -94,7 +93,7 @@ class PKCS8 extends PKCS
 
         $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
 
-        $rsaOID = Hex::decode('300d06092a864886f70d0101010500'); // hex version of MA0GCSqGSIb3DQEBAQUA
+        $rsaOID = "\x30\x0d\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"; // hex version of MA0GCSqGSIb3DQEBAQUA
         $RSAPrivateKey = pack(
             'Ca*a*Ca*a*',
             self::ASN1_INTEGER,
@@ -190,7 +189,7 @@ class PKCS8 extends PKCS
         );
 
         // sequence(oid(1.2.840.113549.1.1.1), null)) = rsaEncryption.
-        $rsaOID = Hex::decode('300d06092a864886f70d0101010500'); // hex version of MA0GCSqGSIb3DQEBAQUA
+        $rsaOID = "\x30\x0d\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"; // hex version of MA0GCSqGSIb3DQEBAQUA
         $RSAPublicKey = chr(0) . $RSAPublicKey;
         $RSAPublicKey = chr(3) . self::_encodeLength(strlen($RSAPublicKey)) . $RSAPublicKey;
 

--- a/phpseclib/Crypt/RSA/PuTTY.php
+++ b/phpseclib/Crypt/RSA/PuTTY.php
@@ -275,7 +275,7 @@ class PuTTY
         $key.= 'Private-Lines: ' . ((strlen($private) + 63) >> 6) . "\r\n";
         $key.= chunk_split($private, 64);
         $hash = new Hash('sha1');
-        $hash->setKey(Hex::decode(sha1($hashkey)));
+        $hash->setKey(sha1($hashkey, true));
         $key.= 'Private-MAC: ' . Hex::encode($hash->hash($source)) . "\r\n";
 
         return $key;

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -24,9 +24,6 @@
 
 namespace phpseclib\Crypt;
 
-use ParagonIE\ConstantTime\Base64;
-use ParagonIE\ConstantTime\Hex;
-
 /**
  * Pure-PHP Random Number Generator
  *
@@ -96,15 +93,14 @@ class Random
             session_cache_limiter('');
             session_start();
 
-            $v = $seed = $_SESSION['seed'] = Hex::decode(sha1(
-                (isset($_SERVER) ? self::safe_serialize($_SERVER) : '') .
-                (isset($_POST) ? self::safe_serialize($_POST) : '') .
-                (isset($_GET) ? self::safe_serialize($_GET) : '') .
-                (isset($_COOKIE) ? self::safe_serialize($_COOKIE) : '') .
-                self::safe_serialize($GLOBALS) .
-                self::safe_serialize($_SESSION) .
-                self::safe_serialize($_OLD_SESSION)
-            ));
+            $v = (isset($_SERVER) ? self::safe_serialize($_SERVER) : '') .
+                 (isset($_POST) ? self::safe_serialize($_POST) : '') .
+                 (isset($_GET) ? self::safe_serialize($_GET) : '') .
+                 (isset($_COOKIE) ? self::safe_serialize($_COOKIE) : '') .
+                 self::safe_serialize($GLOBALS) .
+                 self::safe_serialize($_SESSION) .
+                 self::safe_serialize($_OLD_SESSION);
+            $v = $seed = $_SESSION['seed'] = sha1($v, true);
             if (!isset($_SESSION['count'])) {
                 $_SESSION['count'] = 0;
             }
@@ -135,8 +131,8 @@ class Random
             // http://tools.ietf.org/html/rfc4253#section-7.2
             //
             // see the is_string($crypto) part for an example of how to expand the keys
-            $key = Hex::decode(sha1($seed . 'A'));
-            $iv = Hex::decode(sha1($seed . 'C'));
+            $key = sha1($seed . 'A', true);
+            $iv = sha1($seed . 'C', true);
 
             // ciphers are used as per the nist.gov link below. also, see this link:
             //

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -1645,7 +1645,7 @@ class BigInteger
                 $components['publicExponent']
             );
 
-            $rsaOID = Hex::decode('300d06092a864886f70d0101010500'); // hex version of MA0GCSqGSIb3DQEBAQUA
+            $rsaOID = "\x30\x0d\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"; // hex version of MA0GCSqGSIb3DQEBAQUA
             $RSAPublicKey = chr(0) . $RSAPublicKey;
             $RSAPublicKey = chr(3) . self::_encodeASN1Length(strlen($RSAPublicKey)) . $RSAPublicKey;
 

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -610,7 +610,7 @@ class SSH1
             }
         }
 
-        $session_id = Hex::decode(md5($host_key_public_modulus->toBytes() . $server_key_public_modulus->toBytes() . $anti_spoofing_cookie));
+        $session_id = md5($host_key_public_modulus->toBytes() . $server_key_public_modulus->toBytes() . $anti_spoofing_cookie, true);
 
         $session_key = Random::string(32);
         $double_encrypted_session_key = $session_key ^ str_pad($session_id, 32, chr(0));


### PR DESCRIPTION
- Hex::decode('aabb') can be replaced with "\xaa\xbb"
- Hex::decode(sha1('...')) can be replaced with sha1('...', true)