### PR TITLE
SSH2: make it so disabling PTY closes exec() channel if it's open

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2601,6 +2601,11 @@ class Net_SSH2
             return false;
         }
 
+        if ($this->in_request_pty_exec) {
+            user_error('If you want to run multiple exec()\'s you will need to disable (and re-enable if appropriate) a PTY for each one.');
+            return false;
+        }
+
         // RFC4254 defines the (client) window size as "bytes the other party can send before it must wait for the window to
         // be adjusted".  0x7FFFFFFF is, at 2GB, the max size.  technically, it should probably be decremented, but,
         // honestly, if you're transferring more than 2GB, you probably shouldn't be using phpseclib, anyway.
@@ -3408,6 +3413,10 @@ class Net_SSH2
      */
     function disablePTY()
     {
+        if ($this->in_request_pty_exec) {
+            $this->_close_channel(NET_SSH2_CHANNEL_EXEC);
+            $this->in_request_pty_exec = false;
+        }
         $this->request_pty = false;
     }
 


### PR DESCRIPTION
Fixes #1009