### PR TITLE
Change default signature algorithm from SHA1 to SHA256

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3222,7 +3222,7 @@ class X509
      * @access public
      * @return mixed
      */
-    function sign($issuer, $subject, $signatureAlgorithm = 'sha1WithRSAEncryption')
+    function sign($issuer, $subject, $signatureAlgorithm = 'sha256WithRSAEncryption')
     {
         if (!is_object($issuer->privateKey) || empty($issuer->dn)) {
             return false;


### PR DESCRIPTION
All major browsers will stop to accept certificates that use SHA1 by 2017 (see https://en.wikipedia.org/wiki/SHA-1). So at least SHA256 should be the default now.