### PR TITLE
Organizational Revamp of the master branch

### DIFF
--- a/phpseclib/Common/StringMethods.php
+++ b/phpseclib/Common/StringMethods.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Common String Methods
+ *
+ * PHP version 5
+ *
+ * @category  Common
+ * @package   StringMethods
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
+ * @copyright 2007 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Common;
+
+/**
+ * Common String Methods
+ *
+ * @package StringMethods
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+trait StringFunctions {
+    /**
+     * String Shift
+     *
+     * Inspired by array_shift
+     *
+     * @param string $string
+     * @param int $index
+     * @access private
+     * @return string
+     */
+    function _string_shift(&$string, $index = 1)
+    {
+        $substr = substr($string, 0, $index);
+        $string = substr($string, $index);
+        return $substr;
+    }
+}

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -37,6 +37,8 @@
 
 namespace phpseclib\Crypt;
 
+use \phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Blowfish.
  *
@@ -45,7 +47,7 @@ namespace phpseclib\Crypt;
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  * @access  public
  */
-class Blowfish extends Base
+class Blowfish extends BlockCipher
 {
     /**
      * Block Length of the cipher

--- a/phpseclib/Crypt/Common/BlockCipher.php
+++ b/phpseclib/Crypt/Common/BlockCipher.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Base Class for all block ciphers
+ *
+ * PHP version 5
+ *
+ * @category  Crypt
+ * @package   BlockCipher
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
+ * @copyright 2007 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Crypt\Common;
+
+/**
+ * Base Class for all block cipher classes
+ *
+ * @package BlockCipher
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+abstract class BlockCipher extends SymmetricKey
+{
+}

--- a/phpseclib/Crypt/Common/StreamCipher.php
+++ b/phpseclib/Crypt/Common/StreamCipher.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Base Class for all stream ciphers
+ *
+ * PHP version 5
+ *
+ * @category  Crypt
+ * @package   StreamCipher
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
+ * @copyright 2007 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Crypt\Common;
+
+/**
+ * Base Class for all stream cipher classes
+ *
+ * @package StreamCipher
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+abstract class StreamCipher extends SymmetricKey
+{
+}

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -34,7 +34,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib\Crypt\Common;
 
 /**
  * Base Class for all \phpseclib\Crypt\* cipher classes
@@ -43,8 +43,10 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  */
-abstract class Base
+abstract class SymmetricKey
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * @access public
      * @see \phpseclib\Crypt\Base::encrypt()
@@ -1922,23 +1924,6 @@ abstract class Base
         }
 
         $this->encryptIV = $this->decryptIV = $this->iv;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @access private
-     * @return string
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -42,6 +42,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of DES.
  *
@@ -49,7 +51,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class DES extends Base
+class DES extends BlockCipher
 {
     /**#@+
      * @access private

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -35,13 +35,15 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of RC2.
  *
  * @package RC2
  * @access  public
  */
-class RC2 extends Base
+class RC2 extends BlockCipher
 {
     /**
      * Block Length of the cipher

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -44,6 +44,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\StreamCipher;
+
 /**
  * Pure-PHP implementation of RC4.
  *
@@ -51,7 +53,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class RC4 extends Base
+class RC4 extends StreamCipher
 {
     /**#@+
      * @access private

--- a/phpseclib/Crypt/RSA/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/MSBLOB.php
@@ -30,6 +30,8 @@ use phpseclib\Math\BigInteger;
  */
 class MSBLOB
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * @access private
      */
@@ -203,22 +205,5 @@ class MSBLOB
         $key.= $n;
 
         return Base64::encode($key);
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 }

--- a/phpseclib/Crypt/RSA/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/OpenSSH.php
@@ -28,6 +28,8 @@ use phpseclib\Math\BigInteger;
  */
 class OpenSSH
 {
+    use \phpseclib\Common\StringMethods;
+
     /**
      * Default comment
      *
@@ -120,22 +122,5 @@ class OpenSSH
         $RSAPublicKey = 'ssh-rsa ' . Base64::encode($RSAPublicKey) . ' ' . self::$comment;
 
         return $RSAPublicKey;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 }

--- a/phpseclib/Crypt/RSA/PKCS.php
+++ b/phpseclib/Crypt/RSA/PKCS.php
@@ -31,6 +31,8 @@ use phpseclib\Math\BigInteger;
  */
 abstract class PKCS
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * @access private
      * @see \phpseclib\Crypt\RSA::createKey()
@@ -439,23 +441,6 @@ abstract class PKCS
 
         $temp = ltrim(pack('N', $length), chr(0));
         return pack('Ca*', 0x80 | strlen($temp), $temp);
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Crypt/RSA/PuTTY.php
+++ b/phpseclib/Crypt/RSA/PuTTY.php
@@ -29,6 +29,8 @@ use phpseclib\Math\BigInteger;
  */
 class PuTTY
 {
+    use \phpseclib\Common\StringMethods;
+
     /**
      * Default comment
      *
@@ -169,23 +171,6 @@ class PuTTY
         $components['coefficients'] = array(2 => new BigInteger(self::_string_shift($private, $length), -256));
 
         return $components;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -54,6 +54,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Rijndael.
  *
@@ -61,7 +63,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class Rijndael extends Base
+class Rijndael extends BlockCipher
 {
     /**
      * The mcrypt specific name of the cipher

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -37,6 +37,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Twofish.
  *
@@ -45,7 +47,7 @@ namespace phpseclib\Crypt;
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  * @access  public
  */
-class Twofish extends Base
+class Twofish extends BlockCipher
 {
     /**
      * The mcrypt specific name of the cipher

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -36,6 +36,8 @@ use phpseclib\Math\BigInteger;
  */
 class ASN1
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * Tag Classes
      *
@@ -1205,23 +1207,6 @@ class ASN1
     function loadFilters($filters)
     {
         $this->filters = $filters;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -63,6 +63,8 @@ use phpseclib\Math\BigInteger;
  */
 class SSH1
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * Encryption Methods
      *
@@ -1270,23 +1272,6 @@ class SSH1
         // In addition to having to set $crc to 0xFFFFFFFF, initially, the return value must be XOR'd with
         // 0xFFFFFFFF for this function to return the same thing that PHP's crc32 function would.
         return $crc;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -72,6 +72,8 @@ use phpseclib\Exception\NoSupportedAlgorithmsException;
  */
 class SSH2
 {
+    use \phpseclib\Common\StringMethods;
+
     /**#@+
      * Execution Bitmap Masks
      *
@@ -3629,23 +3631,6 @@ class SSH2
             fclose($this->fsock);
             return false;
         }
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**


### PR DESCRIPTION
- rename \phpseclib\Crypt\Base to \phpseclib\Crypt\Common\SymmetricKey
- create BlockCipher and StreamCipher to extend SymmetricKey
- create \phpselib\Common\StringMethods as a trait
- move _encodeLength and _decodeLength to Common\Functions\ASN1.php

It probably would have been better if I had made the SymmetricKey / BlockCipher / StreamCipher changes in a separate commit but what's done is done. I'm thinking I'll make RSA extend a new PublicKey class later, after DSA and ECDSA are finished.