### PR TITLE
Handle empty fread return correctly when uploading with SFTP

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1916,7 +1916,7 @@ class SFTP extends SSH2
                 }
             } else {
                 $temp = isset($fp) ? fread($fp, $sftp_packet_size) : substr($data, $sent, $sftp_packet_size);
-                if ($temp === false) {
+                if ($temp === false || $temp === '') {
                     break;
                 }
             }


### PR DESCRIPTION
The pull request #995 introduced an issue when zero-byte file uploading is required.
For instance, we upload a directory which contains a '.gitkeep' file. This file doesn't contain any data and so the filesize is 0 bytes.

The issue is that the `fread` method never returns false, only a empty string is returned for these types of files. This case should also be handled to exit out of the upload while loop.