### PR TITLE
Incorrect namespace hint

### DIFF
--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -102,7 +102,7 @@ class SCP
      *
      * Connects to an SSH server
      *
-     * @param \phpseclib\Net\SSH1|\phpseclin\Net\SSH2 $ssh
+     * @param \phpseclib\Net\SSH1|\phpseclib\Net\SSH2 $ssh
      * @return \phpseclib\Net\SCP
      * @access public
      */


### PR DESCRIPTION
When trying to create SCP instance, IDE reports incorrect object type given. Fixed that by changing namespace in SCP class to correct one.