### PR TITLE
New read mode READ_NEXT to allow non-blocking reads from channel

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -141,6 +141,10 @@ class SSH2
      */
     const READ_REGEX = 2;
     /**
+     * Returns when a string matching the regular expression $expect is found
+     */
+    const READ_NEXT = 3;
+    /**
      * Make sure that the log never gets larger than this
      */
     const LOG_MAX_SIZE = 1048576; // 1024 * 1024
@@ -2812,6 +2816,10 @@ class SSH2
         }
 
         $channel = $this->_get_interactive_channel();
+
+        if ($mode == self::READ_NEXT) {
+            return $this->_get_channel_packet($channel);
+        }
 
         $match = $expect;
         while (true) {


### PR DESCRIPTION
This solves #700.
It is non BC-breaking new functionality.
PR created against 2.0, but I'd be happy to create PRs against the other branches as well (it's not that much code after all). I am aware [you wanted to wait](https://github.com/phpseclib/phpseclib/issues/700#issuecomment-109767519) until refactoring of the API is done, but since that comment is 2 years old, I figured your stances might have changed.
Code is mainly based on @magnusjt's [readWithoutLocking](https://github.com/phpseclib/phpseclib/issues/700#issuecomment-124450755).
Additionally, I think this would replace PR #804, though I am not 100% what the goal of that one was.

Adding this functionality allows for a more manual and controllable flow on interactive shells. It essentially enables a user to receive any input as soon as it is available.

As [mentioned](https://github.com/phpseclib/phpseclib/issues/1080#issuecomment-270467778) [multiple](https://github.com/phpseclib/phpseclib/issues/506#issuecomment-65472481) [times](https://github.com/phpseclib/phpseclib/issues/479), phpseclib currently does not have a way of simple reading any input.

See the little example on how to create a true interactive ssh from a php script:
```
$ php connect.php
```
```php
include 'vendor/autoload.php';

use phpseclib\Crypt\RSA;
use phpseclib\Net\SSH2;

/** Settings */
$host = 'www.example.com';
$user = 'username';
$auth = (new RSA())->loadKey(file_get_contents('private-key.txt'));

// Connect to the host
$ssh = new SSH2($host);
if (!$ssh->login($user, $auth)) {
    exit('Login Failed');
}

// Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
$sttyMode = shell_exec('stty -g');
shell_exec('stty -icanon -echo');

// Read data from streams
try {
    // define base streams to listen to
    $streams = [STDIN, $ssh->fsock];

    // set-up stream select command
    $read  = $streams;
    $write = $except = null;

    // Send empty package to trigger initial output
    // ssh stream seems not to receive anything without it
    $ssh->write("");

    // indefinitely wait for streams to provide data
    $last_response = '';
    while (stream_select($read, $write, $except, PHP_INT_MAX, 0) !== 0) {
        // check all selected read streams
        foreach ($read as $stream) {
            // if the selected stream is the keyboard input, send data
            if ($stream == STDIN) {
                $ssh->write(fgetc(STDIN));
                continue;
            }

            // any other stream must be the ssh connection
            $last_response = $ssh->read('', SSH2::READ_NEXT);
            if (!is_string($last_response)) {
                break 2;
            }
            fwrite(STDOUT, $last_response);
        }

        // reset read to the original stream list
        $read = $streams;
    }
} finally {
    // reset stty so it behaves normally again before continuing with anything else
    shell_exec(sprintf('stty %s', $sttyMode));
}
```