### PR TITLE
namespacing the array_map function

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3464,7 +3464,7 @@ class X509
         $altName = array();
 
         if (isset($subject->domains) && count($subject->domains) > 1) {
-            $altName = array_map(array('X509', '_dnsName'), $subject->domains);
+            $altName = array_map(array('\phpseclib\File\X509', '_dnsName'), $subject->domains);
         }
 
         if (isset($subject->ipAddresses) && count($subject->ipAddresses)) {


### PR DESCRIPTION
It would seem that issue https://github.com/phpseclib/phpseclib/issues/1103 array_map would prefer a fully qualified namespace.