### PR TITLE
Organizational Revamp of the master branch

### DIFF
--- a/phpseclib/Common/Functions/ASN1.php
+++ b/phpseclib/Common/Functions/ASN1.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Common ASN1 Functions
+ *
+ * PHP version 5
+ *
+ * @category  Common
+ * @package   Functions\ASN1
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2016 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Common\Functions;
+
+/**
+ * Common ASN1 Functions
+ *
+ * @package Functions\ASN1
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+class ASN1
+{
+    /**
+     * DER-decode the length
+     *
+     * DER supports lengths up to (2**8)**127, however, we'll only support lengths up to (2**8)**4.  See
+     * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
+     *
+     * @access public
+     * @param string $string
+     * @return int
+     */
+    static function decodeLength(&$string)
+    {
+        $length = ord(Strings::shift($string));
+        if ($length & 0x80) { // definite length, long form
+            $length&= 0x7F;
+            $temp = Strings::shift($string, $length);
+            list(, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
+        }
+        return $length;
+    }
+
+    /**
+     * DER-encode the length
+     *
+     * DER supports lengths up to (2**8)**127, however, we'll only support lengths up to (2**8)**4.  See
+     * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
+     *
+     * @access public
+     * @param int $length
+     * @return string
+     */
+    static function encodeLength($length)
+    {
+        if ($length <= 0x7F) {
+            return chr($length);
+        }
+
+        $temp = ltrim(pack('N', $length), chr(0));
+        return pack('Ca*', 0x80 | strlen($temp), $temp);
+    }
+}

--- a/phpseclib/Common/Functions/Strings.php
+++ b/phpseclib/Common/Functions/Strings.php
@@ -30,7 +30,7 @@ class Strings
      *
      * @param string $string
      * @param int $index
-     * @access private
+     * @access public
      * @return string
      */
     static function shift(&$string, $index = 1)

--- a/phpseclib/Common/Functions/Strings.php
+++ b/phpseclib/Common/Functions/Strings.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Common String Functions
+ *
+ * PHP version 5
+ *
+ * @category  Common
+ * @package   Functions\Strings
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2016 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Common\Functions;
+
+/**
+ * Common String Functions
+ *
+ * @package Functions\Strings
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+class Strings
+{
+    /**
+     * String Shift
+     *
+     * Inspired by array_shift
+     *
+     * @param string $string
+     * @param int $index
+     * @access private
+     * @return string
+     */
+    static function shift(&$string, $index = 1)
+    {
+        $substr = substr($string, 0, $index);
+        $string = substr($string, $index);
+        return $substr;
+    }
+}

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -37,6 +37,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Blowfish.
  *
@@ -45,12 +47,12 @@ namespace phpseclib\Crypt;
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  * @access  public
  */
-class Blowfish extends Base
+class Blowfish extends BlockCipher
 {
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Base::block_size
+     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -59,7 +61,7 @@ class Blowfish extends Base
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -68,7 +70,7 @@ class Blowfish extends Base
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Base::cfb_init_len
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -273,7 +275,7 @@ class Blowfish extends Base
     /**
      * The Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\Base::setKeyLength()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 8 = 32, the min value is 128 / 8 = 16.  Exists in conjunction with $Nk
@@ -321,9 +323,9 @@ class Blowfish extends Base
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::isValidEngine()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      * @param int $engine
      * @access public
      * @return bool
@@ -344,7 +346,7 @@ class Blowfish extends Base
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -471,7 +473,7 @@ class Blowfish extends Base
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Base::_setupInlineCrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     function _setupInlineCrypt()

--- a/phpseclib/Crypt/Common/BlockCipher.php
+++ b/phpseclib/Crypt/Common/BlockCipher.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Base Class for all block ciphers
+ *
+ * PHP version 5
+ *
+ * @category  Crypt
+ * @package   BlockCipher
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
+ * @copyright 2007 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Crypt\Common;
+
+/**
+ * Base Class for all block cipher classes
+ *
+ * @package BlockCipher
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+abstract class BlockCipher extends SymmetricKey
+{
+}

--- a/phpseclib/Crypt/Common/StreamCipher.php
+++ b/phpseclib/Crypt/Common/StreamCipher.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Base Class for all stream ciphers
+ *
+ * PHP version 5
+ *
+ * @category  Crypt
+ * @package   StreamCipher
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @author    Hans-Juergen Petrich <petrich@tronic-media.com>
+ * @copyright 2007 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+namespace phpseclib\Crypt\Common;
+
+/**
+ * Base Class for all stream cipher classes
+ *
+ * @package StreamCipher
+ * @author  Jim Wigginton <terrafrost@php.net>
+ */
+abstract class StreamCipher extends SymmetricKey
+{
+}

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -8,7 +8,7 @@
  * Internally for phpseclib developers:
  *  If you plan to add a new cipher class, please note following rules:
  *
- *  - The new \phpseclib\Crypt\* cipher class should extend \phpseclib\Crypt\Base
+ *  - The new \phpseclib\Crypt\* cipher class should extend \phpseclib\Crypt\Common\SymmetricKey
  *
  *  - Following methods are then required to be overridden/overloaded:
  *
@@ -20,7 +20,7 @@
  *
  *  - All other methods are optional to be overridden/overloaded
  *
- *  - Look at the source code of the current ciphers how they extend \phpseclib\Crypt\Base
+ *  - Look at the source code of the current ciphers how they extend \phpseclib\Crypt\Common\SymmetricKey
  *    and take one of them as a start up for the new cipher class.
  *
  *  - Please read all the other comments/notes/hints here also for each class var/method
@@ -34,7 +34,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib\Crypt\Common;
+
+use phpseclib\Crypt\Hash;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * Base Class for all \phpseclib\Crypt\* cipher classes
@@ -43,12 +46,12 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  */
-abstract class Base
+abstract class SymmetricKey
 {
     /**#@+
      * @access public
-     * @see \phpseclib\Crypt\Base::encrypt()
-     * @see \phpseclib\Crypt\Base::decrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
      */
     /**
      * Encrypt / decrypt using the Counter mode.
@@ -91,7 +94,7 @@ abstract class Base
     /**
      * Whirlpool available flag
      *
-     * @see \phpseclib\Crypt\Base::_hashInlineCryptFunction()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_hashInlineCryptFunction()
      * @var bool
      * @access private
      */
@@ -99,7 +102,7 @@ abstract class Base
 
     /**#@+
      * @access private
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      */
     /**
      * Base value for the internal implementation $engine switch
@@ -901,7 +904,7 @@ abstract class Base
                             $buffer['ciphertext'].= $this->_encryptBlock($xor);
                         }
                         $this->_increment_str($xor);
-                        $key = $this->_string_shift($buffer['ciphertext'], $block_size);
+                        $key = Strings::shift($buffer['ciphertext'], $block_size);
                         $ciphertext.= $block ^ $key;
                     }
                 } else {
@@ -970,7 +973,7 @@ abstract class Base
                             $xor = $this->_encryptBlock($xor);
                             $buffer['xor'].= $xor;
                         }
-                        $key = $this->_string_shift($buffer['xor'], $block_size);
+                        $key = Strings::shift($buffer['xor'], $block_size);
                         $ciphertext.= $block ^ $key;
                     }
                 } else {
@@ -1194,7 +1197,7 @@ abstract class Base
                             $buffer['ciphertext'].= $this->_encryptBlock($xor);
                             $this->_increment_str($xor);
                         }
-                        $key = $this->_string_shift($buffer['ciphertext'], $block_size);
+                        $key = Strings::shift($buffer['ciphertext'], $block_size);
                         $plaintext.= $block ^ $key;
                     }
                 } else {
@@ -1262,7 +1265,7 @@ abstract class Base
                             $xor = $this->_encryptBlock($xor);
                             $buffer['xor'].= $xor;
                         }
-                        $key = $this->_string_shift($buffer['xor'], $block_size);
+                        $key = Strings::shift($buffer['xor'], $block_size);
                         $plaintext.= $block ^ $key;
                     }
                 } else {
@@ -1306,8 +1309,8 @@ abstract class Base
      * OpenSSL CTR Processor
      *
      * PHP's OpenSSL bindings do not operate in continuous mode so we'll wrap around it. Since the keystream
-     * for CTR is the same for both encrypting and decrypting this function is re-used by both Base::encrypt()
-     * and Base::decrypt(). Also, OpenSSL doesn't implement CTR for all of it's symmetric ciphers so this
+     * for CTR is the same for both encrypting and decrypting this function is re-used by both SymmetricKey::encrypt()
+     * and SymmetricKey::decrypt(). Also, OpenSSL doesn't implement CTR for all of it's symmetric ciphers so this
      * function will emulate CTR with ECB when necesary.
      *
      * @see self::encrypt()
@@ -1336,7 +1339,7 @@ abstract class Base
                         $buffer['ciphertext'].= $result;
                     }
                     $this->_increment_str($xor);
-                    $otp = $this->_string_shift($buffer['ciphertext'], $block_size);
+                    $otp = Strings::shift($buffer['ciphertext'], $block_size);
                     $ciphertext.= $block ^ $otp;
                 }
             } else {
@@ -1359,7 +1362,7 @@ abstract class Base
         }
 
         if (strlen($buffer['ciphertext'])) {
-            $ciphertext = $plaintext ^ $this->_string_shift($buffer['ciphertext'], strlen($plaintext));
+            $ciphertext = $plaintext ^ Strings::shift($buffer['ciphertext'], strlen($plaintext));
             $plaintext = substr($plaintext, strlen($ciphertext));
 
             if (!strlen($plaintext)) {
@@ -1401,8 +1404,8 @@ abstract class Base
      * OpenSSL OFB Processor
      *
      * PHP's OpenSSL bindings do not operate in continuous mode so we'll wrap around it. Since the keystream
-     * for OFB is the same for both encrypting and decrypting this function is re-used by both Base::encrypt()
-     * and Base::decrypt().
+     * for OFB is the same for both encrypting and decrypting this function is re-used by both SymmetricKey::encrypt()
+     * and SymmetricKey::decrypt().
      *
      * @see self::encrypt()
      * @see self::decrypt()
@@ -1435,7 +1438,7 @@ abstract class Base
                 if ($this->continuousBuffer) {
                     $encryptIV = $xor;
                 }
-                $ciphertext.= $this->_string_shift($xor, $overflow) ^ substr($plaintext, -$overflow);
+                $ciphertext.= Strings::shift($xor, $overflow) ^ substr($plaintext, -$overflow);
                 if ($this->continuousBuffer) {
                     $buffer['xor'] = $xor;
                 }
@@ -1640,11 +1643,11 @@ abstract class Base
      *
      * Currently, $engine could be:
      *
-     * - \phpseclib\Crypt\Base::ENGINE_OPENSSL  [very fast]
+     * - \phpseclib\Crypt\Common\SymmetricKey::ENGINE_OPENSSL  [very fast]
      *
-     * - \phpseclib\Crypt\Base::ENGINE_MCRYPT   [fast]
+     * - \phpseclib\Crypt\Common\SymmetricKey::ENGINE_MCRYPT   [fast]
      *
-     * - \phpseclib\Crypt\Base::ENGINE_INTERNAL [slow]
+     * - \phpseclib\Crypt\Common\SymmetricKey::ENGINE_INTERNAL [slow]
      *
      * If the preferred crypt engine is not available the fastest available one will be used
      *
@@ -1925,23 +1928,6 @@ abstract class Base
     }
 
     /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @access private
-     * @return string
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
-    }
-
-    /**
      * String Pop
      *
      * Inspired by array_pop
@@ -2057,7 +2043,7 @@ abstract class Base
      */
     function _setupInlineCrypt()
     {
-        // If, for any reason, an extending \phpseclib\Crypt\Base() \phpseclib\Crypt\* class
+        // If, for any reason, an extending \phpseclib\Crypt\Common\SymmetricKey() \phpseclib\Crypt\* class
         // not using inline crypting then it must be ensured that: $this->use_inline_crypt = false
         // ie in the class var declaration of $use_inline_crypt in general for the \phpseclib\Crypt\* class,
         // in the constructor at object instance-time
@@ -2236,7 +2222,7 @@ abstract class Base
                                 $self->_increment_str($_xor);
                                 $_buffer["ciphertext"].= $in;
                             }
-                            $_key = $self->_string_shift($_buffer["ciphertext"], '.$block_size.');
+                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
                             $_ciphertext.= $_block ^ $_key;
                         }
                     } else {
@@ -2274,7 +2260,7 @@ abstract class Base
                                 $self->_increment_str($_xor);
                                 $_buffer["ciphertext"].= $in;
                             }
-                            $_key = $self->_string_shift($_buffer["ciphertext"], '.$block_size.');
+                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
                             $_plaintext.= $_block ^ $_key;
                         }
                     } else {
@@ -2412,7 +2398,7 @@ abstract class Base
                                 $_xor = $in;
                                 $_buffer["xor"].= $_xor;
                             }
-                            $_key = $self->_string_shift($_buffer["xor"], '.$block_size.');
+                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
                             $_ciphertext.= $_block ^ $_key;
                         }
                     } else {
@@ -2448,7 +2434,7 @@ abstract class Base
                                 $_xor = $in;
                                 $_buffer["xor"].= $_xor;
                             }
-                            $_key = $self->_string_shift($_buffer["xor"], '.$block_size.');
+                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
                             $_plaintext.= $_block ^ $_key;
                         }
                     } else {

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -42,6 +42,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of DES.
  *
@@ -49,7 +51,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class DES extends Base
+class DES extends BlockCipher
 {
     /**#@+
      * @access private
@@ -69,7 +71,7 @@ class DES extends Base
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Base::block_size
+     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -78,7 +80,7 @@ class DES extends Base
     /**
      * Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\Base::setKeyLength()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setKeyLength()
      * @var int
      * @access private
      */
@@ -87,7 +89,7 @@ class DES extends Base
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -96,7 +98,7 @@ class DES extends Base
     /**
      * The OpenSSL names of the cipher / modes
      *
-     * @see \phpseclib\Crypt\Base::openssl_mode_names
+     * @see \phpseclib\Crypt\Common\SymmetricKey::openssl_mode_names
      * @var array
      * @access private
      */
@@ -111,7 +113,7 @@ class DES extends Base
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Base::cfb_init_len
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -597,9 +599,9 @@ class DES extends Base
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::isValidEngine()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      * @param int $engine
      * @access public
      * @return bool
@@ -623,7 +625,7 @@ class DES extends Base
      *
      * DES also requires that every eighth bit be a parity bit, however, we'll ignore that.
      *
-     * @see \phpseclib\Crypt\Base::setKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
      * @access public
      * @param string $key
      */
@@ -640,8 +642,8 @@ class DES extends Base
     /**
      * Encrypts a block
      *
-     * @see \phpseclib\Crypt\Base::_encryptBlock()
-     * @see \phpseclib\Crypt\Base::encrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_encryptBlock()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
      * @see self::encrypt()
      * @access private
      * @param string $in
@@ -655,8 +657,8 @@ class DES extends Base
     /**
      * Decrypts a block
      *
-     * @see \phpseclib\Crypt\Base::_decryptBlock()
-     * @see \phpseclib\Crypt\Base::decrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_decryptBlock()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
      * @see self::decrypt()
      * @access private
      * @param string $in
@@ -759,7 +761,7 @@ class DES extends Base
     /**
      * Creates the key schedule
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -1294,7 +1296,7 @@ class DES extends Base
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Base::_setupInlineCrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     function _setupInlineCrypt()

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -35,6 +35,7 @@ namespace phpseclib\Crypt;
 
 use phpseclib\Math\BigInteger;
 use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * @package Hash
@@ -327,7 +328,7 @@ class Hash
         foreach ($chunks as $chunk) {
             $w = array();
             for ($i = 0; $i < 16; $i++) {
-                $temp = new BigInteger(self::_string_shift($chunk, 8), 256);
+                $temp = new BigInteger(Strings::shift($chunk, 8), 256);
                 $temp->setPrecision(64);
                 $w[] = $temp;
             }
@@ -428,22 +429,5 @@ class Hash
                 $hash[4]->toBytes() . $hash[5]->toBytes() . $hash[6]->toBytes() . $hash[7]->toBytes();
 
         return $temp;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 }

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -35,18 +35,20 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of RC2.
  *
  * @package RC2
  * @access  public
  */
-class RC2 extends Base
+class RC2 extends BlockCipher
 {
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Base::block_size
+     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -55,7 +57,7 @@ class RC2 extends Base
     /**
      * The Key
      *
-     * @see \phpseclib\Crypt\Base::key
+     * @see \phpseclib\Crypt\Common\SymmetricKey::key
      * @see self::setKey()
      * @var string
      * @access private
@@ -65,7 +67,7 @@ class RC2 extends Base
     /**
      * The Original (unpadded) Key
      *
-     * @see \phpseclib\Crypt\Base::key
+     * @see \phpseclib\Crypt\Common\SymmetricKey::key
      * @see self::setKey()
      * @see self::encrypt()
      * @see self::decrypt()
@@ -77,7 +79,7 @@ class RC2 extends Base
     /**
      * Don't truncate / null pad key
      *
-     * @see \phpseclib\Crypt\Base::_clearBuffers()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_clearBuffers()
      * @var bool
      * @access private
      */
@@ -95,7 +97,7 @@ class RC2 extends Base
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -104,7 +106,7 @@ class RC2 extends Base
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Base::cfb_init_len
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -278,9 +280,9 @@ class RC2 extends Base
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access public
      * @return bool
@@ -341,7 +343,7 @@ class RC2 extends Base
      * If the key is not explicitly set, it'll be assumed to be a single
      * null byte.
      *
-     * @see \phpseclib\Crypt\Base::setKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
      * @access public
      * @param string $key
      * @param int $t1 optional Effective key length in bits.
@@ -396,7 +398,7 @@ class RC2 extends Base
     /**
      * Encrypts a message.
      *
-     * Mostly a wrapper for \phpseclib\Crypt\Base::encrypt, with some additional OpenSSL handling code
+     * Mostly a wrapper for \phpseclib\Crypt\Common\SymmetricKey::encrypt, with some additional OpenSSL handling code
      *
      * @see self::decrypt()
      * @access public
@@ -419,7 +421,7 @@ class RC2 extends Base
     /**
      * Decrypts a message.
      *
-     * Mostly a wrapper for \phpseclib\Crypt\Base::decrypt, with some additional OpenSSL handling code
+     * Mostly a wrapper for \phpseclib\Crypt\Common\SymmetricKey::decrypt, with some additional OpenSSL handling code
      *
      * @see self::encrypt()
      * @access public
@@ -442,8 +444,8 @@ class RC2 extends Base
     /**
      * Encrypts a block
      *
-     * @see \phpseclib\Crypt\Base::_encryptBlock()
-     * @see \phpseclib\Crypt\Base::encrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_encryptBlock()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
      * @access private
      * @param string $in
      * @return string
@@ -487,8 +489,8 @@ class RC2 extends Base
     /**
      * Decrypts a block
      *
-     * @see \phpseclib\Crypt\Base::_decryptBlock()
-     * @see \phpseclib\Crypt\Base::decrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_decryptBlock()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
      * @access private
      * @param string $in
      * @return string
@@ -530,9 +532,9 @@ class RC2 extends Base
     }
 
     /**
-     * Setup the \phpseclib\Crypt\Base::ENGINE_MCRYPT $engine
+     * Setup the \phpseclib\Crypt\Common\SymmetricKey::ENGINE_MCRYPT $engine
      *
-     * @see \phpseclib\Crypt\Base::_setupMcrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupMcrypt()
      * @access private
      */
     function _setupMcrypt()
@@ -547,7 +549,7 @@ class RC2 extends Base
     /**
      * Creates the key schedule
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -568,7 +570,7 @@ class RC2 extends Base
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Base::_setupInlineCrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     function _setupInlineCrypt()

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -44,6 +44,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\StreamCipher;
+
 /**
  * Pure-PHP implementation of RC4.
  *
@@ -51,7 +53,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class RC4 extends Base
+class RC4 extends StreamCipher
 {
     /**#@+
      * @access private
@@ -67,7 +69,7 @@ class RC4 extends Base
      * RC4 is a stream cipher
      * so we the block_size to 0
      *
-     * @see \phpseclib\Crypt\Base::block_size
+     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -85,7 +87,7 @@ class RC4 extends Base
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -94,7 +96,7 @@ class RC4 extends Base
     /**
      * Holds whether performance-optimized $inline_crypt() can/should be used.
      *
-     * @see \phpseclib\Crypt\Base::inline_crypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::inline_crypt
      * @var mixed
      * @access private
      */
@@ -121,21 +123,21 @@ class RC4 extends Base
     /**
      * Default Constructor.
      *
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @return \phpseclib\Crypt\RC4
      * @access public
      */
     function __construct()
     {
-        parent::__construct(Base::MODE_STREAM);
+        parent::__construct(self::MODE_STREAM);
     }
 
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access public
      * @return bool
@@ -143,7 +145,7 @@ class RC4 extends Base
     function isValidEngine($engine)
     {
         switch ($engine) {
-            case Base::ENGINE_OPENSSL:
+            case self::ENGINE_OPENSSL:
                 switch (strlen($this->key)) {
                     case 5:
                         $this->cipher_name_openssl = 'rc4-40';
@@ -215,7 +217,7 @@ class RC4 extends Base
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Base::decrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
      * @see self::_crypt()
      * @access public
      * @param string $plaintext
@@ -223,7 +225,7 @@ class RC4 extends Base
      */
     function encrypt($plaintext)
     {
-        if ($this->engine != Base::ENGINE_INTERNAL) {
+        if ($this->engine != self::ENGINE_INTERNAL) {
             return parent::encrypt($plaintext);
         }
         return $this->_crypt($plaintext, self::ENCRYPT);
@@ -235,7 +237,7 @@ class RC4 extends Base
      * $this->decrypt($this->encrypt($plaintext)) == $this->encrypt($this->encrypt($plaintext)).
      * At least if the continuous buffer is disabled.
      *
-     * @see \phpseclib\Crypt\Base::encrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
      * @see self::_crypt()
      * @access public
      * @param string $ciphertext
@@ -243,7 +245,7 @@ class RC4 extends Base
      */
     function decrypt($ciphertext)
     {
-        if ($this->engine != Base::ENGINE_INTERNAL) {
+        if ($this->engine != self::ENGINE_INTERNAL) {
             return parent::decrypt($ciphertext);
         }
         return $this->_crypt($ciphertext, self::DECRYPT);
@@ -274,7 +276,7 @@ class RC4 extends Base
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1094,47 +1094,6 @@ class RSA
     }
 
     /**
-     * DER-decode the length
-     *
-     * DER supports lengths up to (2**8)**127, however, we'll only support lengths up to (2**8)**4.  See
-     * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
-     *
-     * @access private
-     * @param string $string
-     * @return int
-     */
-    function _decodeLength(&$string)
-    {
-        $length = ord(Strings::shift($string));
-        if ($length & 0x80) { // definite length, long form
-            $length&= 0x7F;
-            $temp = Strings::shift($string, $length);
-            list(, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
-        }
-        return $length;
-    }
-
-    /**
-     * DER-encode the length
-     *
-     * DER supports lengths up to (2**8)**127, however, we'll only support lengths up to (2**8)**4.  See
-     * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
-     *
-     * @access private
-     * @param int $length
-     * @return string
-     */
-    function _encodeLength($length)
-    {
-        if ($length <= 0x7F) {
-            return chr($length);
-        }
-
-        $temp = ltrim(pack('N', $length), chr(0));
-        return pack('Ca*', 0x80 | strlen($temp), $temp);
-    }
-
-    /**
      * Determines the private key format
      *
      * @see self::__toString()

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -48,6 +48,7 @@ namespace phpseclib\Crypt;
 use ParagonIE\ConstantTime\Base64;
 use phpseclib\File\ASN1;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * Pure-PHP PKCS#1 compliant implementation of RSA.
@@ -1104,10 +1105,10 @@ class RSA
      */
     function _decodeLength(&$string)
     {
-        $length = ord($this->_string_shift($string));
+        $length = ord(Strings::shift($string));
         if ($length & 0x80) { // definite length, long form
             $length&= 0x7F;
-            $temp = $this->_string_shift($string, $length);
+            $temp = Strings::shift($string, $length);
             list(, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
         }
         return $length;
@@ -1131,23 +1132,6 @@ class RSA
 
         $temp = ltrim(pack('N', $length), chr(0));
         return pack('Ca*', 0x80 | strlen($temp), $temp);
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**
@@ -2072,12 +2056,12 @@ class RSA
             return false;
         }
 
-        if ($this->_string_shift($em, 2) != "\0\1") {
+        if (Strings::shift($em, 2) != "\0\1") {
             return false;
         }
 
         $em = ltrim($em, "\xFF");
-        if ($this->_string_shift($em) != "\0") {
+        if (Strings::shift($em) != "\0") {
             return false;
         }
 

--- a/phpseclib/Crypt/RSA/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/MSBLOB.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Miccrosoft BLOB Formatted RSA Key Handler
  *

--- a/phpseclib/Crypt/RSA/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/OpenSSH.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * OpenSSH Formatted RSA Key Handler
  *

--- a/phpseclib/Crypt/RSA/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/OpenSSH.php
@@ -18,6 +18,7 @@ namespace phpseclib\Crypt\RSA;
 
 use ParagonIE\ConstantTime\Base64;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * OpenSSH Formatted RSA Key Handler
@@ -73,23 +74,23 @@ class OpenSSH
         if (substr($key, 0, 11) != "\0\0\0\7ssh-rsa") {
             return false;
         }
-        self::_string_shift($key, 11);
+        Strings::shift($key, 11);
         if (strlen($key) <= 4) {
             return false;
         }
-        extract(unpack('Nlength', self::_string_shift($key, 4)));
+        extract(unpack('Nlength', Strings::shift($key, 4)));
         if (strlen($key) <= $length) {
             return false;
         }
-        $publicExponent = new BigInteger(self::_string_shift($key, $length), -256);
+        $publicExponent = new BigInteger(Strings::shift($key, $length), -256);
         if (strlen($key) <= 4) {
             return false;
         }
-        extract(unpack('Nlength', self::_string_shift($key, 4)));
+        extract(unpack('Nlength', Strings::shift($key, 4)));
         if (strlen($key) != $length) {
             return false;
         }
-        $modulus = new BigInteger(self::_string_shift($key, $length), -256);
+        $modulus = new BigInteger(Strings::shift($key, $length), -256);
 
         return array(
             'isPublicKey' => true,
@@ -120,22 +121,5 @@ class OpenSSH
         $RSAPublicKey = 'ssh-rsa ' . Base64::encode($RSAPublicKey) . ' ' . self::$comment;
 
         return $RSAPublicKey;
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 }

--- a/phpseclib/Crypt/RSA/PKCS.php
+++ b/phpseclib/Crypt/RSA/PKCS.php
@@ -16,11 +16,13 @@ namespace phpseclib\Crypt\RSA;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Base;
 use phpseclib\Crypt\DES;
 use phpseclib\Crypt\TripleDES;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * PKCS Formatted RSA Key Handler
@@ -94,15 +96,15 @@ abstract class PKCS
     {
         switch ($mode) {
             case 'CBC':
-                return Base::MODE_CBC;
+                return BlockCipher::MODE_CBC;
             case 'ECB':
-                return Base::MODE_ECB;
+                return BlockCipher::MODE_ECB;
             case 'CFB':
-                return Base::MODE_CFB;
+                return BlockCipher::MODE_CFB;
             case 'OFB':
-                return Base::MODE_OFB;
+                return BlockCipher::MODE_OFB;
             case 'CTR':
-                return Base::MODE_CTR;
+                return BlockCipher::MODE_CTR;
         }
         throw new \UnexpectedValueException('Unsupported block cipher mode of operation');
     }
@@ -208,14 +210,14 @@ abstract class PKCS
             }
         }
 
-        if (ord(self::_string_shift($key)) != self::ASN1_SEQUENCE) {
+        if (ord(Strings::shift($key)) != self::ASN1_SEQUENCE) {
             return false;
         }
         if (self::_decodeLength($key) != strlen($key)) {
             return false;
         }
 
-        $tag = ord(self::_string_shift($key));
+        $tag = ord(Strings::shift($key));
         /* intended for keys for which OpenSSL's asn1parse returns the following:
 
             0:d=0  hl=4 l= 631 cons: SEQUENCE
@@ -228,17 +230,17 @@ abstract class PKCS
            ie. PKCS8 keys */
 
         if ($tag == self::ASN1_INTEGER && substr($key, 0, 3) == "\x01\x00\x30") {
-            self::_string_shift($key, 3);
+            Strings::shift($key, 3);
             $tag = self::ASN1_SEQUENCE;
         }
 
         if ($tag == self::ASN1_SEQUENCE) {
-            $temp = self::_string_shift($key, self::_decodeLength($key));
-            if (ord(self::_string_shift($temp)) != self::ASN1_OBJECT) {
+            $temp = Strings::shift($key, self::_decodeLength($key));
+            if (ord(Strings::shift($temp)) != self::ASN1_OBJECT) {
                 return false;
             }
             $length = self::_decodeLength($temp);
-            switch (self::_string_shift($temp, $length)) {
+            switch (Strings::shift($temp, $length)) {
                 case "\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01": // rsaEncryption
                     break;
                 case "\x2a\x86\x48\x86\xf7\x0d\x01\x05\x03": // pbeWithMD5AndDES-CBC
@@ -247,20 +249,20 @@ abstract class PKCS
                            salt OCTET STRING (SIZE(8)),
                            iterationCount INTEGER }
                     */
-                    if (ord(self::_string_shift($temp)) != self::ASN1_SEQUENCE) {
+                    if (ord(Strings::shift($temp)) != self::ASN1_SEQUENCE) {
                         return false;
                     }
                     if (self::_decodeLength($temp) != strlen($temp)) {
                         return false;
                     }
-                    self::_string_shift($temp); // assume it's an octet string
-                    $salt = self::_string_shift($temp, self::_decodeLength($temp));
-                    if (ord(self::_string_shift($temp)) != self::ASN1_INTEGER) {
+                    Strings::shift($temp); // assume it's an octet string
+                    $salt = Strings::shift($temp, self::_decodeLength($temp));
+                    if (ord(Strings::shift($temp)) != self::ASN1_INTEGER) {
                         return false;
                     }
                     self::_decodeLength($temp);
                     list(, $iterationCount) = unpack('N', str_pad($temp, 4, chr(0), STR_PAD_LEFT));
-                    self::_string_shift($key); // assume it's an octet string
+                    Strings::shift($key); // assume it's an octet string
                     $length = self::_decodeLength($key);
                     if (strlen($key) != $length) {
                         return false;
@@ -283,82 +285,82 @@ abstract class PKCS
                 6:d=2  hl=2 l=   9 prim:   OBJECT            :rsaEncryption
                17:d=2  hl=2 l=   0 prim:   NULL
                19:d=1  hl=4 l= 271 prim:  BIT STRING */
-            $tag = ord(self::_string_shift($key)); // skip over the BIT STRING / OCTET STRING tag
+            $tag = ord(Strings::shift($key)); // skip over the BIT STRING / OCTET STRING tag
             self::_decodeLength($key); // skip over the BIT STRING / OCTET STRING length
             // "The initial octet shall encode, as an unsigned binary integer wtih bit 1 as the least significant bit, the number of
             //  unused bits in the final subsequent octet. The number shall be in the range zero to seven."
             //  -- http://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf (section 8.6.2.2)
             if ($tag == self::ASN1_BITSTRING) {
-                self::_string_shift($key);
+                Strings::shift($key);
             }
-            if (ord(self::_string_shift($key)) != self::ASN1_SEQUENCE) {
+            if (ord(Strings::shift($key)) != self::ASN1_SEQUENCE) {
                 return false;
             }
             if (self::_decodeLength($key) != strlen($key)) {
                 return false;
             }
-            $tag = ord(self::_string_shift($key));
+            $tag = ord(Strings::shift($key));
         }
         if ($tag != self::ASN1_INTEGER) {
             return false;
         }
 
         $length = self::_decodeLength($key);
-        $temp = self::_string_shift($key, $length);
+        $temp = Strings::shift($key, $length);
         if (strlen($temp) != 1 || ord($temp) > 2) {
             $components['modulus'] = new BigInteger($temp, 256);
-            self::_string_shift($key); // skip over self::ASN1_INTEGER
+            Strings::shift($key); // skip over self::ASN1_INTEGER
             $length = self::_decodeLength($key);
-            $components[$components['isPublicKey'] ? 'publicExponent' : 'privateExponent'] = new BigInteger(self::_string_shift($key, $length), 256);
+            $components[$components['isPublicKey'] ? 'publicExponent' : 'privateExponent'] = new BigInteger(Strings::shift($key, $length), 256);
 
             return $components;
         }
-        if (ord(self::_string_shift($key)) != self::ASN1_INTEGER) {
+        if (ord(Strings::shift($key)) != self::ASN1_INTEGER) {
             return false;
         }
         $length = self::_decodeLength($key);
-        $components['modulus'] = new BigInteger(self::_string_shift($key, $length), 256);
-        self::_string_shift($key);
+        $components['modulus'] = new BigInteger(Strings::shift($key, $length), 256);
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['publicExponent'] = new BigInteger(self::_string_shift($key, $length), 256);
-        self::_string_shift($key);
+        $components['publicExponent'] = new BigInteger(Strings::shift($key, $length), 256);
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['privateExponent'] = new BigInteger(self::_string_shift($key, $length), 256);
-        self::_string_shift($key);
+        $components['privateExponent'] = new BigInteger(Strings::shift($key, $length), 256);
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['primes'] = array(1 => new BigInteger(self::_string_shift($key, $length), 256));
-        self::_string_shift($key);
+        $components['primes'] = array(1 => new BigInteger(Strings::shift($key, $length), 256));
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['primes'][] = new BigInteger(self::_string_shift($key, $length), 256);
-        self::_string_shift($key);
+        $components['primes'][] = new BigInteger(Strings::shift($key, $length), 256);
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['exponents'] = array(1 => new BigInteger(self::_string_shift($key, $length), 256));
-        self::_string_shift($key);
+        $components['exponents'] = array(1 => new BigInteger(Strings::shift($key, $length), 256));
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['exponents'][] = new BigInteger(self::_string_shift($key, $length), 256);
-        self::_string_shift($key);
+        $components['exponents'][] = new BigInteger(Strings::shift($key, $length), 256);
+        Strings::shift($key);
         $length = self::_decodeLength($key);
-        $components['coefficients'] = array(2 => new BigInteger(self::_string_shift($key, $length), 256));
+        $components['coefficients'] = array(2 => new BigInteger(Strings::shift($key, $length), 256));
 
         if (!empty($key)) {
-            if (ord(self::_string_shift($key)) != self::ASN1_SEQUENCE) {
+            if (ord(Strings::shift($key)) != self::ASN1_SEQUENCE) {
                 return false;
             }
             self::_decodeLength($key);
             while (!empty($key)) {
-                if (ord(self::_string_shift($key)) != self::ASN1_SEQUENCE) {
+                if (ord(Strings::shift($key)) != self::ASN1_SEQUENCE) {
                     return false;
                 }
                 self::_decodeLength($key);
                 $key = substr($key, 1);
                 $length = self::_decodeLength($key);
-                $components['primes'][] = new BigInteger(self::_string_shift($key, $length), 256);
-                self::_string_shift($key);
+                $components['primes'][] = new BigInteger(Strings::shift($key, $length), 256);
+                Strings::shift($key);
                 $length = self::_decodeLength($key);
-                $components['exponents'][] = new BigInteger(self::_string_shift($key, $length), 256);
-                self::_string_shift($key);
+                $components['exponents'][] = new BigInteger(Strings::shift($key, $length), 256);
+                Strings::shift($key);
                 $length = self::_decodeLength($key);
-                $components['coefficients'][] = new BigInteger(self::_string_shift($key, $length), 256);
+                $components['coefficients'][] = new BigInteger(Strings::shift($key, $length), 256);
             }
         }
 
@@ -412,10 +414,10 @@ abstract class PKCS
      */
     static function _decodeLength(&$string)
     {
-        $length = ord(self::_string_shift($string));
+        $length = ord(Strings::shift($string));
         if ($length & 0x80) { // definite length, long form
             $length&= 0x7F;
-            $temp = self::_string_shift($string, $length);
+            $temp = Strings::shift($string, $length);
             list(, $length) = unpack('N', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
         }
         return $length;
@@ -439,23 +441,6 @@ abstract class PKCS
 
         $temp = ltrim(pack('N', $length), chr(0));
         return pack('Ca*', 0x80 | strlen($temp), $temp);
-    }
-
-    /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    static function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
     }
 
     /**

--- a/phpseclib/Crypt/RSA/PKCS1.php
+++ b/phpseclib/Crypt/RSA/PKCS1.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PKCS#1 Formatted RSA Key Handler
  *
@@ -29,6 +30,7 @@ use phpseclib\Crypt\DES;
 use phpseclib\Crypt\Random;
 use phpseclib\Crypt\TripleDES;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\ASN1;
 
 /**
  * PKCS#1 Formatted RSA Key Handler
@@ -88,7 +90,7 @@ class PKCS1 extends PKCS
 
         $components = array();
         foreach ($raw as $name => $value) {
-            $components[$name] = pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($value)), $value);
+            $components[$name] = pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($value)), $value);
         }
 
         $RSAPrivateKey = implode('', $components);
@@ -103,15 +105,15 @@ class PKCS1 extends PKCS
                 //     exponent          INTEGER,  -- di
                 //     coefficient       INTEGER   -- ti
                 // }
-                $OtherPrimeInfo = pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($primes[$i]->toBytes(true))), $primes[$i]->toBytes(true));
-                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($exponents[$i]->toBytes(true))), $exponents[$i]->toBytes(true));
-                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($coefficients[$i]->toBytes(true))), $coefficients[$i]->toBytes(true));
-                $OtherPrimeInfos.= pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($OtherPrimeInfo)), $OtherPrimeInfo);
+                $OtherPrimeInfo = pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($primes[$i]->toBytes(true))), $primes[$i]->toBytes(true));
+                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($exponents[$i]->toBytes(true))), $exponents[$i]->toBytes(true));
+                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($coefficients[$i]->toBytes(true))), $coefficients[$i]->toBytes(true));
+                $OtherPrimeInfos.= pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($OtherPrimeInfo)), $OtherPrimeInfo);
             }
-            $RSAPrivateKey.= pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($OtherPrimeInfos)), $OtherPrimeInfos);
+            $RSAPrivateKey.= pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($OtherPrimeInfos)), $OtherPrimeInfos);
         }
 
-        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
+        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
 
         if (!empty($password) || is_string($password)) {
             $cipher = self::getEncryptionObject(self::$defaultEncryptionAlgorithm);
@@ -153,14 +155,14 @@ class PKCS1 extends PKCS
         //     publicExponent    INTEGER   -- e
         // }
         $components = array(
-            'modulus' => pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($modulus)), $modulus),
-            'publicExponent' => pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($publicExponent)), $publicExponent)
+            'modulus' => pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($modulus)), $modulus),
+            'publicExponent' => pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($publicExponent)), $publicExponent)
         );
 
         $RSAPublicKey = pack(
             'Ca*a*a*',
             self::ASN1_SEQUENCE,
-            self::_encodeLength(strlen($components['modulus']) + strlen($components['publicExponent'])),
+            ASN1::encodeLength(strlen($components['modulus']) + strlen($components['publicExponent'])),
             $components['modulus'],
             $components['publicExponent']
         );

--- a/phpseclib/Crypt/RSA/PKCS8.php
+++ b/phpseclib/Crypt/RSA/PKCS8.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PKCS#8 Formatted RSA Key Handler
  *
@@ -28,6 +29,7 @@ use ParagonIE\ConstantTime\Base64;
 use phpseclib\Crypt\DES;
 use phpseclib\Crypt\Random;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\ASN1;
 
 /**
  * PKCS#8 Formatted RSA Key Handler
@@ -68,7 +70,7 @@ class PKCS8 extends PKCS
 
         $components = array();
         foreach ($raw as $name => $value) {
-            $components[$name] = pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($value)), $value);
+            $components[$name] = pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($value)), $value);
         }
 
         $RSAPrivateKey = implode('', $components);
@@ -83,15 +85,15 @@ class PKCS8 extends PKCS
                 //     exponent          INTEGER,  -- di
                 //     coefficient       INTEGER   -- ti
                 // }
-                $OtherPrimeInfo = pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($primes[$i]->toBytes(true))), $primes[$i]->toBytes(true));
-                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($exponents[$i]->toBytes(true))), $exponents[$i]->toBytes(true));
-                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($coefficients[$i]->toBytes(true))), $coefficients[$i]->toBytes(true));
-                $OtherPrimeInfos.= pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($OtherPrimeInfo)), $OtherPrimeInfo);
+                $OtherPrimeInfo = pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($primes[$i]->toBytes(true))), $primes[$i]->toBytes(true));
+                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($exponents[$i]->toBytes(true))), $exponents[$i]->toBytes(true));
+                $OtherPrimeInfo.= pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($coefficients[$i]->toBytes(true))), $coefficients[$i]->toBytes(true));
+                $OtherPrimeInfos.= pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($OtherPrimeInfo)), $OtherPrimeInfo);
             }
-            $RSAPrivateKey.= pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($OtherPrimeInfos)), $OtherPrimeInfos);
+            $RSAPrivateKey.= pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($OtherPrimeInfos)), $OtherPrimeInfos);
         }
 
-        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
+        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
 
         $rsaOID = "\x30\x0d\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"; // hex version of MA0GCSqGSIb3DQEBAQUA
         $RSAPrivateKey = pack(
@@ -100,10 +102,10 @@ class PKCS8 extends PKCS
             "\01\00",
             $rsaOID,
             4,
-            self::_encodeLength(strlen($RSAPrivateKey)),
+            ASN1::encodeLength(strlen($RSAPrivateKey)),
             $RSAPrivateKey
         );
-        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
+        $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
         if (!empty($password) || is_string($password)) {
             $salt = Random::string(8);
             $iterationCount = 2048;
@@ -115,10 +117,10 @@ class PKCS8 extends PKCS
             $parameters = pack(
                 'Ca*a*Ca*N',
                 self::ASN1_OCTETSTRING,
-                self::_encodeLength(strlen($salt)),
+                ASN1::encodeLength(strlen($salt)),
                 $salt,
                 self::ASN1_INTEGER,
-                self::_encodeLength(4),
+                ASN1::encodeLength(4),
                 $iterationCount
             );
             $pbeWithMD5AndDES_CBC = "\x2a\x86\x48\x86\xf7\x0d\x01\x05\x03";
@@ -126,24 +128,24 @@ class PKCS8 extends PKCS
             $encryptionAlgorithm = pack(
                 'Ca*a*Ca*a*',
                 self::ASN1_OBJECT,
-                self::_encodeLength(strlen($pbeWithMD5AndDES_CBC)),
+                ASN1::encodeLength(strlen($pbeWithMD5AndDES_CBC)),
                 $pbeWithMD5AndDES_CBC,
                 self::ASN1_SEQUENCE,
-                self::_encodeLength(strlen($parameters)),
+                ASN1::encodeLength(strlen($parameters)),
                 $parameters
             );
 
             $RSAPrivateKey = pack(
                 'Ca*a*Ca*a*',
                 self::ASN1_SEQUENCE,
-                self::_encodeLength(strlen($encryptionAlgorithm)),
+                ASN1::encodeLength(strlen($encryptionAlgorithm)),
                 $encryptionAlgorithm,
                 self::ASN1_OCTETSTRING,
-                self::_encodeLength(strlen($RSAPrivateKey)),
+                ASN1::encodeLength(strlen($RSAPrivateKey)),
                 $RSAPrivateKey
             );
 
-            $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, self::_encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
+            $RSAPrivateKey = pack('Ca*a*', self::ASN1_SEQUENCE, ASN1::encodeLength(strlen($RSAPrivateKey)), $RSAPrivateKey);
 
             $RSAPrivateKey = "-----BEGIN ENCRYPTED PRIVATE KEY-----\r\n" .
                  chunk_split(Base64::encode($RSAPrivateKey), 64) .
@@ -176,14 +178,14 @@ class PKCS8 extends PKCS
         //     publicExponent    INTEGER   -- e
         // }
         $components = array(
-            'modulus' => pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($modulus)), $modulus),
-            'publicExponent' => pack('Ca*a*', self::ASN1_INTEGER, self::_encodeLength(strlen($publicExponent)), $publicExponent)
+            'modulus' => pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($modulus)), $modulus),
+            'publicExponent' => pack('Ca*a*', self::ASN1_INTEGER, ASN1::encodeLength(strlen($publicExponent)), $publicExponent)
         );
 
         $RSAPublicKey = pack(
             'Ca*a*a*',
             self::ASN1_SEQUENCE,
-            self::_encodeLength(strlen($components['modulus']) + strlen($components['publicExponent'])),
+            ASN1::encodeLength(strlen($components['modulus']) + strlen($components['publicExponent'])),
             $components['modulus'],
             $components['publicExponent']
         );
@@ -191,12 +193,12 @@ class PKCS8 extends PKCS
         // sequence(oid(1.2.840.113549.1.1.1), null)) = rsaEncryption.
         $rsaOID = "\x30\x0d\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"; // hex version of MA0GCSqGSIb3DQEBAQUA
         $RSAPublicKey = chr(0) . $RSAPublicKey;
-        $RSAPublicKey = chr(3) . self::_encodeLength(strlen($RSAPublicKey)) . $RSAPublicKey;
+        $RSAPublicKey = chr(3) . ASN1::encodeLength(strlen($RSAPublicKey)) . $RSAPublicKey;
 
         $RSAPublicKey = pack(
             'Ca*a*',
             self::ASN1_SEQUENCE,
-            self::_encodeLength(strlen($rsaOID . $RSAPublicKey)),
+            ASN1::encodeLength(strlen($rsaOID . $RSAPublicKey)),
             $rsaOID . $RSAPublicKey
         );
 

--- a/phpseclib/Crypt/RSA/PuTTY.php
+++ b/phpseclib/Crypt/RSA/PuTTY.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PuTTY Formatted RSA Key Handler
  *

--- a/phpseclib/Crypt/RSA/Raw.php
+++ b/phpseclib/Crypt/RSA/Raw.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Raw RSA Key Handler
  *

--- a/phpseclib/Crypt/RSA/XML.php
+++ b/phpseclib/Crypt/RSA/XML.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * XML Formatted RSA Key Handler
  *

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -24,6 +24,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP Random Number Generator
  *
@@ -139,19 +141,19 @@ class Random
             // http://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator#Designs_based_on_cryptographic_primitives
             switch (true) {
                 case class_exists('\phpseclib\Crypt\AES'):
-                    $crypto = new AES(Base::MODE_CTR);
+                    $crypto = new AES(BlockCipher::MODE_CTR);
                     break;
                 case class_exists('\phpseclib\Crypt\Twofish'):
-                    $crypto = new Twofish(Base::MODE_CTR);
+                    $crypto = new Twofish(BlockCipher::MODE_CTR);
                     break;
                 case class_exists('\phpseclib\Crypt\Blowfish'):
-                    $crypto = new Blowfish(Base::MODE_CTR);
+                    $crypto = new Blowfish(BlockCipher::MODE_CTR);
                     break;
                 case class_exists('\phpseclib\Crypt\TripleDES'):
-                    $crypto = new TripleDES(Base::MODE_CTR);
+                    $crypto = new TripleDES(BlockCipher::MODE_CTR);
                     break;
                 case class_exists('\phpseclib\Crypt\DES'):
-                    $crypto = new DES(Base::MODE_CTR);
+                    $crypto = new DES(BlockCipher::MODE_CTR);
                     break;
                 case class_exists('\phpseclib\Crypt\RC4'):
                     $crypto = new RC4();

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -54,6 +54,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Rijndael.
  *
@@ -61,7 +63,7 @@ namespace phpseclib\Crypt;
  * @author  Jim Wigginton <terrafrost@php.net>
  * @access  public
  */
-class Rijndael extends Base
+class Rijndael extends BlockCipher
 {
     /**
      * The mcrypt specific name of the cipher
@@ -71,8 +73,8 @@ class Rijndael extends Base
      * or not for the current $block_size/$key_length.
      * In case of, $cipher_name_mcrypt will be set dynamically at run time accordingly.
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
-     * @see \phpseclib\Crypt\Base::engine
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::engine
      * @see self::isValidEngine()
      * @var string
      * @access private
@@ -82,8 +84,8 @@ class Rijndael extends Base
     /**
      * The default salt used by setPassword()
      *
-     * @see \phpseclib\Crypt\Base::password_default_salt
-     * @see \phpseclib\Crypt\Base::setPassword()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::password_default_salt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setPassword()
      * @var string
      * @access private
      */
@@ -277,9 +279,9 @@ class Rijndael extends Base
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access public
      * @return bool
@@ -499,7 +501,7 @@ class Rijndael extends Base
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -804,7 +806,7 @@ class Rijndael extends Base
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Base::_setupInlineCrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     function _setupInlineCrypt()

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -55,9 +55,9 @@ class TripleDES extends DES
     /**
      * Encrypt / decrypt using outer chaining
      *
-     * Outer chaining is used by SSH-2 and when the mode is set to \phpseclib\Crypt\Base::MODE_CBC.
+     * Outer chaining is used by SSH-2 and when the mode is set to \phpseclib\Crypt\Common\BlockCipher::MODE_CBC.
      */
-    const MODE_CBC3 = Base::MODE_CBC;
+    const MODE_CBC3 = self::MODE_CBC;
 
     /**
      * Key Length (in bytes)
@@ -71,8 +71,8 @@ class TripleDES extends DES
     /**
      * The default salt used by setPassword()
      *
-     * @see \phpseclib\Crypt\Base::password_default_salt
-     * @see \phpseclib\Crypt\Base::setPassword()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::password_default_salt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setPassword()
      * @var string
      * @access private
      */
@@ -82,7 +82,7 @@ class TripleDES extends DES
      * The mcrypt specific name of the cipher
      *
      * @see \phpseclib\Crypt\DES::cipher_name_mcrypt
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -91,7 +91,7 @@ class TripleDES extends DES
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Base::cfb_init_len
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -132,20 +132,20 @@ class TripleDES extends DES
      *
      * $mode could be:
      *
-     * - \phpseclib\Crypt\Base::MODE_ECB
+     * - \phpseclib\Crypt\Common\BlockCipher::MODE_ECB
      *
-     * - \phpseclib\Crypt\Base::MODE_CBC
+     * - \phpseclib\Crypt\Common\BlockCipher::MODE_CBC
      *
-     * - \phpseclib\Crypt\Base::MODE_CTR
+     * - \phpseclib\Crypt\Common\BlockCipher::MODE_CTR
      *
-     * - \phpseclib\Crypt\Base::MODE_CFB
+     * - \phpseclib\Crypt\Common\BlockCipher::MODE_CFB
      *
-     * - \phpseclib\Crypt\Base::MODE_OFB
+     * - \phpseclib\Crypt\Common\BlockCipher::MODE_OFB
      *
      * - \phpseclib\Crypt\TripleDES::MODE_3CB
      *
      * @see \phpseclib\Crypt\DES::__construct()
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @param int $mode
      * @access public
      */
@@ -155,14 +155,14 @@ class TripleDES extends DES
             // In case of self::MODE_3CBC, we init as CRYPT_DES_MODE_CBC
             // and additional flag us internally as 3CBC
             case self::MODE_3CBC:
-                parent::__construct(Base::MODE_CBC);
+                parent::__construct(self::MODE_CBC);
                 $this->mode_3cbc = true;
 
                 // This three $des'es will do the 3CBC work (if $key > 64bits)
                 $this->des = array(
-                    new DES(Base::MODE_CBC),
-                    new DES(Base::MODE_CBC),
-                    new DES(Base::MODE_CBC),
+                    new DES(self::MODE_CBC),
+                    new DES(self::MODE_CBC),
+                    new DES(self::MODE_CBC),
                 );
 
                 // we're going to be doing the padding, ourselves, so disable it in the \phpseclib\Crypt\DES objects
@@ -179,9 +179,9 @@ class TripleDES extends DES
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Base::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Base::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access public
      * @return bool
@@ -200,9 +200,9 @@ class TripleDES extends DES
     /**
      * Sets the initialization vector.
      *
-     * SetIV is not required when \phpseclib\Crypt\Base::MODE_ECB is being used.
+     * SetIV is not required when \phpseclib\Crypt\Common\SymmetricKey::MODE_ECB is being used.
      *
-     * @see \phpseclib\Crypt\Base::setIV()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setIV()
      * @access public
      * @param string $iv
      */
@@ -223,7 +223,7 @@ class TripleDES extends DES
      *
      * If you want to use a 64-bit key use DES.php
      *
-     * @see \phpseclib\Crypt\Base:setKeyLength()
+     * @see \phpseclib\Crypt\Common\SymmetricKey:setKeyLength()
      * @access public
      * @throws \LengthException if the key length is invalid
      * @param int $length
@@ -250,7 +250,7 @@ class TripleDES extends DES
      *
      * @access public
      * @see \phpseclib\Crypt\DES::setKey()
-     * @see \phpseclib\Crypt\Base::setKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
      * @throws \LengthException if the key length is invalid
      * @param string $key
      */
@@ -269,7 +269,7 @@ class TripleDES extends DES
                 throw new \LengthException('Key of size ' . strlen($key) . ' not supported by this algorithm. Only keys of sizes 16 or 24 are supported');
         }
 
-        // copied from Base::setKey()
+        // copied from self::setKey()
         $this->key = $key;
         $this->key_length = strlen($key);
         $this->changed = true;
@@ -285,7 +285,7 @@ class TripleDES extends DES
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Base::encrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
      * @access public
      * @param string $plaintext
      * @return string $cipertext
@@ -312,7 +312,7 @@ class TripleDES extends DES
     /**
      * Decrypts a message.
      *
-     * @see \phpseclib\Crypt\Base::decrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext
@@ -368,7 +368,7 @@ class TripleDES extends DES
      * continuous buffers not be used.  They do offer better security and are, in fact, sometimes required (SSH uses them),
      * however, they are also less intuitive and more likely to cause you problems.
      *
-     * @see \phpseclib\Crypt\Base::enableContinuousBuffer()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::enableContinuousBuffer()
      * @see self::disableContinuousBuffer()
      * @access public
      */
@@ -387,7 +387,7 @@ class TripleDES extends DES
      *
      * The default behavior.
      *
-     * @see \phpseclib\Crypt\Base::disableContinuousBuffer()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::disableContinuousBuffer()
      * @see self::enableContinuousBuffer()
      * @access public
      */
@@ -405,7 +405,7 @@ class TripleDES extends DES
      * Creates the key schedule
      *
      * @see \phpseclib\Crypt\DES::_setupKey()
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -439,8 +439,8 @@ class TripleDES extends DES
     /**
      * Sets the internal crypt engine
      *
-     * @see \phpseclib\Crypt\Base::__construct()
-     * @see \phpseclib\Crypt\Base::setPreferredEngine()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::setPreferredEngine()
      * @param int $engine
      * @access public
      * @return int

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -37,6 +37,8 @@
 
 namespace phpseclib\Crypt;
 
+use phpseclib\Crypt\Common\BlockCipher;
+
 /**
  * Pure-PHP implementation of Twofish.
  *
@@ -45,12 +47,12 @@ namespace phpseclib\Crypt;
  * @author  Hans-Juergen Petrich <petrich@tronic-media.com>
  * @access  public
  */
-class Twofish extends Base
+class Twofish extends BlockCipher
 {
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Base::cipher_name_mcrypt
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -59,7 +61,7 @@ class Twofish extends Base
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Base::cfb_init_len
+     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -433,7 +435,7 @@ class Twofish extends Base
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Base::_setupKey()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     function _setupKey()
@@ -700,7 +702,7 @@ class Twofish extends Base
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Base::_setupInlineCrypt()
+     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     function _setupInlineCrypt()

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -1208,23 +1208,6 @@ class ASN1
     }
 
     /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
-    }
-
-    /**
      * String type conversion
      *
      * This is a lazy conversion, dealing only with character size.

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -26,6 +26,7 @@ namespace phpseclib\File;
 use ParagonIE\ConstantTime\Base64;
 use phpseclib\File\ASN1\Element;
 use phpseclib\Math\BigInteger;
+use phpseclib\Common\Functions\ASN1 as Functions;
 
 /**
  * Pure-PHP ASN.1 Parser
@@ -884,7 +885,7 @@ class ASN1
                          */
                         if (isset($child['explicit']) || $child['type'] == self::TYPE_CHOICE) {
                             $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | $child['constant']);
-                            $temp = $subtag . $this->_encodeLength(strlen($temp)) . $temp;
+                            $temp = $subtag . Functions::encodeLength(strlen($temp)) . $temp;
                         } else {
                             $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | (ord($temp[0]) & 0x20) | $child['constant']);
                             $temp = $subtag . substr($temp, 1);
@@ -918,7 +919,7 @@ class ASN1
                     if (isset($child['constant'])) {
                         if (isset($child['explicit']) || $child['type'] == self::TYPE_CHOICE) {
                             $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | $child['constant']);
-                            $temp = $subtag . $this->_encodeLength(strlen($temp)) . $temp;
+                            $temp = $subtag . Functions::encodeLength(strlen($temp)) . $temp;
                         } else {
                             $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | (ord($temp[0]) & 0x20) | $child['constant']);
                             $temp = $subtag . substr($temp, 1);
@@ -1089,34 +1090,14 @@ class ASN1
 
         if (isset($mapping['cast'])) {
             if (isset($mapping['explicit']) || $mapping['type'] == self::TYPE_CHOICE) {
-                $value = chr($tag) . $this->_encodeLength(strlen($value)) . $value;
+                $value = chr($tag) . Functions::encodeLength(strlen($value)) . $value;
                 $tag = ($mapping['class'] << 6) | 0x20 | $mapping['cast'];
             } else {
                 $tag = ($mapping['class'] << 6) | (ord($temp[0]) & 0x20) | $mapping['cast'];
             }
         }
 
-        return chr($tag) . $this->_encodeLength(strlen($value)) . $value;
-    }
-
-    /**
-     * DER-encode the length
-     *
-     * DER supports lengths up to (2**8)**127, however, we'll only support lengths up to (2**8)**4.  See
-     * {@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3} for more information.
-     *
-     * @access private
-     * @param int $length
-     * @return string
-     */
-    function _encodeLength($length)
-    {
-        if ($length <= 0x7F) {
-            return chr($length);
-        }
-
-        $temp = ltrim(pack('N', $length), chr(0));
-        return pack('Ca*', 0x80 | strlen($temp), $temp);
+        return chr($tag) . Functions::encodeLength(strlen($value)) . $value;
     }
 
     /**

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -33,6 +33,7 @@
 namespace phpseclib\Net;
 
 use phpseclib\Exception\FileNotFoundException;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementations of SCP.
@@ -305,7 +306,7 @@ class SCP
                     switch ($response[SSH1::RESPONSE_TYPE]) {
                         case NET_SSH1_SMSG_STDOUT_DATA:
                             extract(unpack('Nlength', $response[SSH1::RESPONSE_DATA]));
-                            return $this->ssh->_string_shift($response[SSH1::RESPONSE_DATA], $length);
+                            return Strings::shift($response[SSH1::RESPONSE_DATA], $length);
                         case NET_SSH1_SMSG_STDERR_DATA:
                             break;
                         case NET_SSH1_SMSG_EXITSTATUS:

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -39,6 +39,7 @@ namespace phpseclib\Net;
 
 use ParagonIE\ConstantTime\Hex;
 use phpseclib\Exception\FileNotFoundException;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementations of SFTP.
@@ -475,13 +476,13 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_VERSION');
         }
 
-        extract(unpack('Nversion', $this->_string_shift($response, 4)));
+        extract(unpack('Nversion', Strings::shift($response, 4)));
         $this->version = $version;
         while (!empty($response)) {
-            extract(unpack('Nlength', $this->_string_shift($response, 4)));
-            $key = $this->_string_shift($response, $length);
-            extract(unpack('Nlength', $this->_string_shift($response, 4)));
-            $value = $this->_string_shift($response, $length);
+            extract(unpack('Nlength', Strings::shift($response, 4)));
+            $key = Strings::shift($response, $length);
+            extract(unpack('Nlength', Strings::shift($response, 4)));
+            $value = Strings::shift($response, $length);
             $this->extensions[$key] = $value;
         }
 
@@ -590,14 +591,14 @@ class SFTP extends SSH2
     function _logError($response, $status = -1)
     {
         if ($status == -1) {
-            extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+            extract(unpack('Nstatus', Strings::shift($response, 4)));
         }
 
         $error = $this->status_codes[$status];
 
         if ($this->version > 2) {
-            extract(unpack('Nlength', $this->_string_shift($response, 4)));
-            $this->sftp_errors[] = $error . ': ' . $this->_string_shift($response, $length);
+            extract(unpack('Nlength', Strings::shift($response, 4)));
+            $this->sftp_errors[] = $error . ': ' . Strings::shift($response, $length);
         } else {
             $this->sftp_errors[] = $error;
         }
@@ -644,9 +645,9 @@ class SFTP extends SSH2
                     // although SSH_FXP_NAME is implemented differently in SFTPv3 than it is in SFTPv4+, the following
                     // should work on all SFTP versions since the only part of the SSH_FXP_NAME packet the following looks
                     // at is the first part and that part is defined the same in SFTP versions 3 through 6.
-                    $this->_string_shift($response, 4); // skip over the count - it should be 1, anyway
-                    extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                    return $this->_string_shift($response, $length);
+                    Strings::shift($response, 4); // skip over the count - it should be 1, anyway
+                    extract(unpack('Nlength', Strings::shift($response, 4)));
+                    return Strings::shift($response, $length);
                 case NET_SFTP_STATUS:
                     $this->_logError($response);
                     return false;
@@ -878,12 +879,12 @@ class SFTP extends SSH2
             $response = $this->_get_sftp_packet();
             switch ($this->packet_type) {
                 case NET_SFTP_NAME:
-                    extract(unpack('Ncount', $this->_string_shift($response, 4)));
+                    extract(unpack('Ncount', Strings::shift($response, 4)));
                     for ($i = 0; $i < $count; $i++) {
-                        extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                        $shortname = $this->_string_shift($response, $length);
-                        extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                        $longname = $this->_string_shift($response, $length);
+                        extract(unpack('Nlength', Strings::shift($response, 4)));
+                        $shortname = Strings::shift($response, $length);
+                        extract(unpack('Nlength', Strings::shift($response, 4)));
+                        $longname = Strings::shift($response, $length);
                         $attributes = $this->_parseAttributes($response);
                         if (!isset($attributes['type'])) {
                             $fileType = $this->_parseLongname($longname);
@@ -908,7 +909,7 @@ class SFTP extends SSH2
                     }
                     break;
                 case NET_SFTP_STATUS:
-                    extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+                    extract(unpack('Nstatus', Strings::shift($response, 4)));
                     if ($status != NET_SFTP_STATUS_EOF) {
                         $this->_logError($response, $status);
                         return false;
@@ -1501,7 +1502,7 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
         }
 
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             return false;
@@ -1613,14 +1614,14 @@ class SFTP extends SSH2
                 throw new \UnexpectedValueException('Expected SSH_FXP_NAME or SSH_FXP_STATUS');
         }
 
-        extract(unpack('Ncount', $this->_string_shift($response, 4)));
+        extract(unpack('Ncount', Strings::shift($response, 4)));
         // the file isn't a symlink
         if (!$count) {
             return false;
         }
 
-        extract(unpack('Nlength', $this->_string_shift($response, 4)));
-        return $this->_string_shift($response, $length);
+        extract(unpack('Nlength', Strings::shift($response, 4)));
+        return Strings::shift($response, $length);
     }
 
     /**
@@ -1653,7 +1654,7 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
         }
 
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             return false;
@@ -1716,7 +1717,7 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
         }
 
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             return false;
@@ -1753,7 +1754,7 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
         }
 
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED?
             $this->_logError($response, $status);
@@ -1979,7 +1980,7 @@ class SFTP extends SSH2
                 throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
             }
 
-            extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+            extract(unpack('Nstatus', Strings::shift($response, 4)));
             if ($status != NET_SFTP_STATUS_OK) {
                 $this->_logError($response, $status);
                 break;
@@ -2010,7 +2011,7 @@ class SFTP extends SSH2
             throw new \UnexpectedValueException('Expected SSH_FXP_STATUS');
         }
 
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             return false;
@@ -2200,7 +2201,7 @@ class SFTP extends SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             if (!$recursive) {
@@ -2625,7 +2626,7 @@ class SFTP extends SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-        extract(unpack('Nstatus', $this->_string_shift($response, 4)));
+        extract(unpack('Nstatus', Strings::shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
             return false;
@@ -2652,7 +2653,7 @@ class SFTP extends SSH2
     function _parseAttributes(&$response)
     {
         $attr = array();
-        extract(unpack('Nflags', $this->_string_shift($response, 4)));
+        extract(unpack('Nflags', Strings::shift($response, 4)));
         // SFTPv4+ have a type field (a byte) that follows the above flag field
         foreach ($this->attributes as $key => $value) {
             switch ($flags & $key) {
@@ -2663,13 +2664,13 @@ class SFTP extends SSH2
                     // IEEE 754 binary64 "double precision" on such platforms and
                     // as such can represent integers of at least 2^50 without loss
                     // of precision. Interpreted in filesize, 2^50 bytes = 1024 TiB.
-                    $attr['size'] = hexdec(Hex::encode($this->_string_shift($response, 8)));
+                    $attr['size'] = hexdec(Hex::encode(Strings::shift($response, 8)));
                     break;
                 case NET_SFTP_ATTR_UIDGID: // 0x00000002 (SFTPv3 only)
-                    $attr+= unpack('Nuid/Ngid', $this->_string_shift($response, 8));
+                    $attr+= unpack('Nuid/Ngid', Strings::shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_PERMISSIONS: // 0x00000004
-                    $attr+= unpack('Npermissions', $this->_string_shift($response, 4));
+                    $attr+= unpack('Npermissions', Strings::shift($response, 4));
                     // mode == permissions; permissions was the original array key and is retained for bc purposes.
                     // mode was added because that's the more industry standard terminology
                     $attr+= array('mode' => $attr['permissions']);
@@ -2679,15 +2680,15 @@ class SFTP extends SSH2
                     }
                     break;
                 case NET_SFTP_ATTR_ACCESSTIME: // 0x00000008
-                    $attr+= unpack('Natime/Nmtime', $this->_string_shift($response, 8));
+                    $attr+= unpack('Natime/Nmtime', Strings::shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_EXTENDED: // 0x80000000
-                    extract(unpack('Ncount', $this->_string_shift($response, 4)));
+                    extract(unpack('Ncount', Strings::shift($response, 4)));
                     for ($i = 0; $i < $count; $i++) {
-                        extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                        $key = $this->_string_shift($response, $length);
-                        extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                        $attr[$key] = $this->_string_shift($response, $length);
+                        extract(unpack('Nlength', Strings::shift($response, 4)));
+                        $key = Strings::shift($response, $length);
+                        extract(unpack('Nlength', Strings::shift($response, 4)));
+                        $attr[$key] = Strings::shift($response, $length);
                     }
             }
         }
@@ -2839,7 +2840,7 @@ class SFTP extends SSH2
             }
             $this->packet_buffer.= $temp;
         }
-        extract(unpack('Nlength', $this->_string_shift($this->packet_buffer, 4)));
+        extract(unpack('Nlength', Strings::shift($this->packet_buffer, 4)));
         $tempLength = $length;
         $tempLength-= strlen($this->packet_buffer);
 
@@ -2857,16 +2858,16 @@ class SFTP extends SSH2
 
         $stop = strtok(microtime(), ' ') + strtok('');
 
-        $this->packet_type = ord($this->_string_shift($this->packet_buffer));
+        $this->packet_type = ord(Strings::shift($this->packet_buffer));
 
         if ($this->request_id !== false) {
-            $this->_string_shift($this->packet_buffer, 4); // remove the request id
+            Strings::shift($this->packet_buffer, 4); // remove the request id
             $length-= 5; // account for the request id and the packet type
         } else {
             $length-= 1; // account for the packet type
         }
 
-        $packet = $this->_string_shift($this->packet_buffer, $length);
+        $packet = Strings::shift($this->packet_buffer, $length);
 
         if (defined('NET_SFTP_LOGGING')) {
             $packet_type = '<- ' . $this->packet_types[$this->packet_type] .

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -50,7 +50,7 @@
 namespace phpseclib\Net;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\Blowfish;
 use phpseclib\Crypt\Hash;
 use phpseclib\Crypt\Random;
@@ -62,6 +62,7 @@ use phpseclib\Crypt\Twofish;
 use phpseclib\Math\BigInteger; // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
 use phpseclib\System\SSH\Agent;
 use phpseclib\Exception\NoSupportedAlgorithmsException;
+use phpseclib\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementation of SSHv2.
@@ -1303,40 +1304,40 @@ class SSH2
         $client_cookie = Random::string(16);
 
         $response = $kexinit_payload_server;
-        $this->_string_shift($response, 1); // skip past the message number (it should be SSH_MSG_KEXINIT)
-        $server_cookie = $this->_string_shift($response, 16);
+        Strings::shift($response, 1); // skip past the message number (it should be SSH_MSG_KEXINIT)
+        $server_cookie = Strings::shift($response, 16);
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->kex_algorithms = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->kex_algorithms = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->server_host_key_algorithms = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->server_host_key_algorithms = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->encryption_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->encryption_algorithms_client_to_server = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->encryption_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->encryption_algorithms_server_to_client = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->mac_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->mac_algorithms_client_to_server = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->mac_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->mac_algorithms_server_to_client = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->compression_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->compression_algorithms_client_to_server = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->compression_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->compression_algorithms_server_to_client = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->languages_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->languages_client_to_server = explode(',', Strings::shift($response, $temp['length']));
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->languages_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->languages_server_to_client = explode(',', Strings::shift($response, $temp['length']));
 
-        extract(unpack('Cfirst_kex_packet_follows', $this->_string_shift($response, 1)));
+        extract(unpack('Cfirst_kex_packet_follows', Strings::shift($response, 1)));
         $first_kex_packet_follows = $first_kex_packet_follows != 0;
 
         // the sending of SSH2_MSG_KEXINIT could go in one of two places.  this is the second place.
@@ -1429,18 +1430,18 @@ class SSH2
                     user_error('Connection closed by server');
                     return false;
                 }
-                extract(unpack('Ctype', $this->_string_shift($response, 1)));
+                extract(unpack('Ctype', Strings::shift($response, 1)));
                 if ($type != NET_SSH2_MSG_KEXDH_GEX_GROUP) {
                     user_error('Expected SSH_MSG_KEX_DH_GEX_GROUP');
                     return false;
                 }
 
-                extract(unpack('NprimeLength', $this->_string_shift($response, 4)));
-                $primeBytes = $this->_string_shift($response, $primeLength);
+                extract(unpack('NprimeLength', Strings::shift($response, 4)));
+                $primeBytes = Strings::shift($response, $primeLength);
                 $prime = new BigInteger($primeBytes, -256);
 
-                extract(unpack('NgLength', $this->_string_shift($response, 4)));
-                $gBytes = $this->_string_shift($response, $gLength);
+                extract(unpack('NgLength', Strings::shift($response, 4)));
+                $gBytes = Strings::shift($response, $gLength);
                 $g = new BigInteger($gBytes, -256);
 
                 $exchange_hash_rfc4419 = pack(
@@ -1519,26 +1520,26 @@ class SSH2
         if ($response === false) {
             throw new \RuntimeException('Connection closed by server');
         }
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         if ($type != $serverKexReplyMessage) {
             throw new \UnexpectedValueException('Expected SSH_MSG_KEXDH_REPLY');
         }
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->server_public_host_key = $server_public_host_key = $this->_string_shift($response, $temp['length']);
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->server_public_host_key = $server_public_host_key = Strings::shift($response, $temp['length']);
 
-        $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-        $public_key_format = $this->_string_shift($server_public_host_key, $temp['length']);
+        $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+        $public_key_format = Strings::shift($server_public_host_key, $temp['length']);
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $fBytes = $this->_string_shift($response, $temp['length']);
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $fBytes = Strings::shift($response, $temp['length']);
 
-        $temp = unpack('Nlength', $this->_string_shift($response, 4));
-        $this->signature = $this->_string_shift($response, $temp['length']);
+        $temp = unpack('Nlength', Strings::shift($response, 4));
+        $this->signature = Strings::shift($response, $temp['length']);
 
-        $temp = unpack('Nlength', $this->_string_shift($this->signature, 4));
-        $this->signature_format = $this->_string_shift($this->signature, $temp['length']);
+        $temp = unpack('Nlength', Strings::shift($this->signature, 4));
+        $this->signature_format = Strings::shift($this->signature, $temp['length']);
 
         if ($kex_algorithm === 'curve25519-sha256@libssh.org') {
             if (strlen($fBytes) !== 32) {
@@ -1606,7 +1607,7 @@ class SSH2
             throw new \RuntimeException('Connection closed by server');
         }
 
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         if ($type != NET_SSH2_MSG_NEWKEYS) {
             throw new \UnexpectedValueException('Expected SSH_MSG_NEWKEYS');
@@ -1824,30 +1825,30 @@ class SSH2
     {
         switch ($algorithm) {
             case '3des-cbc':
-                return new TripleDES(Base::MODE_CBC);
+                return new TripleDES(BlockCipher::MODE_CBC);
             case '3des-ctr':
-                return new TripleDES(Base::MODE_CTR);
+                return new TripleDES(BlockCipher::MODE_CTR);
             case 'aes256-cbc':
             case 'aes192-cbc':
             case 'aes128-cbc':
-                return new Rijndael(Base::MODE_CBC);
+                return new Rijndael(BlockCipher::MODE_CBC);
             case 'aes256-ctr':
             case 'aes192-ctr':
             case 'aes128-ctr':
-                return new Rijndael(Base::MODE_CTR);
+                return new Rijndael(BlockCipher::MODE_CTR);
             case 'blowfish-cbc':
-                return new Blowfish(Base::MODE_CBC);
+                return new Blowfish(BlockCipher::MODE_CBC);
             case 'blowfish-ctr':
-                return new Blowfish(Base::MODE_CTR);
+                return new Blowfish(BlockCipher::MODE_CTR);
             case 'twofish128-cbc':
             case 'twofish192-cbc':
             case 'twofish256-cbc':
             case 'twofish-cbc':
-                return new Twofish(Base::MODE_CBC);
+                return new Twofish(BlockCipher::MODE_CBC);
             case 'twofish128-ctr':
             case 'twofish192-ctr':
             case 'twofish256-ctr':
-                return new Twofish(Base::MODE_CTR);
+                return new Twofish(BlockCipher::MODE_CTR);
             case 'arcfour':
             case 'arcfour128':
             case 'arcfour256':
@@ -1940,7 +1941,7 @@ class SSH2
                 throw new \RuntimeException('Connection closed by server');
             }
 
-            extract(unpack('Ctype', $this->_string_shift($response, 1)));
+            extract(unpack('Ctype', Strings::shift($response, 1)));
 
             if ($type != NET_SSH2_MSG_SERVICE_ACCEPT) {
                 throw new \UnexpectedValueException('Expected SSH_MSG_SERVICE_ACCEPT');
@@ -1987,7 +1988,7 @@ class SSH2
                 throw new \RuntimeException('Connection closed by server');
             }
 
-            extract(unpack('Ctype', $this->_string_shift($response, 1)));
+            extract(unpack('Ctype', Strings::shift($response, 1)));
 
             switch ($type) {
                 case NET_SSH2_MSG_USERAUTH_SUCCESS:
@@ -2041,22 +2042,22 @@ class SSH2
             throw new \RuntimeException('Connection closed by server');
         }
 
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_PASSWD_CHANGEREQ: // in theory, the password can be changed
                 if (defined('NET_SSH2_LOGGING')) {
                     $this->message_number_log[count($this->message_number_log) - 1] = 'NET_SSH2_MSG_USERAUTH_PASSWD_CHANGEREQ';
                 }
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $this->errors[] = 'SSH_MSG_USERAUTH_PASSWD_CHANGEREQ: ' . utf8_decode($this->_string_shift($response, $length));
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                $this->errors[] = 'SSH_MSG_USERAUTH_PASSWD_CHANGEREQ: ' . utf8_decode(Strings::shift($response, $length));
                 return $this->_disconnect(NET_SSH2_DISCONNECT_AUTH_CANCELLED_BY_USER);
             case NET_SSH2_MSG_USERAUTH_FAILURE:
                 // can we use keyboard-interactive authentication?  if not then either the login is bad or the server employees
                 // multi-factor authentication
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $auth_methods = explode(',', $this->_string_shift($response, $length));
-                extract(unpack('Cpartial_success', $this->_string_shift($response, 1)));
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                $auth_methods = explode(',', Strings::shift($response, $length));
+                extract(unpack('Cpartial_success', Strings::shift($response, 1)));
                 $partial_success = $partial_success != 0;
 
                 if (!$partial_success && in_array('keyboard-interactive', $auth_methods)) {
@@ -2130,17 +2131,17 @@ class SSH2
             }
         }
 
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_INFO_REQUEST:
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $this->_string_shift($response, $length); // name; may be empty
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $this->_string_shift($response, $length); // instruction; may be empty
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $this->_string_shift($response, $length); // language tag; may be empty
-                extract(unpack('Nnum_prompts', $this->_string_shift($response, 4)));
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                Strings::shift($response, $length); // name; may be empty
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                Strings::shift($response, $length); // instruction; may be empty
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                Strings::shift($response, $length); // language tag; may be empty
+                extract(unpack('Nnum_prompts', Strings::shift($response, 4)));
 
                 for ($i = 0; $i < count($responses); $i++) {
                     if (is_array($responses[$i])) {
@@ -2154,10 +2155,10 @@ class SSH2
 
                 if (isset($this->keyboard_requests_responses)) {
                     for ($i = 0; $i < $num_prompts; $i++) {
-                        extract(unpack('Nlength', $this->_string_shift($response, 4)));
+                        extract(unpack('Nlength', Strings::shift($response, 4)));
                         // prompt - ie. "Password: "; must not be empty
-                        $prompt = $this->_string_shift($response, $length);
-                        //$echo = $this->_string_shift($response) != chr(0);
+                        $prompt = Strings::shift($response, $length);
+                        //$echo = Strings::shift($response) != chr(0);
                         foreach ($this->keyboard_requests_responses as $key => $value) {
                             if (substr($prompt, 0, strlen($key)) == $key) {
                                 $responses[] = $value;
@@ -2299,12 +2300,12 @@ class SSH2
             throw new \RuntimeException('Connection closed by server');
         }
 
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_FAILURE:
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                $this->errors[] = 'SSH_MSG_USERAUTH_FAILURE: ' . $this->_string_shift($response, $length);
+                extract(unpack('Nlength', Strings::shift($response, 4)));
+                $this->errors[] = 'SSH_MSG_USERAUTH_FAILURE: ' . Strings::shift($response, $length);
                 return false;
             case NET_SSH2_MSG_USERAUTH_PK_OK:
                 // we'll just take it on faith that the public key blob and the public key algorithm name are as
@@ -2333,7 +2334,7 @@ class SSH2
             throw new \RuntimeException('Connection closed by server');
         }
 
-        extract(unpack('Ctype', $this->_string_shift($response, 1)));
+        extract(unpack('Ctype', Strings::shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_FAILURE:
@@ -2451,7 +2452,7 @@ class SSH2
                 throw new \RuntimeException('Connection closed by server');
             }
 
-            list(, $type) = unpack('C', $this->_string_shift($response, 1));
+            list(, $type) = unpack('C', Strings::shift($response, 1));
 
             switch ($type) {
                 case NET_SSH2_MSG_CHANNEL_SUCCESS:
@@ -2588,7 +2589,7 @@ class SSH2
             throw new \RuntimeException('Connection closed by server');
         }
 
-        list(, $type) = unpack('C', $this->_string_shift($response, 1));
+        list(, $type) = unpack('C', Strings::shift($response, 1));
 
         switch ($type) {
             case NET_SSH2_MSG_CHANNEL_SUCCESS:
@@ -2700,12 +2701,12 @@ class SSH2
             }
             $pos = strlen($match) ? strpos($this->interactiveBuffer, $match) : false;
             if ($pos !== false) {
-                return $this->_string_shift($this->interactiveBuffer, $pos + strlen($match));
+                return Strings::shift($this->interactiveBuffer, $pos + strlen($match));
             }
             $response = $this->_get_channel_packet($channel);
             if (is_bool($response)) {
                 $this->in_request_pty_exec = false;
-                return $response ? $this->_string_shift($this->interactiveBuffer, strlen($this->interactiveBuffer)) : false;
+                return $response ? Strings::shift($this->interactiveBuffer, strlen($this->interactiveBuffer)) : false;
             }
 
             $this->interactiveBuffer.= $response;
@@ -2921,7 +2922,7 @@ class SSH2
             throw new \RuntimeException('Unable to decrypt content');
         }
 
-        extract(unpack('Npacket_length/Cpadding_length', $this->_string_shift($raw, 5)));
+        extract(unpack('Npacket_length/Cpadding_length', Strings::shift($raw, 5)));
 
         $remaining_length = $packet_length + 4 - $this->decrypt_block_size;
 
@@ -2947,8 +2948,8 @@ class SSH2
             $raw.= $this->decrypt !== false ? $this->decrypt->decrypt($buffer) : $buffer;
         }
 
-        $payload = $this->_string_shift($raw, $packet_length - $padding_length - 1);
-        $padding = $this->_string_shift($raw, $padding_length); // should leave $raw empty
+        $payload = Strings::shift($raw, $packet_length - $padding_length - 1);
+        $padding = Strings::shift($raw, $padding_length); // should leave $raw empty
 
         if ($this->hmac_check !== false) {
             $hmac = stream_get_contents($this->fsock, $this->hmac_size);
@@ -2991,18 +2992,18 @@ class SSH2
     {
         switch (ord($payload[0])) {
             case NET_SSH2_MSG_DISCONNECT:
-                $this->_string_shift($payload, 1);
-                extract(unpack('Nreason_code/Nlength', $this->_string_shift($payload, 8)));
-                $this->errors[] = 'SSH_MSG_DISCONNECT: ' . $this->disconnect_reasons[$reason_code] . "\r\n" . utf8_decode($this->_string_shift($payload, $length));
+                Strings::shift($payload, 1);
+                extract(unpack('Nreason_code/Nlength', Strings::shift($payload, 8)));
+                $this->errors[] = 'SSH_MSG_DISCONNECT: ' . $this->disconnect_reasons[$reason_code] . "\r\n" . utf8_decode(Strings::shift($payload, $length));
                 $this->bitmap = 0;
                 return false;
             case NET_SSH2_MSG_IGNORE:
                 $payload = $this->_get_binary_packet();
                 break;
             case NET_SSH2_MSG_DEBUG:
-                $this->_string_shift($payload, 2);
-                extract(unpack('Nlength', $this->_string_shift($payload, 4)));
-                $this->errors[] = 'SSH_MSG_DEBUG: ' . utf8_decode($this->_string_shift($payload, $length));
+                Strings::shift($payload, 2);
+                extract(unpack('Nlength', Strings::shift($payload, 4)));
+                $this->errors[] = 'SSH_MSG_DEBUG: ' . utf8_decode(Strings::shift($payload, $length));
                 $payload = $this->_get_binary_packet();
                 break;
             case NET_SSH2_MSG_UNIMPLEMENTED:
@@ -3019,9 +3020,9 @@ class SSH2
 
         // see http://tools.ietf.org/html/rfc4252#section-5.4; only called when the encryption has been activated and when we haven't already logged in
         if (($this->bitmap & self::MASK_CONNECTED) && !($this->bitmap & self::MASK_LOGIN) && ord($payload[0]) == NET_SSH2_MSG_USERAUTH_BANNER) {
-            $this->_string_shift($payload, 1);
-            extract(unpack('Nlength', $this->_string_shift($payload, 4)));
-            $this->banner_message = utf8_decode($this->_string_shift($payload, $length));
+            Strings::shift($payload, 1);
+            extract(unpack('Nlength', Strings::shift($payload, 4)));
+            $this->banner_message = utf8_decode(Strings::shift($payload, $length));
             $payload = $this->_get_binary_packet();
         }
 
@@ -3029,8 +3030,8 @@ class SSH2
         if (($this->bitmap & self::MASK_CONNECTED) && ($this->bitmap & self::MASK_LOGIN)) {
             switch (ord($payload[0])) {
                 case NET_SSH2_MSG_GLOBAL_REQUEST: // see http://tools.ietf.org/html/rfc4254#section-4
-                    extract(unpack('Nlength', $this->_string_shift($payload, 4)));
-                    $this->errors[] = 'SSH_MSG_GLOBAL_REQUEST: ' . $this->_string_shift($payload, $length);
+                    extract(unpack('Nlength', Strings::shift($payload, 4)));
+                    $this->errors[] = 'SSH_MSG_GLOBAL_REQUEST: ' . Strings::shift($payload, $length);
 
                     if (!$this->_send_binary_packet(pack('C', NET_SSH2_MSG_REQUEST_FAILURE))) {
                         return $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
@@ -3039,18 +3040,18 @@ class SSH2
                     $payload = $this->_get_binary_packet();
                     break;
                 case NET_SSH2_MSG_CHANNEL_OPEN: // see http://tools.ietf.org/html/rfc4254#section-5.1
-                    $this->_string_shift($payload, 1);
-                    extract(unpack('Nlength', $this->_string_shift($payload, 4)));
-                    $data = $this->_string_shift($payload, $length);
-                    extract(unpack('Nserver_channel', $this->_string_shift($payload, 4)));
+                    Strings::shift($payload, 1);
+                    extract(unpack('Nlength', Strings::shift($payload, 4)));
+                    $data = Strings::shift($payload, $length);
+                    extract(unpack('Nserver_channel', Strings::shift($payload, 4)));
                     switch ($data) {
                         case 'auth-agent':
                         case 'auth-agent@openssh.com':
                             if (isset($this->agent)) {
                                 $new_channel = self::CHANNEL_AGENT_FORWARD;
 
-                                extract(unpack('Nremote_window_size', $this->_string_shift($payload, 4)));
-                                extract(unpack('Nremote_maximum_packet_size', $this->_string_shift($payload, 4)));
+                                extract(unpack('Nremote_window_size', Strings::shift($payload, 4)));
+                                extract(unpack('Nremote_maximum_packet_size', Strings::shift($payload, 4)));
 
                                 $this->packet_size_client_to_server[$new_channel] = $remote_window_size;
                                 $this->window_size_server_to_client[$new_channel] = $remote_maximum_packet_size;
@@ -3093,9 +3094,9 @@ class SSH2
                     $payload = $this->_get_binary_packet();
                     break;
                 case NET_SSH2_MSG_CHANNEL_WINDOW_ADJUST:
-                    $this->_string_shift($payload, 1);
-                    extract(unpack('Nchannel', $this->_string_shift($payload, 4)));
-                    extract(unpack('Nwindow_size', $this->_string_shift($payload, 4)));
+                    Strings::shift($payload, 1);
+                    extract(unpack('Nchannel', Strings::shift($payload, 4)));
+                    extract(unpack('Nwindow_size', Strings::shift($payload, 4)));
                     $this->window_size_client_to_server[$channel]+= $window_size;
 
                     $payload = ($this->bitmap & self::MASK_WINDOW_ADJUST) ? true : $this->_get_binary_packet();
@@ -3224,12 +3225,12 @@ class SSH2
                 return '';
             }
 
-            extract(unpack('Ctype', $this->_string_shift($response, 1)));
+            extract(unpack('Ctype', Strings::shift($response, 1)));
 
             if ($type == NET_SSH2_MSG_CHANNEL_OPEN) {
-                extract(unpack('Nlength', $this->_string_shift($response, 4)));
+                extract(unpack('Nlength', Strings::shift($response, 4)));
             } else {
-                extract(unpack('Nchannel', $this->_string_shift($response, 4)));
+                extract(unpack('Nchannel', Strings::shift($response, 4)));
             }
 
             // will not be setup yet on incoming channel open request
@@ -3249,15 +3250,15 @@ class SSH2
                     case NET_SSH2_MSG_CHANNEL_OPEN:
                         switch ($type) {
                             case NET_SSH2_MSG_CHANNEL_OPEN_CONFIRMATION:
-                                extract(unpack('Nserver_channel', $this->_string_shift($response, 4)));
+                                extract(unpack('Nserver_channel', Strings::shift($response, 4)));
                                 $this->server_channels[$channel] = $server_channel;
-                                extract(unpack('Nwindow_size', $this->_string_shift($response, 4)));
+                                extract(unpack('Nwindow_size', Strings::shift($response, 4)));
                                 if ($window_size < 0) {
                                     $window_size&= 0x7FFFFFFF;
                                     $window_size+= 0x80000000;
                                 }
                                 $this->window_size_client_to_server[$channel] = $window_size;
-                                $temp = unpack('Npacket_size_client_to_server', $this->_string_shift($response, 4));
+                                $temp = unpack('Npacket_size_client_to_server', Strings::shift($response, 4));
                                 $this->packet_size_client_to_server[$channel] = $temp['packet_size_client_to_server'];
                                 $result = $client_channel == $channel ? true : $this->_get_channel_packet($client_channel, $skip_extended);
                                 $this->_on_channel_open();
@@ -3296,8 +3297,8 @@ class SSH2
                         $this->_send_channel_packet($channel, chr(0));
                     }
                     */
-                    extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                    $data = $this->_string_shift($response, $length);
+                    extract(unpack('Nlength', Strings::shift($response, 4)));
+                    $data = Strings::shift($response, $length);
 
                     if ($channel == self::CHANNEL_AGENT_FORWARD) {
                         $agent_response = $this->agent->_forward_data($data);
@@ -3322,8 +3323,8 @@ class SSH2
                     }
                     */
                     // currently, there's only one possible value for $data_type_code: NET_SSH2_EXTENDED_DATA_STDERR
-                    extract(unpack('Ndata_type_code/Nlength', $this->_string_shift($response, 8)));
-                    $data = $this->_string_shift($response, $length);
+                    extract(unpack('Ndata_type_code/Nlength', Strings::shift($response, 8)));
+                    $data = Strings::shift($response, $length);
                     $this->stdErrorLog.= $data;
                     if ($skip_extended || $this->quiet_mode) {
                         break;
@@ -3337,17 +3338,17 @@ class SSH2
                     $this->channel_buffers[$channel][] = $data;
                     break;
                 case NET_SSH2_MSG_CHANNEL_REQUEST:
-                    extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                    $value = $this->_string_shift($response, $length);
+                    extract(unpack('Nlength', Strings::shift($response, 4)));
+                    $value = Strings::shift($response, $length);
                     switch ($value) {
                         case 'exit-signal':
-                            $this->_string_shift($response, 1);
-                            extract(unpack('Nlength', $this->_string_shift($response, 4)));
-                            $this->errors[] = 'SSH_MSG_CHANNEL_REQUEST (exit-signal): ' . $this->_string_shift($response, $length);
-                            $this->_string_shift($response, 1);
-                            extract(unpack('Nlength', $this->_string_shift($response, 4)));
+                            Strings::shift($response, 1);
+                            extract(unpack('Nlength', Strings::shift($response, 4)));
+                            $this->errors[] = 'SSH_MSG_CHANNEL_REQUEST (exit-signal): ' . Strings::shift($response, $length);
+                            Strings::shift($response, 1);
+                            extract(unpack('Nlength', Strings::shift($response, 4)));
                             if ($length) {
-                                $this->errors[count($this->errors)].= "\r\n" . $this->_string_shift($response, $length);
+                                $this->errors[count($this->errors)].= "\r\n" . Strings::shift($response, $length);
                             }
 
                             $this->_send_binary_packet(pack('CN', NET_SSH2_MSG_CHANNEL_EOF, $this->server_channels[$client_channel]));
@@ -3357,7 +3358,7 @@ class SSH2
 
                             break;
                         case 'exit-status':
-                            extract(unpack('Cfalse/Nexit_status', $this->_string_shift($response, 5)));
+                            extract(unpack('Cfalse/Nexit_status', Strings::shift($response, 5)));
                             $this->exit_status = $exit_status;
 
                             // "The client MAY ignore these messages."
@@ -3465,7 +3466,7 @@ class SSH2
     {
         // remove the byte identifying the message type from all but the first two messages (ie. the identification strings)
         if (strlen($message_number) > 2) {
-            $this->_string_shift($message);
+            Strings::shift($message);
         }
 
         switch (NET_SSH2_LOGGING) {
@@ -3558,7 +3559,7 @@ class SSH2
                 $this->window_size_client_to_server[$client_channel]
             );
 
-            $temp = $this->_string_shift($data, $max_size);
+            $temp = Strings::shift($data, $max_size);
             $packet = pack(
                 'CN2a*',
                 NET_SSH2_MSG_CHANNEL_DATA,
@@ -3632,23 +3633,6 @@ class SSH2
     }
 
     /**
-     * String Shift
-     *
-     * Inspired by array_shift
-     *
-     * @param string $string
-     * @param int $index
-     * @return string
-     * @access private
-     */
-    function _string_shift(&$string, $index = 1)
-    {
-        $substr = substr($string, 0, $index);
-        $string = substr($string, $index);
-        return $substr;
-    }
-
-    /**
      * Define Array
      *
      * Takes any number of arrays whose indices are integers and whose values are strings and defines a bunch of
@@ -3717,7 +3701,7 @@ class SSH2
                 if (strlen($current_log)) {
                     $output.= str_pad(dechex($j), 7, '0', STR_PAD_LEFT) . '0  ';
                 }
-                $fragment = $this->_string_shift($current_log, $this->log_short_width);
+                $fragment = Strings::shift($current_log, $this->log_short_width);
                 $hex = substr(preg_replace_callback('#.#s', array($this, '_format_log_helper'), $fragment), strlen($this->log_boundary));
                 // replace non ASCII printable characters with dots
                 // http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters
@@ -3986,8 +3970,8 @@ class SSH2
         $signature = $this->signature;
         $server_public_host_key = $this->server_public_host_key;
 
-        extract(unpack('Nlength', $this->_string_shift($server_public_host_key, 4)));
-        $this->_string_shift($server_public_host_key, $length);
+        extract(unpack('Nlength', Strings::shift($server_public_host_key, 4)));
+        Strings::shift($server_public_host_key, $length);
 
         if ($this->signature_validated) {
             return $this->bitmap ?
@@ -4001,29 +3985,29 @@ class SSH2
             case 'ssh-dss':
                 $zero = new BigInteger();
 
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $p = new BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $p = new BigInteger(Strings::shift($server_public_host_key, $temp['length']), -256);
 
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $q = new BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $q = new BigInteger(Strings::shift($server_public_host_key, $temp['length']), -256);
 
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $g = new BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $g = new BigInteger(Strings::shift($server_public_host_key, $temp['length']), -256);
 
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $y = new BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $y = new BigInteger(Strings::shift($server_public_host_key, $temp['length']), -256);
 
                 /* The value for 'dss_signature_blob' is encoded as a string containing
                    r, followed by s (which are 160-bit integers, without lengths or
                    padding, unsigned, and in network byte order). */
-                $temp = unpack('Nlength', $this->_string_shift($signature, 4));
+                $temp = unpack('Nlength', Strings::shift($signature, 4));
                 if ($temp['length'] != 40) {
                     $this->_disconnect(NET_SSH2_DISCONNECT_KEY_EXCHANGE_FAILED);
                     throw new \RuntimeException('Invalid signature');
                 }
 
-                $r = new BigInteger($this->_string_shift($signature, 20), 256);
-                $s = new BigInteger($this->_string_shift($signature, 20), 256);
+                $r = new BigInteger(Strings::shift($signature, 20), 256);
+                $s = new BigInteger(Strings::shift($signature, 20), 256);
 
                 switch (true) {
                     case $r->equals($zero):
@@ -4056,17 +4040,17 @@ class SSH2
 
                 break;
             case 'ssh-rsa':
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $e = new BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $e = new BigInteger(Strings::shift($server_public_host_key, $temp['length']), -256);
 
-                $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
-                $rawN = $this->_string_shift($server_public_host_key, $temp['length']);
+                $temp = unpack('Nlength', Strings::shift($server_public_host_key, 4));
+                $rawN = Strings::shift($server_public_host_key, $temp['length']);
                 $n = new BigInteger($rawN, -256);
                 $nLength = strlen(ltrim($rawN, "\0"));
 
                 /*
-                $temp = unpack('Nlength', $this->_string_shift($signature, 4));
-                $signature = $this->_string_shift($signature, $temp['length']);
+                $temp = unpack('Nlength', Strings::shift($signature, 4));
+                $signature = Strings::shift($signature, $temp['length']);
 
                 $rsa = new RSA();
                 $rsa->load(array('e' => $e, 'n' => $n), 'raw');
@@ -4077,8 +4061,8 @@ class SSH2
                 }
                 */
 
-                $temp = unpack('Nlength', $this->_string_shift($signature, 4));
-                $s = new BigInteger($this->_string_shift($signature, $temp['length']), 256);
+                $temp = unpack('Nlength', Strings::shift($signature, 4));
+                $s = new BigInteger(Strings::shift($signature, $temp['length']), 256);
 
                 // validate an RSA signature per "8.2 RSASSA-PKCS1-v1_5", "5.2.2 RSAVP1", and "9.1 EMSA-PSS" in the
                 // following URL:

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Pure-PHP ssh-agent client.
  *

--- a/tests/Unit/Crypt/AES/InternalTest.php
+++ b/tests/Unit/Crypt/AES/InternalTest.php
@@ -5,12 +5,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_InternalTest extends Unit_Crypt_AES_TestCase
 {
     protected function setUp()
     {
-        $this->engine = Base::ENGINE_INTERNAL;
+        $this->engine = BlockCipher::ENGINE_INTERNAL;
     }
 }

--- a/tests/Unit/Crypt/AES/McryptTest.php
+++ b/tests/Unit/Crypt/AES/McryptTest.php
@@ -5,12 +5,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_McryptTest extends Unit_Crypt_AES_TestCase
 {
     protected function setUp()
     {
-        $this->engine = Base::ENGINE_MCRYPT;
+        $this->engine = BlockCipher::ENGINE_MCRYPT;
     }
 }

--- a/tests/Unit/Crypt/AES/OpenSSLTest.php
+++ b/tests/Unit/Crypt/AES/OpenSSLTest.php
@@ -5,12 +5,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_OpenSSLTest extends Unit_Crypt_AES_TestCase
 {
     protected function setUp()
     {
-        $this->engine = Base::ENGINE_OPENSSL;
+        $this->engine = BlockCipher::ENGINE_OPENSSL;
     }
 }

--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -6,7 +6,7 @@
  */
 
 use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\Rijndael;
 
 abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
@@ -18,10 +18,10 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
         if ($aes->getEngine() != $this->engine) {
             $engine = 'internal';
             switch ($this->engine) {
-                case Base::ENGINE_OPENSSL:
+                case BlockCipher::ENGINE_OPENSSL:
                     $engine = 'OpenSSL';
                     break;
-                case Base::ENGINE_MCRYPT:
+                case BlockCipher::ENGINE_MCRYPT:
                     $engine = 'mcrypt';
             }
             self::markTestSkipped('Unable to initialize ' . $engine . ' engine');
@@ -36,9 +36,9 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     public function continuousBufferCombos()
     {
         $modes = array(
-            Base::MODE_CTR,
-            Base::MODE_OFB,
-            Base::MODE_CFB,
+            BlockCipher::MODE_CTR,
+            BlockCipher::MODE_OFB,
+            BlockCipher::MODE_CFB,
         );
         $plaintexts = array(
             '',
@@ -100,7 +100,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
         // this test case is from the following URL:
         // https://web.archive.org/web/20070209120224/http://fp.gladman.plus.com/cryptography_technology/rijndael/aesdvec.zip
 
-        $aes = new Rijndael(Base::MODE_CBC);
+        $aes = new Rijndael(BlockCipher::MODE_CBC);
         $aes->setPreferredEngine($this->engine);
         $aes->disablePadding();
         $aes->setKey(pack('H*', '2b7e151628aed2a6abf7158809cf4f3c762e7160')); // 160-bit key. Valid in Rijndael.
@@ -118,7 +118,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     {
         // same as the above - just with a different ciphertext
 
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
         $aes->setPreferredEngine($this->engine);
         $aes->disablePadding();
         $aes->setKey(pack('H*', '2b7e151628aed2a6abf7158809cf4f3c762e7160')); // 160-bit key. supported by Rijndael - not AES
@@ -136,9 +136,9 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     public function continuousBufferBatteryCombos()
     {
         $modes = array(
-            Base::MODE_CTR,
-            Base::MODE_OFB,
-            Base::MODE_CFB,
+            BlockCipher::MODE_CTR,
+            BlockCipher::MODE_OFB,
+            BlockCipher::MODE_CFB,
         );
 
         $combos = array(
@@ -267,7 +267,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     // from http://csrc.nist.gov/groups/STM/cavp/documents/aes/AESAVS.pdf#page=16
     public function testGFSBox128()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
 
         $aes->setKey(pack('H*', '00000000000000000000000000000000'));
         $aes->setIV(pack('H*', '00000000000000000000000000000000'));
@@ -294,7 +294,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
 
     public function testGFSBox192()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
 
         $aes->setKey(pack('H*', '000000000000000000000000000000000000000000000000'));
         $aes->setIV(pack('H*', '00000000000000000000000000000000'));
@@ -319,7 +319,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
 
     public function testGFSBox256()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
 
         $aes->setKey(pack('H*', '00000000000000000000000000000000' . '00000000000000000000000000000000'));
         $aes->setIV(pack('H*', '00000000000000000000000000000000'));
@@ -342,13 +342,13 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
 
     public function testGetKeyLengthDefault()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
         $this->assertSame($aes->getKeyLength(), 128);
     }
 
     public function testGetKeyLengthWith192BitKey()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
         $aes->setKey(str_repeat('a', 24));
         $this->assertSame($aes->getKeyLength(), 192);
     }
@@ -358,7 +358,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
      */
     public function testSetKeyLengthWithLargerKey()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
         $aes->setKeyLength(128);
         $aes->setKey(str_repeat('a', 24));
         $aes->setIV(str_repeat("\0", 16));
@@ -373,7 +373,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
      */
     public function testSetKeyLengthWithSmallerKey()
     {
-        $aes = new AES(Base::MODE_CBC);
+        $aes = new AES(BlockCipher::MODE_CBC);
         $aes->setKeyLength(256);
         $aes->setKey(str_repeat('a', 16));
         $aes->setIV(str_repeat("\0", 16));

--- a/tests/Unit/Crypt/BlowfishTest.php
+++ b/tests/Unit/Crypt/BlowfishTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\Blowfish;
 
 class Unit_Crypt_BlowfishTest extends PhpseclibTestCase
@@ -13,9 +13,9 @@ class Unit_Crypt_BlowfishTest extends PhpseclibTestCase
     public function engineVectors()
     {
         $engines = array(
-            Base::ENGINE_INTERNAL => 'internal',
-            Base::ENGINE_MCRYPT => 'mcrypt',
-            Base::ENGINE_OPENSSL => 'OpenSSL',
+            BlockCipher::ENGINE_INTERNAL => 'internal',
+            BlockCipher::ENGINE_MCRYPT => 'mcrypt',
+            BlockCipher::ENGINE_OPENSSL => 'OpenSSL',
         );
 
         // tests from https://www.schneier.com/code/vectors.txt

--- a/tests/Unit/Crypt/RC2Test.php
+++ b/tests/Unit/Crypt/RC2Test.php
@@ -5,15 +5,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\RC2;
 
 class Unit_Crypt_RC2Test extends PhpseclibTestCase
 {
     var $engines = array(
-        Base::ENGINE_INTERNAL => 'internal',
-        Base::ENGINE_MCRYPT => 'mcrypt',
-        Base::ENGINE_OPENSSL => 'OpenSSL',
+        BlockCipher::ENGINE_INTERNAL => 'internal',
+        BlockCipher::ENGINE_MCRYPT => 'mcrypt',
+        BlockCipher::ENGINE_OPENSSL => 'OpenSSL',
     );
 
     public function engineVectors()
@@ -45,7 +45,7 @@ class Unit_Crypt_RC2Test extends PhpseclibTestCase
     // this test is just confirming RC2's key expansion
     public function testEncryptPadding()
     {
-        $rc2 = new RC2(Base::MODE_ECB);
+        $rc2 = new RC2(BlockCipher::MODE_ECB);
 
         // unlike Crypt_AES / Crypt_Rijndael, when you tell Crypt_RC2 that the key length is 128-bits the key isn't null padded to that length.
         // instead, RC2 key expansion is used to extend it out to that length. this isn't done for AES / Rijndael since that doesn't define any
@@ -82,22 +82,22 @@ class Unit_Crypt_RC2Test extends PhpseclibTestCase
 
         $rc2->setKey(str_repeat('d', 16), 128);
 
-        $rc2->setPreferredEngine(Base::ENGINE_INTERNAL);
+        $rc2->setPreferredEngine(BlockCipher::ENGINE_INTERNAL);
         $internal = $rc2->encrypt('d');
 
         $result = pack('H*', 'e3b36057f4821346');
         $this->assertEquals($result, $internal, 'Failed asserting that the internal engine produced the correct result');
 
-        $rc2->setPreferredEngine(Base::ENGINE_MCRYPT);
-        if ($rc2->getEngine() == Base::ENGINE_MCRYPT) {
+        $rc2->setPreferredEngine(BlockCipher::ENGINE_MCRYPT);
+        if ($rc2->getEngine() == BlockCipher::ENGINE_MCRYPT) {
             $mcrypt = $rc2->encrypt('d');
             $this->assertEquals($result, $mcrypt, 'Failed asserting that the mcrypt engine produced the correct result');
         } else {
             self::markTestSkipped('Unable to initialize mcrypt engine');
         }
 
-        $rc2->setPreferredEngine(Base::ENGINE_OPENSSL);
-        if ($rc2->getEngine() == Base::ENGINE_OPENSSL) {
+        $rc2->setPreferredEngine(BlockCipher::ENGINE_OPENSSL);
+        if ($rc2->getEngine() == BlockCipher::ENGINE_OPENSSL) {
             $openssl = $rc2->encrypt('d');
             $this->assertEquals($result, $openssl,  'Failed asserting that the OpenSSL engine produced the correct result');
         } else {

--- a/tests/Unit/Crypt/RC4Test.php
+++ b/tests/Unit/Crypt/RC4Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\StreamCipher;
 use phpseclib\Crypt\RC4;
 
 class Unit_Crypt_RC4Test extends PhpseclibTestCase
@@ -13,9 +13,9 @@ class Unit_Crypt_RC4Test extends PhpseclibTestCase
     public function engineVectors()
     {
         $engines = array(
-            Base::ENGINE_INTERNAL => 'internal',
-            Base::ENGINE_MCRYPT => 'mcrypt',
-            Base::ENGINE_OPENSSL => 'OpenSSL',
+            StreamCipher::ENGINE_INTERNAL => 'internal',
+            StreamCipher::ENGINE_MCRYPT => 'mcrypt',
+            StreamCipher::ENGINE_OPENSSL => 'OpenSSL',
         );
         // tests from https://tools.ietf.org/html/rfc6229
         $tests = array(

--- a/tests/Unit/Crypt/TripleDESTest.php
+++ b/tests/Unit/Crypt/TripleDESTest.php
@@ -5,15 +5,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\TripleDES;
 
 class Unit_Crypt_TripleDESTest extends PhpseclibTestCase
 {
     var $engines = array(
-        Base::ENGINE_INTERNAL => 'internal',
-        Base::ENGINE_MCRYPT => 'mcrypt',
-        Base::ENGINE_OPENSSL => 'OpenSSL',
+        BlockCipher::ENGINE_INTERNAL => 'internal',
+        BlockCipher::ENGINE_MCRYPT => 'mcrypt',
+        BlockCipher::ENGINE_OPENSSL => 'OpenSSL',
     );
 
     public function engineVectors()
@@ -120,9 +120,9 @@ class Unit_Crypt_TripleDESTest extends PhpseclibTestCase
     public function engineIVVectors()
     {
         $engines = array(
-            Base::ENGINE_INTERNAL => 'internal',
-            Base::ENGINE_MCRYPT => 'mcrypt',
-            Base::ENGINE_OPENSSL => 'OpenSSL',
+            BlockCipher::ENGINE_INTERNAL => 'internal',
+            BlockCipher::ENGINE_MCRYPT => 'mcrypt',
+            BlockCipher::ENGINE_OPENSSL => 'OpenSSL',
         );
 
         // tests from http://csrc.nist.gov/groups/STM/cavp/documents/des/DESMMT.pdf

--- a/tests/Unit/Crypt/TwofishTest.php
+++ b/tests/Unit/Crypt/TwofishTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
+use phpseclib\Crypt\Common\BlockCipher;
 use phpseclib\Crypt\Twofish;
 
 class Unit_Crypt_TwofishTest extends PhpseclibTestCase
@@ -13,9 +13,9 @@ class Unit_Crypt_TwofishTest extends PhpseclibTestCase
     public function testVectors()
     {
         $engines = array(
-            Base::ENGINE_INTERNAL => 'internal',
-            Base::ENGINE_MCRYPT => 'mcrypt',
-            Base::ENGINE_OPENSSL => 'OpenSSL',
+            BlockCipher::ENGINE_INTERNAL => 'internal',
+            BlockCipher::ENGINE_MCRYPT => 'mcrypt',
+            BlockCipher::ENGINE_OPENSSL => 'OpenSSL',
         );
 
         foreach ($engines as $engine => $name) {

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -9,6 +9,7 @@ use phpseclib\File\ASN1;
 use phpseclib\File\ASN1\Element;
 use phpseclib\File\X509;
 use phpseclib\Crypt\RSA;
+use phpseclib\Common\Functions\ASN1 as Functions;
 
 class Unit_File_X509_X509Test extends PhpseclibTestCase
 {
@@ -136,10 +137,10 @@ IOkKcGQRCMha8X2e7GmlpdWC1ycenlbN0nbVeSv3JUMcafC4+Q==
         $asn1 = new ASN1();
 
         $value = $this->_encodeOID('1.2.3.4');
-        $ext = chr(ASN1::TYPE_OBJECT_IDENTIFIER) . $asn1->_encodeLength(strlen($value)) . $value;
+        $ext = chr(ASN1::TYPE_OBJECT_IDENTIFIER) . Functions::encodeLength(strlen($value)) . $value;
         $value = 'zzzzzzzzz';
-        $ext.= chr(ASN1::TYPE_OCTET_STRING) . $asn1->_encodeLength(strlen($value)) . $value;
-        $ext = chr(ASN1::TYPE_SEQUENCE | 0x20) . $asn1->_encodeLength(strlen($ext)) . $ext;
+        $ext.= chr(ASN1::TYPE_OCTET_STRING) . Functions::encodeLength(strlen($value)) . $value;
+        $ext = chr(ASN1::TYPE_SEQUENCE | 0x20) . Functions::encodeLength(strlen($ext)) . $ext;
 
         $cert['tbsCertificate']['extensions'][4] = new Element($ext);
 


### PR DESCRIPTION
- rename \phpseclib\Crypt\Base to \phpseclib\Crypt\Common\SymmetricKey
- create BlockCipher and StreamCipher to extend SymmetricKey
- replace _string_shift with \phpseclib\Common\Functions\Strings::shift
- move _encodeLength and _decodeLength to Common\Functions\ASN1.php

It probably would have been better if I had made the SymmetricKey / BlockCipher / StreamCipher changes in a separate commit but what's done is done. I'm thinking I'll make RSA extend a new PublicKey class later, after DSA and ECDSA are finished.

Also, in theory, I could probably just increase the interdependence of phpseclib and make PKCS.php use the ASN1 class and provide a mapping for it like X509 does but idk. It'd also be cool if, in theory, you could use SSH2.php without having X509.php included, for example. Like if phpseclib was as modularized as PEAR or something. And if phpseclib ever achieves such modularity reduced interdependence might be more virtuous. I mean, I suppose, even then, the virtue of it is still debatable, but whatever.

As for naming the directory Common...  I also considered Shared but arbitrarily decided upon Common just 'cause.