### PR TITLE
CRL optimization

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -225,14 +225,15 @@ class ASN1
      *
      * @param string $encoded
      * @param int $start
+     * @param int $encoded_pos
      * @return array
      * @access private
      */
-    function _decode_ber($encoded, $start = 0)
+    function _decode_ber($encoded, $start = 0, $encoded_pos = 0)
     {
         $current = array('start' => $start);
 
-        $type = ord($this->_string_shift($encoded));
+        $type = ord($encoded[$encoded_pos++]);
         $start++;
 
         $constructed = ($type >> 5) & 1;
@@ -244,23 +245,24 @@ class ASN1
             do {
                 $loop = ord($encoded[0]) >> 7;
                 $tag <<= 7;
-                $tag |= ord($this->_string_shift($encoded)) & 0x7F;
+                $tag |= ord($encoded[$encoded_pos++]) & 0x7F;
                 $start++;
             } while ($loop);
         }
 
         // Length, as discussed in paragraph 8.1.3 of X.690-0207.pdf#page=13
-        $length = ord($this->_string_shift($encoded));
+        $length = ord($encoded[$encoded_pos++]);
         $start++;
         if ($length == 0x80) { // indefinite length
             // "[A sender shall] use the indefinite form (see 8.1.3.6) if the encoding is constructed and is not all
             //  immediately available." -- paragraph 8.1.3.2.c
-            $length = strlen($encoded);
+            $length = strlen($encoded) - $encoded_pos;
         } elseif ($length & 0x80) { // definite length, long form
             // technically, the long form of the length can be represented by up to 126 octets (bytes), but we'll only
             // support it up to four.
             $length&= 0x7F;
-            $temp = $this->_string_shift($encoded, $length);
+            $temp = substr($encoded, $encoded_pos, $length);
+            $encoded_pos += $length;
             // tags of indefinte length don't really have a header length; this length includes the tag
             $current+= array('headerlength' => $length + 2);
             $start+= $length;
@@ -269,11 +271,12 @@ class ASN1
             $current+= array('headerlength' => 2);
         }
 
-        if ($length > strlen($encoded)) {
+        if ($length > (strlen($encoded) - $encoded_pos)) {
             return false;
         }
 
-        $content = $this->_string_shift($encoded, $length);
+        $content = substr($encoded, $encoded_pos, $length);
+        $content_pos = 0;
 
         // at this point $length can be overwritten. it's only accurate for definite length things as is
 
@@ -306,7 +309,7 @@ class ASN1
                     $temp = $this->_decode_ber($content, $start);
                     $length = $temp['length'];
                     // end-of-content octets - see paragraph 8.1.5
-                    if (substr($content, $length, 2) == "\0\0") {
+                    if (substr($content, $content_pos + $length, 2) == "\0\0") {
                         $length+= 2;
                         $start+= $length;
                         $newcontent[] = $temp;
@@ -315,7 +318,7 @@ class ASN1
                     $start+= $length;
                     $remainingLength-= $length;
                     $newcontent[] = $temp;
-                    $this->_string_shift($content, $length);
+                    $content_pos += $length;
                 }
 
                 return array(
@@ -339,11 +342,11 @@ class ASN1
                 //if (strlen($content) != 1) {
                 //    return false;
                 //}
-                $current['content'] = (bool) ord($content[0]);
+                $current['content'] = (bool) ord($content[$content_pos]);
                 break;
             case self::TYPE_INTEGER:
             case self::TYPE_ENUMERATED:
-                $current['content'] = new BigInteger($content, -256);
+                $current['content'] = new BigInteger(substr($content, $content_pos), -256);
                 break;
             case self::TYPE_REAL: // not currently supported
                 return false;
@@ -352,10 +355,10 @@ class ASN1
                 // the number of unused bits in the final subsequent octet. The number shall be in the range zero to
                 // seven.
                 if (!$constructed) {
-                    $current['content'] = $content;
+                    $current['content'] = substr($content, $content_pos);
                 } else {
-                    $temp = $this->_decode_ber($content, $start);
-                    $length-= strlen($content);
+                    $temp = $this->_decode_ber($content, $start, $content_pos);
+                    $length-= (strlen($content) - $content_pos);
                     $last = count($temp) - 1;
                     for ($i = 0; $i < $last; $i++) {
                         // all subtags should be bit strings
@@ -373,13 +376,13 @@ class ASN1
                 break;
             case self::TYPE_OCTET_STRING:
                 if (!$constructed) {
-                    $current['content'] = $content;
+                    $current['content'] = substr($content, $content_pos);
                 } else {
                     $current['content'] = '';
                     $length = 0;
-                    while (substr($content, 0, 2) != "\0\0") {
-                        $temp = $this->_decode_ber($content, $length + $start);
-                        $this->_string_shift($content, $temp['length']);
+                    while (substr($content, $content_pos, 2) != "\0\0") {
+                        $temp = $this->_decode_ber($content, $length + $start, $content_pos);
+                        $content_pos += $temp['length'];
                         // all subtags should be octet strings
                         //if ($temp['type'] != self::TYPE_OCTET_STRING) {
                         //    return false;
@@ -387,7 +390,7 @@ class ASN1
                         $current['content'].= $temp['content'];
                         $length+= $temp['length'];
                     }
-                    if (substr($content, 0, 2) == "\0\0") {
+                    if (substr($content, $content_pos, 2) == "\0\0") {
                         $length+= 2; // +2 for the EOC
                     }
                 }
@@ -402,26 +405,28 @@ class ASN1
             case self::TYPE_SET:
                 $offset = 0;
                 $current['content'] = array();
-                while (strlen($content)) {
+                $content_len = strlen($content);
+                while ($content_pos < $content_len) {
                     // if indefinite length construction was used and we have an end-of-content string next
                     // see paragraphs 8.1.1.3, 8.1.3.2, 8.1.3.6, 8.1.5, and (for an example) 8.6.4.2
-                    if (!isset($current['headerlength']) && substr($content, 0, 2) == "\0\0") {
+                    if (!isset($current['headerlength']) && substr($content, $content_pos, 2) == "\0\0") {
                         $length = $offset + 2; // +2 for the EOC
                         break 2;
                     }
-                    $temp = $this->_decode_ber($content, $start + $offset);
-                    $this->_string_shift($content, $temp['length']);
+                    $temp = $this->_decode_ber($content, $start + $offset, $content_pos);
+                    $content_pos += $temp['length'];
                     $current['content'][] = $temp;
                     $offset+= $temp['length'];
                 }
                 break;
             case self::TYPE_OBJECT_IDENTIFIER:
-                $temp = ord($this->_string_shift($content));
+                $temp = ord($content[$content_pos++]);
                 $current['content'] = sprintf('%d.%d', floor($temp / 40), $temp % 40);
                 $valuen = 0;
                 // process septets
-                while (strlen($content)) {
-                    $temp = ord($this->_string_shift($content));
+                $content_len = strlen($content);
+                while ($content_pos < $content_len) {
+                    $temp = ord($content[$content_pos++]);
                     $valuen <<= 7;
                     $valuen |= $temp & 0x7F;
                     if (~$temp & 0x80) {
@@ -462,11 +467,11 @@ class ASN1
             case self::TYPE_UTF8_STRING:
                 // ????
             case self::TYPE_BMP_STRING:
-                $current['content'] = $content;
+                $current['content'] = substr($content, $content_pos);
                 break;
             case self::TYPE_UTC_TIME:
             case self::TYPE_GENERALIZED_TIME:
-                $current['content'] = $this->_decodeTime($content, $tag);
+                $current['content'] = $this->_decodeTime(substr($content, $content_pos), $tag);
             default:
         }
 

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -1487,7 +1487,9 @@ class X509
 
         $this->signatureSubject = substr($cert, $decoded[0]['content'][0]['start'], $decoded[0]['content'][0]['length']);
 
-        $this->_mapInExtensions($x509, 'tbsCertificate/extensions', $asn1);
+        if ($this->_isSubArrayValid($x509, 'tbsCertificate/extensions')) {
+            $this->_mapInExtensions($x509, 'tbsCertificate/extensions', $asn1);
+        }
         $this->_mapInDNs($x509, 'tbsCertificate/issuer/rdnSequence', $asn1);
         $this->_mapInDNs($x509, 'tbsCertificate/subject/rdnSequence', $asn1);
 
@@ -1591,9 +1593,9 @@ class X509
      */
     function _mapInExtensions(&$root, $path, $asn1)
     {
-        $extensions = &$this->_subArray($root, $path);
+        $extensions = &$this->_subArrayUnchecked($root, $path);
 
-        if (is_array($extensions)) {
+        if ($extensions) {
             for ($i = 0; $i < count($extensions); $i++) {
                 $id = $extensions[$i]['extnId'];
                 $value = &$extensions[$i]['extnValue'];
@@ -1725,7 +1727,7 @@ class X509
                             if ($mapped !== false) {
                                 $values[$j] = $mapped;
                             }
-                            if ($id == 'pkcs-9-at-extensionRequest') {
+                            if ($id == 'pkcs-9-at-extensionRequest' && $this->_isSubArrayValid($values, $j)) {
                                 $this->_mapInExtensions($values, $j, $asn1);
                             }
                         } elseif ($map) {
@@ -3244,11 +3246,18 @@ class X509
         $this->signatureSubject = substr($orig, $decoded[0]['content'][0]['start'], $decoded[0]['content'][0]['length']);
 
         $this->_mapInDNs($crl, 'tbsCertList/issuer/rdnSequence', $asn1);
-        $this->_mapInExtensions($crl, 'tbsCertList/crlExtensions', $asn1);
-        $rclist = &$this->_subArray($crl, 'tbsCertList/revokedCertificates');
-        if (is_array($rclist)) {
-            foreach ($rclist as $i => $extension) {
-                $this->_mapInExtensions($rclist, "$i/crlEntryExtensions", $asn1);
+        if ($this->_isSubArrayValid($crl, 'tbsCertList/crlExtensions')) {
+            $this->_mapInExtensions($crl, 'tbsCertList/crlExtensions', $asn1);
+        }
+        if ($this->_isSubArrayValid($crl, 'tbsCertList/revokedCertificates')) {
+            $rclist_ref = &$this->_subArrayUnchecked($crl, 'tbsCertList/revokedCertificates');
+            if ($rclist_ref) {
+                $rclist = $crl['tbsCertList']['revokedCertificates'];
+                foreach ($rclist as $i => $extension) {
+                    if ($this->_isSubArrayValid($rclist, "$i/crlEntryExtensions", $asn1)) {
+                        $this->_mapInExtensions($rclist_ref, "$i/crlEntryExtensions", $asn1);
+                    }
+                }
             }
         }
 
@@ -3865,6 +3874,74 @@ class X509
     function makeCA()
     {
         $this->caFlag = true;
+    }
+
+    /**
+     * Check for validity of subarray
+     *
+     * This is intended for use in conjunction with _subArrayUnchecked(),
+     * implementing the checks included in _subArray() but without copying
+     * a potentially large array by passing its reference by-value to is_array().
+     *
+     * @param array $root
+     * @param string $path
+     * @return boolean
+     * @access private
+     */
+    function _isSubArrayValid($root, $path)
+    {
+        if (!is_array($root)) {
+            return false;
+        }
+
+        foreach (explode('/', $path) as $i) {
+            if (!is_array($root)) {
+                return false;
+            }
+
+            if (!isset($root[$i])) {
+                return true;
+            }
+
+            $root = $root[$i];
+        }
+
+        return true;
+    }
+
+    /**
+     * Get a reference to a subarray
+     *
+     * This variant of _subArray() does no is_array() checking,
+     * so $root should be checked with _isSubArrayValid() first.
+     *
+     * This is here for performance reasons:
+     * Passing a reference (i.e. $root) by-value (i.e. to is_array())
+     * creates a copy. If $root is an especially large array, this is expensive.
+     *
+     * @param array $root
+     * @param string $path  absolute path with / as component separator
+     * @param bool $create optional
+     * @access private
+     * @return array|false
+     */
+    function &_subArrayUnchecked(&$root, $path, $create = false)
+    {
+        $false = false;
+
+        foreach (explode('/', $path) as $i) {
+            if (!isset($root[$i])) {
+                if (!$create) {
+                    return $false;
+                }
+
+                $root[$i] = array();
+            }
+
+            $root = &$root[$i];
+        }
+
+        return $root;
     }
 
     /**


### PR DESCRIPTION
I happened to come across issue #871 which referenced a previous PR of mine dealing with performance, and it piqued my curiosity. With this pull request I think I have addressed the primary contributors to low performance when loading large CRLs.

By sprinkling some timestamp output throughout the code paths I determined 2 main areas where a slowdown was happening. The vast majority of time was spent in `X509->loadCRL()`, where it runs `_mapInExtensions()` for each item in `$crl['tbsCertList']['revokedCertificates']`. I narrowed this down to `is_array()` running abnormally slowly. As it turns out, this is due to the use of references. As far as I can tell, the section of code in question passes around references to arrays within arrays using `_subArray()` as a convenience for validating and addressing nested associative entries.

The problem lies in how PHP references work. Normally, variable assignment by-value operates with copy-on-write, so if you pass a large array to a function by-value, its contents don't actually get copied in memory unless one of the copied variables is written to. However, if a variable is created as a reference and it subsequently gets passed by-value to a function, it will be immediately copied.

So, what was happening is that in `_subArray()` the `$root` variable is passed as a reference, and then subsequently re-assigned locally as a reference to deeper sub-arrays, and at every step it is passed to `is_array()` which caused the entire thing to be copied in memory. Specifically, the `$rclist` array reference was passed to `_subArray()` once for every entry in the 'revokedCertificates' array. In addition, there are several places outside of `_subArray()` where a reference it returned was passed to `is_array()`.

At first I attempted to remove the use of references altogether, but that proved difficult as it's clear the reason for using them in the first place is to allow modification of these sub-arrays in place. So short of a massive refactor around that, my solution was to split the `_subArray()` function into 2 parts: a validator to which the array in question is passed by-value, and a reference returner which doesn't do any `is_array()` calls. This requires a bit of extra code everywhere `_mapInExtensions()` is called (to do the validation call first) but the speedup is huge (see below for performance data).

The second major slowdown area is in `ASN1->_decode_ber()`. This is where the use of `_string_shift()` as hypothesized in the issue actually manifests itself. Similar to PR #129, the issue here is that `_string_shift()` calls `substr()` on *both* halves of the (potentially large) input data as it is parsed. This causes both the (relatively small) current data to be copied for parsing, as well as the (relatively large) rest of the data to be copied, effectively only for the purpose of tracking where the next data is (it seems like the goal was to emulate consuming a file handle).

My solution to this was, rather than copying the remaining data over and over, to simply maintain a position index of where the next data is in the input string. Then, the only data that is copied is the "current" data being parsed, bit by bit.

Below are some timed runs of a test script to illustrate the speedups from the above changes. I used a local copy of the ~2MB CRL file from the original issue. Here is the test script:

```php
<?php

require_once 'vendor/autoload.php';

$crl_data = file_get_contents('crl2009.crl');
$cer = new phpseclib\File\X509();
$crl = $cer->loadCRL($crl_data);
```

Before any changes:
```
$ time php crltest.php
^C

real	70m55.993s
user	69m46.406s
sys	1m7.734s
$ 
```
As you can see, I killed the script after over an hour. Based on rough estimates from some previous runs with embedded timestamp output, it looked like this would have taken on the order of 10 hours to actually complete.

After the updates around the usage of `_subArray()`:
```
$ time php crltest.php

real	1m32.754s
user	1m31.713s
sys	0m1.002s
$ 
```

And after additionally the refactoring of the usage of `_string_shift()`:
```
$ time php crltest.php

real	0m6.804s
user	0m6.539s
sys	0m0.250s
$ 
```

As far as I can tell I have not affected the actual logic or correctness of the code with these optimizations, though I admit I haven't taken the time to 100% grok the CRL parser. The isolated operations I changed should be equivalent to the originals, and I did run the test suite to make sure that didn't catch anything.

As an additional note, I had to up my maximum memory setting in php.ini to even run this use case, and the PHP process ended up using about 430MB of RAM.