### PR TITLE
suppress unpack() PHP warnings

### DIFF
--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -335,6 +335,9 @@ class Net_SCP
                     $response = $this->ssh->_get_binary_packet();
                     switch ($response[NET_SSH1_RESPONSE_TYPE]) {
                         case NET_SSH1_SMSG_STDOUT_DATA:
+                            if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 4) {
+                                return false;
+                            }
                             extract(unpack('Nlength', $response[NET_SSH1_RESPONSE_DATA]));
                             return $this->ssh->_string_shift($response[NET_SSH1_RESPONSE_DATA], $length);
                         case NET_SSH1_SMSG_STDERR_DATA:

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -527,11 +527,20 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nversion', $this->_string_shift($response, 4)));
         $this->version = $version;
         while (!empty($response)) {
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('Nlength', $this->_string_shift($response, 4)));
             $key = $this->_string_shift($response, $length);
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('Nlength', $this->_string_shift($response, 4)));
             $value = $this->_string_shift($response, $length);
             $this->extensions[$key] = $value;
@@ -642,12 +651,15 @@ class Net_SFTP extends Net_SSH2
     function _logError($response, $status = -1)
     {
         if ($status == -1) {
+            if (strlen($response) < 4) {
+                return;
+            }
             extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         }
 
         $error = $this->status_codes[$status];
 
-        if ($this->version > 2) {
+        if ($this->version > 2 || strlen($response) < 4) {
             extract(unpack('Nlength', $this->_string_shift($response, 4)));
             $this->sftp_errors[] = $error . ': ' . $this->_string_shift($response, $length);
         } else {
@@ -696,6 +708,9 @@ class Net_SFTP extends Net_SSH2
                     // should work on all SFTP versions since the only part of the SSH_FXP_NAME packet the following looks
                     // at is the first part and that part is defined the same in SFTP versions 3 through 6.
                     $this->_string_shift($response, 4); // skip over the count - it should be 1, anyway
+                    if (strlen($response) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nlength', $this->_string_shift($response, 4)));
                     return $this->_string_shift($response, $length);
                 case NET_SFTP_STATUS:
@@ -930,10 +945,19 @@ class Net_SFTP extends Net_SSH2
             $response = $this->_get_sftp_packet();
             switch ($this->packet_type) {
                 case NET_SFTP_NAME:
+                    if (strlen($response) < 4) {
+                        return false;
+                    }
                     extract(unpack('Ncount', $this->_string_shift($response, 4)));
                     for ($i = 0; $i < $count; $i++) {
+                        if (strlen($response) < 4) {
+                            return false;
+                        }
                         extract(unpack('Nlength', $this->_string_shift($response, 4)));
                         $shortname = $this->_string_shift($response, $length);
+                        if (strlen($response) < 4) {
+                            return false;
+                        }
                         extract(unpack('Nlength', $this->_string_shift($response, 4)));
                         $longname = $this->_string_shift($response, $length);
                         $attributes = $this->_parseAttributes($response);
@@ -960,6 +984,9 @@ class Net_SFTP extends Net_SSH2
                     }
                     break;
                 case NET_SFTP_STATUS:
+                    if (strlen($response) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nstatus', $this->_string_shift($response, 4)));
                     if ($status != NET_SFTP_STATUS_EOF) {
                         $this->_logError($response, $status);
@@ -1554,6 +1581,9 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -1666,12 +1696,18 @@ class Net_SFTP extends Net_SSH2
                 return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Ncount', $this->_string_shift($response, 4)));
         // the file isn't a symlink
         if (!$count) {
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nlength', $this->_string_shift($response, 4)));
         return $this->_string_shift($response, $length);
     }
@@ -1706,6 +1742,9 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -1769,6 +1808,9 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -1806,6 +1848,9 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED?
@@ -2033,6 +2078,9 @@ class Net_SFTP extends Net_SSH2
                 return false;
             }
 
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('Nstatus', $this->_string_shift($response, 4)));
             if ($status != NET_SFTP_STATUS_OK) {
                 $this->_logError($response, $status);
@@ -2064,6 +2112,9 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -2254,6 +2305,9 @@ class Net_SFTP extends Net_SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -2679,6 +2733,9 @@ class Net_SFTP extends Net_SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        if (strlen($response) < 4) {
+            return false;
+        }
         extract(unpack('Nstatus', $this->_string_shift($response, 4)));
         if ($status != NET_SFTP_STATUS_OK) {
             $this->_logError($response, $status);
@@ -2706,6 +2763,10 @@ class Net_SFTP extends Net_SSH2
     function _parseAttributes(&$response)
     {
         $attr = array();
+        if (strlen($response) < 4) {
+            user_error('Malformed file attributes');
+            return array();
+        }
         extract(unpack('Nflags', $this->_string_shift($response, 4)));
         // SFTPv4+ have a type field (a byte) that follows the above flag field
         foreach ($this->attributes as $key => $value) {
@@ -2720,9 +2781,17 @@ class Net_SFTP extends Net_SSH2
                     $attr['size'] = hexdec(bin2hex($this->_string_shift($response, 8)));
                     break;
                 case NET_SFTP_ATTR_UIDGID: // 0x00000002 (SFTPv3 only)
+                    if (strlen($response) < 8) {
+                        user_error('Malformed file attributes');
+                        return $attr;
+                    }
                     $attr+= unpack('Nuid/Ngid', $this->_string_shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_PERMISSIONS: // 0x00000004
+                    if (strlen($response) < 4) {
+                        user_error('Malformed file attributes');
+                        return $attr;
+                    }
                     $attr+= unpack('Npermissions', $this->_string_shift($response, 4));
                     // mode == permissions; permissions was the original array key and is retained for bc purposes.
                     // mode was added because that's the more industry standard terminology
@@ -2733,13 +2802,29 @@ class Net_SFTP extends Net_SSH2
                     }
                     break;
                 case NET_SFTP_ATTR_ACCESSTIME: // 0x00000008
+                    if (strlen($response) < 8) {
+                        user_error('Malformed file attributes');
+                        return $attr;
+                    }
                     $attr+= unpack('Natime/Nmtime', $this->_string_shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_EXTENDED: // 0x80000000
+                    if (strlen($response) < 4) {
+                        user_error('Malformed file attributes');
+                        return $attr;
+                    }
                     extract(unpack('Ncount', $this->_string_shift($response, 4)));
                     for ($i = 0; $i < $count; $i++) {
+                        if (strlen($response) < 4) {
+                            user_error('Malformed file attributes');
+                            return $attr;
+                        }
                         extract(unpack('Nlength', $this->_string_shift($response, 4)));
                         $key = $this->_string_shift($response, $length);
+                        if (strlen($response) < 4) {
+                            user_error('Malformed file attributes');
+                            return $attr;
+                        }
                         extract(unpack('Nlength', $this->_string_shift($response, 4)));
                         $attr[$key] = $this->_string_shift($response, $length);
                     }
@@ -2892,6 +2977,9 @@ class Net_SFTP extends Net_SSH2
                 return false;
             }
             $this->packet_buffer.= $temp;
+        }
+        if (strlen($this->packet_buffer) < 4) {
+            return false;
         }
         extract(unpack('Nlength', $this->_string_shift($this->packet_buffer, 4)));
         $tempLength = $length;

--- a/phpseclib/Net/SSH1.php
+++ b/phpseclib/Net/SSH1.php
@@ -614,20 +614,32 @@ class Net_SSH1
 
         $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 4);
 
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 2) {
+            return false;
+        }
         $temp = unpack('nlen', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 2));
         $server_key_public_exponent = new Math_BigInteger($this->_string_shift($response[NET_SSH1_RESPONSE_DATA], ceil($temp['len'] / 8)), 256);
         $this->server_key_public_exponent = $server_key_public_exponent;
 
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 2) {
+            return false;
+        }
         $temp = unpack('nlen', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 2));
         $server_key_public_modulus = new Math_BigInteger($this->_string_shift($response[NET_SSH1_RESPONSE_DATA], ceil($temp['len'] / 8)), 256);
         $this->server_key_public_modulus = $server_key_public_modulus;
 
         $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 4);
 
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 2) {
+            return false;
+        }
         $temp = unpack('nlen', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 2));
         $host_key_public_exponent = new Math_BigInteger($this->_string_shift($response[NET_SSH1_RESPONSE_DATA], ceil($temp['len'] / 8)), 256);
         $this->host_key_public_exponent = $host_key_public_exponent;
 
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 2) {
+            return false;
+        }
         $temp = unpack('nlen', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 2));
         $host_key_public_modulus = new Math_BigInteger($this->_string_shift($response[NET_SSH1_RESPONSE_DATA], ceil($temp['len'] / 8)), 256);
         $this->host_key_public_modulus = $host_key_public_modulus;
@@ -635,6 +647,9 @@ class Net_SSH1
         $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 4);
 
         // get a list of the supported ciphers
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 4) {
+            return false;
+        }
         extract(unpack('Nsupported_ciphers_mask', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 4)));
         foreach ($this->supported_ciphers as $mask => $name) {
             if (($supported_ciphers_mask & (1 << $mask)) == 0) {
@@ -643,6 +658,9 @@ class Net_SSH1
         }
 
         // get a list of the supported authentications
+        if (strlen($response[NET_SSH1_RESPONSE_DATA]) < 4) {
+            return false;
+        }
         extract(unpack('Nsupported_authentications_mask', $this->_string_shift($response[NET_SSH1_RESPONSE_DATA], 4)));
         foreach ($this->supported_authentications as $mask => $name) {
             if (($supported_authentications_mask & (1 << $mask)) == 0) {
@@ -1139,7 +1157,11 @@ class Net_SSH1
         }
 
         $start = strtok(microtime(), ' ') + strtok(''); // http://php.net/microtime#61838
-        $temp = unpack('Nlength', fread($this->fsock, 4));
+        $data = fread($this->fsock, 4);
+        if (strlen($data) < 4) {
+            return false;
+        }
+        $temp = unpack('Nlength', $data);
 
         $padding_length = 8 - ($temp['length'] & 7);
         $length = $temp['length'] + $padding_length;
@@ -1160,6 +1182,9 @@ class Net_SSH1
         $type = $raw[$padding_length];
         $data = substr($raw, $padding_length + 1, -4);
 
+        if (strlen($raw) < 4) {
+            return false;
+        }
         $temp = unpack('Ncrc', substr($raw, -4));
 
         //if ( $temp['crc'] != $this->_crc($padding . $type . $data) ) {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1124,7 +1124,7 @@ class Net_SSH2
             return false;
         }
 
-        if (ord($response[0]) != NET_SSH2_MSG_KEXINIT) {
+        if (!strlen($response) || ord($response[0]) != NET_SSH2_MSG_KEXINIT) {
             user_error('Expected SSH_MSG_KEXINIT');
             return false;
         }
@@ -1313,36 +1313,69 @@ class Net_SSH2
         $this->_string_shift($response, 1); // skip past the message number (it should be SSH_MSG_KEXINIT)
         $server_cookie = $this->_string_shift($response, 16);
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->kex_algorithms = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->server_host_key_algorithms = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->encryption_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->encryption_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->mac_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->mac_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->compression_algorithms_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->compression_algorithms_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->languages_client_to_server = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->languages_server_to_client = explode(',', $this->_string_shift($response, $temp['length']));
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Cfirst_kex_packet_follows', $this->_string_shift($response, 1)));
         $first_kex_packet_follows = $first_kex_packet_follows != 0;
 
@@ -1426,16 +1459,25 @@ class Net_SSH2
                 user_error('Connection closed by server');
                 return false;
             }
+            if (!strlen($response)) {
+                return false;
+            }
             extract(unpack('Ctype', $this->_string_shift($response, 1)));
             if ($type != NET_SSH2_MSG_KEXDH_GEX_GROUP) {
                 user_error('Expected SSH_MSG_KEX_DH_GEX_GROUP');
                 return false;
             }
 
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('NprimeLength', $this->_string_shift($response, 4)));
             $primeBytes = $this->_string_shift($response, $primeLength);
             $prime = new Math_BigInteger($primeBytes, -256);
 
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('NgLength', $this->_string_shift($response, 4)));
             $gBytes = $this->_string_shift($response, $gLength);
             $g = new Math_BigInteger($gBytes, -256);
@@ -1518,6 +1560,9 @@ class Net_SSH2
             user_error('Connection closed by server');
             return false;
         }
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         if ($type != $serverKexReplyMessage) {
@@ -1525,19 +1570,34 @@ class Net_SSH2
             return false;
         }
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->server_public_host_key = $server_public_host_key = $this->_string_shift($response, $temp['length']);
 
+        if (strlen($server_public_host_key) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
         $public_key_format = $this->_string_shift($server_public_host_key, $temp['length']);
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $fBytes = $this->_string_shift($response, $temp['length']);
         $f = new Math_BigInteger($fBytes, -256);
 
+        if (strlen($response) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($response, 4));
         $this->signature = $this->_string_shift($response, $temp['length']);
 
+        if (strlen($this->signature) < 4) {
+            return false;
+        }
         $temp = unpack('Nlength', $this->_string_shift($this->signature, 4));
         $this->signature_format = $this->_string_shift($this->signature, $temp['length']);
 
@@ -1598,6 +1658,9 @@ class Net_SSH2
             return false;
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         if ($type != NET_SSH2_MSG_NEWKEYS) {
@@ -2030,6 +2093,9 @@ class Net_SSH2
                 return false;
             }
 
+            if (strlen($response) < 4) {
+                return false;
+            }
             extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
             if ($type != NET_SSH2_MSG_SERVICE_ACCEPT) {
@@ -2083,6 +2149,9 @@ class Net_SSH2
                 return false;
             }
 
+            if (!strlen($response)) {
+                return false;
+            }
             extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
             switch ($type) {
@@ -2138,6 +2207,9 @@ class Net_SSH2
             return false;
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         switch ($type) {
@@ -2145,14 +2217,23 @@ class Net_SSH2
                 if (defined('NET_SSH2_LOGGING')) {
                     $this->message_number_log[count($this->message_number_log) - 1] = 'NET_SSH2_MSG_USERAUTH_PASSWD_CHANGEREQ';
                 }
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $this->errors[] = 'SSH_MSG_USERAUTH_PASSWD_CHANGEREQ: ' . utf8_decode($this->_string_shift($response, $length));
                 return $this->_disconnect(NET_SSH2_DISCONNECT_AUTH_CANCELLED_BY_USER);
             case NET_SSH2_MSG_USERAUTH_FAILURE:
                 // can we use keyboard-interactive authentication?  if not then either the login is bad or the server employees
                 // multi-factor authentication
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $auth_methods = explode(',', $this->_string_shift($response, $length));
+                if (!strlen($response)) {
+                    return false;
+                }
                 extract(unpack('Cpartial_success', $this->_string_shift($response, 1)));
                 $partial_success = $partial_success != 0;
 
@@ -2227,16 +2308,31 @@ class Net_SSH2
             }
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_INFO_REQUEST:
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $this->_string_shift($response, $length); // name; may be empty
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $this->_string_shift($response, $length); // instruction; may be empty
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $this->_string_shift($response, $length); // language tag; may be empty
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nnum_prompts', $this->_string_shift($response, 4)));
 
                 for ($i = 0; $i < count($responses); $i++) {
@@ -2251,6 +2347,9 @@ class Net_SSH2
 
                 if (isset($this->keyboard_requests_responses)) {
                     for ($i = 0; $i < $num_prompts; $i++) {
+                        if (strlen($response) < 4) {
+                            return false;
+                        }
                         extract(unpack('Nlength', $this->_string_shift($response, 4)));
                         // prompt - ie. "Password: "; must not be empty
                         $prompt = $this->_string_shift($response, $length);
@@ -2396,10 +2495,16 @@ class Net_SSH2
             return false;
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_FAILURE:
+                if (strlen($response) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
                 $this->errors[] = 'SSH_MSG_USERAUTH_FAILURE: ' . $this->_string_shift($response, $length);
                 return false;
@@ -2431,6 +2536,9 @@ class Net_SSH2
             return false;
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
         switch ($type) {
@@ -2549,6 +2657,9 @@ class Net_SSH2
                 return false;
             }
 
+            if (!strlen($response)) {
+                return false;
+            }
             list(, $type) = unpack('C', $this->_string_shift($response, 1));
 
             switch ($type) {
@@ -2686,6 +2797,9 @@ class Net_SSH2
             return false;
         }
 
+        if (!strlen($response)) {
+            return false;
+        }
         list(, $type) = unpack('C', $this->_string_shift($response, 1));
 
         switch ($type) {
@@ -3021,6 +3135,9 @@ class Net_SSH2
             return false;
         }
 
+        if (strlen($raw) < 5) {
+            return false;
+        }
         extract(unpack('Npacket_length/Cpadding_length', $this->_string_shift($raw, 5)));
 
         $remaining_length = $packet_length + 4 - $this->decrypt_block_size;
@@ -3096,6 +3213,9 @@ class Net_SSH2
         switch (ord($payload[0])) {
             case NET_SSH2_MSG_DISCONNECT:
                 $this->_string_shift($payload, 1);
+                if (strlen($payload) < 8) {
+                    return false;
+                }
                 extract(unpack('Nreason_code/Nlength', $this->_string_shift($payload, 8)));
                 $this->errors[] = 'SSH_MSG_DISCONNECT: ' . $this->disconnect_reasons[$reason_code] . "\r\n" . utf8_decode($this->_string_shift($payload, $length));
                 $this->bitmap = 0;
@@ -3105,6 +3225,9 @@ class Net_SSH2
                 break;
             case NET_SSH2_MSG_DEBUG:
                 $this->_string_shift($payload, 2);
+                if (strlen($payload) < 4) {
+                    return false;
+                }
                 extract(unpack('Nlength', $this->_string_shift($payload, 4)));
                 $this->errors[] = 'SSH_MSG_DEBUG: ' . utf8_decode($this->_string_shift($payload, $length));
                 $payload = $this->_get_binary_packet();
@@ -3124,6 +3247,9 @@ class Net_SSH2
         // see http://tools.ietf.org/html/rfc4252#section-5.4; only called when the encryption has been activated and when we haven't already logged in
         if (($this->bitmap & NET_SSH2_MASK_CONNECTED) && !($this->bitmap & NET_SSH2_MASK_LOGIN) && ord($payload[0]) == NET_SSH2_MSG_USERAUTH_BANNER) {
             $this->_string_shift($payload, 1);
+            if (strlen($payload) < 4) {
+                return false;
+            }
             extract(unpack('Nlength', $this->_string_shift($payload, 4)));
             $this->banner_message = utf8_decode($this->_string_shift($payload, $length));
             $payload = $this->_get_binary_packet();
@@ -3133,6 +3259,9 @@ class Net_SSH2
         if (($this->bitmap & NET_SSH2_MASK_CONNECTED) && ($this->bitmap & NET_SSH2_MASK_LOGIN)) {
             switch (ord($payload[0])) {
                 case NET_SSH2_MSG_GLOBAL_REQUEST: // see http://tools.ietf.org/html/rfc4254#section-4
+                    if (strlen($payload) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nlength', $this->_string_shift($payload, 4)));
                     $this->errors[] = 'SSH_MSG_GLOBAL_REQUEST: ' . $this->_string_shift($payload, $length);
 
@@ -3144,8 +3273,14 @@ class Net_SSH2
                     break;
                 case NET_SSH2_MSG_CHANNEL_OPEN: // see http://tools.ietf.org/html/rfc4254#section-5.1
                     $this->_string_shift($payload, 1);
+                    if (strlen($payload) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nlength', $this->_string_shift($payload, 4)));
                     $data = $this->_string_shift($payload, $length);
+                    if (strlen($payload) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nserver_channel', $this->_string_shift($payload, 4)));
                     switch ($data) {
                         case 'auth-agent':
@@ -3153,6 +3288,9 @@ class Net_SSH2
                             if (isset($this->agent)) {
                                 $new_channel = NET_SSH2_CHANNEL_AGENT_FORWARD;
 
+                                if (strlen($payload) < 8) {
+                                    return false;
+                                }
                                 extract(unpack('Nremote_window_size', $this->_string_shift($payload, 4)));
                                 extract(unpack('Nremote_maximum_packet_size', $this->_string_shift($payload, 4)));
 
@@ -3198,6 +3336,9 @@ class Net_SSH2
                     break;
                 case NET_SSH2_MSG_CHANNEL_WINDOW_ADJUST:
                     $this->_string_shift($payload, 1);
+                    if (strlen($payload) < 8) {
+                        return false;
+                    }
                     extract(unpack('Nchannel', $this->_string_shift($payload, 4)));
                     extract(unpack('Nwindow_size', $this->_string_shift($payload, 4)));
                     $this->window_size_client_to_server[$channel]+= $window_size;
@@ -3330,8 +3471,14 @@ class Net_SSH2
                 return '';
             }
 
+            if (!strlen($response)) {
+                return false;
+            }
             extract(unpack('Ctype', $this->_string_shift($response, 1)));
 
+            if (strlen($response) < 4) {
+                return false;
+            }
             if ($type == NET_SSH2_MSG_CHANNEL_OPEN) {
                 extract(unpack('Nlength', $this->_string_shift($response, 4)));
             } else {
@@ -3355,14 +3502,23 @@ class Net_SSH2
                     case NET_SSH2_MSG_CHANNEL_OPEN:
                         switch ($type) {
                             case NET_SSH2_MSG_CHANNEL_OPEN_CONFIRMATION:
+                                if (strlen($response) < 4) {
+                                    return false;
+                                }
                                 extract(unpack('Nserver_channel', $this->_string_shift($response, 4)));
                                 $this->server_channels[$channel] = $server_channel;
+                                if (strlen($response) < 4) {
+                                    return false;
+                                }
                                 extract(unpack('Nwindow_size', $this->_string_shift($response, 4)));
                                 if ($window_size < 0) {
                                     $window_size&= 0x7FFFFFFF;
                                     $window_size+= 0x80000000;
                                 }
                                 $this->window_size_client_to_server[$channel] = $window_size;
+                                if (strlen($response) < 4) {
+                                     return false;
+                                }
                                 $temp = unpack('Npacket_size_client_to_server', $this->_string_shift($response, 4));
                                 $this->packet_size_client_to_server[$channel] = $temp['packet_size_client_to_server'];
                                 $result = $client_channel == $channel ? true : $this->_get_channel_packet($client_channel, $skip_extended);
@@ -3402,6 +3558,9 @@ class Net_SSH2
                         $this->_send_channel_packet($channel, chr(0));
                     }
                     */
+                    if (strlen($response) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nlength', $this->_string_shift($response, 4)));
                     $data = $this->_string_shift($response, $length);
 
@@ -3428,6 +3587,9 @@ class Net_SSH2
                     }
                     */
                     // currently, there's only one possible value for $data_type_code: NET_SSH2_EXTENDED_DATA_STDERR
+                    if (strlen($response) < 8) {
+                        return false;
+                    }
                     extract(unpack('Ndata_type_code/Nlength', $this->_string_shift($response, 8)));
                     $data = $this->_string_shift($response, $length);
                     $this->stdErrorLog.= $data;
@@ -3443,14 +3605,23 @@ class Net_SSH2
                     $this->channel_buffers[$channel][] = $data;
                     break;
                 case NET_SSH2_MSG_CHANNEL_REQUEST:
+                    if (strlen($response) < 4) {
+                        return false;
+                    }
                     extract(unpack('Nlength', $this->_string_shift($response, 4)));
                     $value = $this->_string_shift($response, $length);
                     switch ($value) {
                         case 'exit-signal':
                             $this->_string_shift($response, 1);
+                            if (strlen($response) < 4) {
+                                return false;
+                            }
                             extract(unpack('Nlength', $this->_string_shift($response, 4)));
                             $this->errors[] = 'SSH_MSG_CHANNEL_REQUEST (exit-signal): ' . $this->_string_shift($response, $length);
                             $this->_string_shift($response, 1);
+                            if (strlen($response) < 4) {
+                                return false;
+                            }
                             extract(unpack('Nlength', $this->_string_shift($response, 4)));
                             if ($length) {
                                 $this->errors[count($this->errors)].= "\r\n" . $this->_string_shift($response, $length);
@@ -3463,6 +3634,9 @@ class Net_SSH2
 
                             break;
                         case 'exit-status':
+                            if (strlen($response) < 5) {
+                                return false;
+                            }
                             extract(unpack('Cfalse/Nexit_status', $this->_string_shift($response, 5)));
                             $this->exit_status = $exit_status;
 
@@ -4091,6 +4265,9 @@ class Net_SSH2
         $signature = $this->signature;
         $server_public_host_key = $this->server_public_host_key;
 
+        if (strlen($server_public_host_key) < 4) {
+            return false;
+        }
         extract(unpack('Nlength', $this->_string_shift($server_public_host_key, 4)));
         $this->_string_shift($server_public_host_key, $length);
 
@@ -4106,15 +4283,27 @@ class Net_SSH2
             case 'ssh-dss':
                 $zero = new Math_BigInteger();
 
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $p = new Math_BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
 
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $q = new Math_BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
 
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $g = new Math_BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
 
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $y = new Math_BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
 
@@ -4161,15 +4350,24 @@ class Net_SSH2
 
                 break;
             case 'ssh-rsa':
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $e = new Math_BigInteger($this->_string_shift($server_public_host_key, $temp['length']), -256);
 
+                if (strlen($server_public_host_key) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($server_public_host_key, 4));
                 $rawN = $this->_string_shift($server_public_host_key, $temp['length']);
                 $n = new Math_BigInteger($rawN, -256);
                 $nLength = strlen(ltrim($rawN, "\0"));
 
                 /*
+                if (strlen($signature) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($signature, 4));
                 $signature = $this->_string_shift($signature, $temp['length']);
 
@@ -4186,6 +4384,9 @@ class Net_SSH2
                 }
                 */
 
+                if (strlen($signature) < 4) {
+                    return false;
+                }
                 $temp = unpack('Nlength', $this->_string_shift($signature, 4));
                 $s = new Math_BigInteger($this->_string_shift($signature, $temp['length']), 256);
 


### PR DESCRIPTION
This changes suppresses the "not enough input" errors that phpseclib can emit.

The specific motivation for this was #1046 (scroll towards the bottom).