### PR TITLE
SFTP: Add a NO_REALPATH option to put()

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -162,7 +162,7 @@ class SFTP extends SSH2
      * Current working directory
      *
      * @var string
-     * @see self::_realpath()
+     * @see self::realpath()
      * @see self::chdir()
      * @access private
      */
@@ -1282,7 +1282,7 @@ class SFTP extends SSH2
     /**
      * Returns general information about a file or symbolic link
      *
-     * Determines information without calling \phpseclib\Net\SFTP::_realpath().
+     * Determines information without calling \phpseclib\Net\SFTP::realpath().
      * The second parameter can be either NET_SFTP_STAT or NET_SFTP_LSTAT.
      *
      * @param string $filename
@@ -1444,7 +1444,7 @@ class SFTP extends SSH2
             return true;
         }
 
-        $filename = $this->realPath($filename);
+        $filename = $this->realpath($filename);
         // rather than return what the permissions *should* be, we'll return what they actually are.  this will also
         // tell us if the file actually exists.
         // incidentally, SFTPv4+ adds an additional 32-bit integer field - flags - to the following:

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -68,29 +68,25 @@ class SFTP extends SSH2
     /**
      * Reads data from a local file.
      */
-    const SOURCE_LOCAL_FILE = 0x1;
+    const SOURCE_LOCAL_FILE = 1;
     /**
      * Reads data from a string.
      */
     // this value isn't really used anymore but i'm keeping it reserved for historical reasons
-    const SOURCE_STRING = 0x2;
-    /**
-     * Resumes an upload
-     */
-    const RESUME = 0x4;
-    /**
-     * Append a local file to an already existing remote file
-     */
-    const RESUME_START = 0x8;
+    const SOURCE_STRING = 2;
     /**
      * Reads data from callback:
      * function callback($length) returns string to proceed, null for EOF
      */
-    const SOURCE_CALLBACK = 0x10;
+    const SOURCE_CALLBACK = 16;
     /**
-     * Skip canonicalizing the remote path
+     * Resumes an upload
      */
-    const NO_REALPATH = 0x20;
+    const RESUME = 4;
+    /**
+     * Append a local file to an already existing remote file
+     */
+    const RESUME_START = 8;
     /**#@-*/
 
     /**
@@ -1823,9 +1819,8 @@ class SFTP extends SSH2
      * Currently, only binary mode is supported.  As such, if the line endings need to be adjusted, you will need to take
      * care of that, yourself.
      *
-     * $mode can take three additional parameters - self::RESUME, self::RESUME_START and self::NO_REALPATH. These are
-     * bitwise AND'd with $mode. So if you want to resume upload of a 300mb file on the local file system you'd set
-     * $mode to the following:
+     * $mode can take an additional two parameters - self::RESUME and self::RESUME_START. These are bitwise AND'd with
+     * $mode. So if you want to resume upload of a 300mb file on the local file system you'd set $mode to the following:
      *
      * self::SOURCE_LOCAL_FILE | self::RESUME
      *
@@ -1840,9 +1835,6 @@ class SFTP extends SSH2
      * middle of one.
      *
      * Setting $local_start to > 0 or $mode | self::RESUME_START doesn't do anything unless $mode | self::SOURCE_LOCAL_FILE.
-     *
-     * Passing self::NO_REALPATH skips canonicalization of the remote path; $remote_file will be passed verbatim to the
-     * remote host.
      *
      * @param string $remote_file
      * @param string|resource $data
@@ -1863,11 +1855,9 @@ class SFTP extends SSH2
             return false;
         }
 
-        if (!($mode & self::NO_REALPATH)) {
-            $remote_file = $this->realpath($remote_file);
-            if ($remote_file === false) {
-                return false;
-            }
+        $remote_file = $this->realpath($remote_file);
+        if ($remote_file === false) {
+            return false;
         }
 
         $this->remove_from_stat_cache($remote_file);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -68,25 +68,29 @@ class SFTP extends SSH2
     /**
      * Reads data from a local file.
      */
-    const SOURCE_LOCAL_FILE = 1;
+    const SOURCE_LOCAL_FILE = 0x1;
     /**
      * Reads data from a string.
      */
     // this value isn't really used anymore but i'm keeping it reserved for historical reasons
-    const SOURCE_STRING = 2;
+    const SOURCE_STRING = 0x2;
+    /**
+     * Resumes an upload
+     */
+    const RESUME = 0x4;
+    /**
+     * Append a local file to an already existing remote file
+     */
+    const RESUME_START = 0x8;
     /**
      * Reads data from callback:
      * function callback($length) returns string to proceed, null for EOF
      */
-    const SOURCE_CALLBACK = 16;
+    const SOURCE_CALLBACK = 0x10;
     /**
-     * Resumes an upload
+     * Skip canonicalizing the remote path
      */
-    const RESUME = 4;
-    /**
-     * Append a local file to an already existing remote file
-     */
-    const RESUME_START = 8;
+    const NO_REALPATH = 0x20;
     /**#@-*/
 
     /**
@@ -1819,8 +1823,9 @@ class SFTP extends SSH2
      * Currently, only binary mode is supported.  As such, if the line endings need to be adjusted, you will need to take
      * care of that, yourself.
      *
-     * $mode can take an additional two parameters - self::RESUME and self::RESUME_START. These are bitwise AND'd with
-     * $mode. So if you want to resume upload of a 300mb file on the local file system you'd set $mode to the following:
+     * $mode can take three additional parameters - self::RESUME, self::RESUME_START and self::NO_REALPATH. These are
+     * bitwise AND'd with $mode. So if you want to resume upload of a 300mb file on the local file system you'd set
+     * $mode to the following:
      *
      * self::SOURCE_LOCAL_FILE | self::RESUME
      *
@@ -1835,6 +1840,9 @@ class SFTP extends SSH2
      * middle of one.
      *
      * Setting $local_start to > 0 or $mode | self::RESUME_START doesn't do anything unless $mode | self::SOURCE_LOCAL_FILE.
+     *
+     * Passing self::NO_REALPATH skips canonicalization of the remote path; $remote_file will be passed verbatim to the
+     * remote host.
      *
      * @param string $remote_file
      * @param string|resource $data
@@ -1855,9 +1863,11 @@ class SFTP extends SSH2
             return false;
         }
 
-        $remote_file = $this->realpath($remote_file);
-        if ($remote_file === false) {
-            return false;
+        if (!($mode & self::NO_REALPATH)) {
+            $remote_file = $this->realpath($remote_file);
+            if ($remote_file === false) {
+                return false;
+            }
         }
 
         $this->remove_from_stat_cache($remote_file);


### PR DESCRIPTION
A third party we communicate with apparently requires us to use an initial double slash in the path when uploading files, for reasons unknown to me. Never the less, using just one slash does not appear to work.

Since the internal realpath() method strips all redundant slashes we need to bypass it.