### PR TITLE
Allow $encryption_algorithms to be configured

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -871,6 +871,49 @@ class SSH2
     var $agent;
 
     /**
+     * Contains all possible algorithms
+     *
+     * @see self::_key_exchange()
+     * @var array
+     * @access private
+     */
+    var $encryption_algorithms = array(
+        // from <http://tools.ietf.org/html/rfc4345#section-4>:
+        'arcfour256',
+        'arcfour128',
+
+        //'arcfour',      // OPTIONAL          the ARCFOUR stream cipher with a 128-bit key
+
+        // CTR modes from <http://tools.ietf.org/html/rfc4344#section-4>:
+        'aes128-ctr',     // RECOMMENDED       AES (Rijndael) in SDCTR mode, with 128-bit key
+        'aes192-ctr',     // RECOMMENDED       AES with 192-bit key
+        'aes256-ctr',     // RECOMMENDED       AES with 256-bit key
+
+        'twofish128-ctr', // OPTIONAL          Twofish in SDCTR mode, with 128-bit key
+        'twofish192-ctr', // OPTIONAL          Twofish with 192-bit key
+        'twofish256-ctr', // OPTIONAL          Twofish with 256-bit key
+
+        'aes128-cbc',     // RECOMMENDED       AES with a 128-bit key
+        'aes192-cbc',     // OPTIONAL          AES with a 192-bit key
+        'aes256-cbc',     // OPTIONAL          AES in CBC mode, with a 256-bit key
+
+        'twofish128-cbc', // OPTIONAL          Twofish with a 128-bit key
+        'twofish192-cbc', // OPTIONAL          Twofish with a 192-bit key
+        'twofish256-cbc',
+        'twofish-cbc',    // OPTIONAL          alias for "twofish256-cbc"
+        //                   (this is being retained for historical reasons)
+
+        'blowfish-ctr',   // OPTIONAL          Blowfish in SDCTR mode
+
+        'blowfish-cbc',   // OPTIONAL          Blowfish in CBC mode
+
+        '3des-ctr',       // RECOMMENDED       Three-key 3DES in SDCTR mode
+
+        '3des-cbc',       // REQUIRED          three-key 3DES in CBC mode
+        //'none'         // OPTIONAL          no encryption; NOT RECOMMENDED
+    );
+
+    /**
      * Default Constructor.
      *
      * $host can either be a string, representing the host, or a stream resource.
@@ -1197,41 +1240,7 @@ class SSH2
             'ssh-dss'  // REQUIRED     sign   Raw DSS Key
         );
 
-        $encryption_algorithms = array(
-            // from <http://tools.ietf.org/html/rfc4345#section-4>:
-            'arcfour256',
-            'arcfour128',
-
-            //'arcfour',      // OPTIONAL          the ARCFOUR stream cipher with a 128-bit key
-
-            // CTR modes from <http://tools.ietf.org/html/rfc4344#section-4>:
-            'aes128-ctr',     // RECOMMENDED       AES (Rijndael) in SDCTR mode, with 128-bit key
-            'aes192-ctr',     // RECOMMENDED       AES with 192-bit key
-            'aes256-ctr',     // RECOMMENDED       AES with 256-bit key
-
-            'twofish128-ctr', // OPTIONAL          Twofish in SDCTR mode, with 128-bit key
-            'twofish192-ctr', // OPTIONAL          Twofish with 192-bit key
-            'twofish256-ctr', // OPTIONAL          Twofish with 256-bit key
-
-            'aes128-cbc',     // RECOMMENDED       AES with a 128-bit key
-            'aes192-cbc',     // OPTIONAL          AES with a 192-bit key
-            'aes256-cbc',     // OPTIONAL          AES in CBC mode, with a 256-bit key
-
-            'twofish128-cbc', // OPTIONAL          Twofish with a 128-bit key
-            'twofish192-cbc', // OPTIONAL          Twofish with a 192-bit key
-            'twofish256-cbc',
-            'twofish-cbc',    // OPTIONAL          alias for "twofish256-cbc"
-                              //                   (this is being retained for historical reasons)
-
-            'blowfish-ctr',   // OPTIONAL          Blowfish in SDCTR mode
-
-            'blowfish-cbc',   // OPTIONAL          Blowfish in CBC mode
-
-            '3des-ctr',       // RECOMMENDED       Three-key 3DES in SDCTR mode
-
-            '3des-cbc',       // REQUIRED          three-key 3DES in CBC mode
-                //'none'         // OPTIONAL          no encryption; NOT RECOMMENDED
-        );
+        $encryption_algorithms = $this->getEncryptionAlgorithms();
 
         if (extension_loaded('openssl') && !extension_loaded('mcrypt')) {
             // OpenSSL does not support arcfour256 in any capacity and arcfour128 / arcfour support is limited to
@@ -4402,5 +4411,27 @@ class SSH2
     {
         $this->windowColumns = $columns;
         $this->windowRows = $rows;
+    }
+
+    /**
+     * Sets the default encryption algorithms
+     *
+     * @access public
+     * @param array $encryption_algorithms
+     */
+    function setEncryptionAlgorithms(array $encryption_algorithms)
+    {
+        $this->encryption_algorithms = $encryption_algorithms;
+    }
+
+    /**
+     * Returns default encryption algorithms
+     *
+     * @access public
+     * @return array
+     */
+    function getEncryptionAlgorithms()
+    {
+        return $this->encryption_algorithms;
     }
 }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -154,7 +154,7 @@ class SSH2
      * @access public
      * @see \phpseclib\Net\SSH2::setEncryptionAlgorithms()
      */
-    const SUPPORTED_ENCRYPTION_ALGORITHMS = array(
+    static $SUPPORTED_ENCRYPTION_ALGORITHMS = array(
         // from <http://tools.ietf.org/html/rfc4345#section-4>:
         'arcfour256',
         'arcfour128',
@@ -4561,7 +4561,7 @@ class SSH2
      */
     function setEncryptionAlgorithms($encryption_algorithms)
     {
-        $unsupportedEncryptionAlgorithms = array_diff($encryption_algorithms, $this->encryption_algorithms);
+        $unsupportedEncryptionAlgorithms = array_diff($encryption_algorithms, self::$SUPPORTED_ENCRYPTION_ALGORITHMS);
         if (count($unsupportedEncryptionAlgorithms) > 0) {
             user_error(sprintf(
                 'Encryption algorithms are not supported: %s',

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -150,6 +150,47 @@ class SSH2
     const READ_NEXT = 3;
     /**#@-*/
 
+    /**#@+
+     * @access public
+     * @see \phpseclib\Net\SSH2::setEncryptionAlgorithms()
+     */
+    const SUPPORTED_ENCRYPTION_ALGORITHMS = array(
+        // from <http://tools.ietf.org/html/rfc4345#section-4>:
+        'arcfour256',
+        'arcfour128',
+
+        'arcfour',      // OPTIONAL          the ARCFOUR stream cipher with a 128-bit key
+
+        // CTR modes from <http://tools.ietf.org/html/rfc4344#section-4>:
+        'aes128-ctr',     // RECOMMENDED       AES (Rijndael) in SDCTR mode, with 128-bit key
+        'aes192-ctr',     // RECOMMENDED       AES with 192-bit key
+        'aes256-ctr',     // RECOMMENDED       AES with 256-bit key
+
+        'twofish128-ctr', // OPTIONAL          Twofish in SDCTR mode, with 128-bit key
+        'twofish192-ctr', // OPTIONAL          Twofish with 192-bit key
+        'twofish256-ctr', // OPTIONAL          Twofish with 256-bit key
+
+        'aes128-cbc',     // RECOMMENDED       AES with a 128-bit key
+        'aes192-cbc',     // OPTIONAL          AES with a 192-bit key
+        'aes256-cbc',     // OPTIONAL          AES in CBC mode, with a 256-bit key
+
+        'twofish128-cbc', // OPTIONAL          Twofish with a 128-bit key
+        'twofish192-cbc', // OPTIONAL          Twofish with a 192-bit key
+        'twofish256-cbc',
+        'twofish-cbc',    // OPTIONAL          alias for "twofish256-cbc"
+        //                   (this is being retained for historical reasons)
+
+        'blowfish-ctr',   // OPTIONAL          Blowfish in SDCTR mode
+
+        'blowfish-cbc',   // OPTIONAL          Blowfish in CBC mode
+
+        '3des-ctr',       // RECOMMENDED       Three-key 3DES in SDCTR mode
+
+        '3des-cbc',       // REQUIRED          three-key 3DES in CBC mode
+        'none'         // OPTIONAL          no encryption; NOT RECOMMENDED
+    );
+    /**#@-*/
+
     /**
      * The SSH identifier
      *
@@ -4419,8 +4460,16 @@ class SSH2
      * @access public
      * @param array $encryption_algorithms
      */
-    function setEncryptionAlgorithms(array $encryption_algorithms)
+    function setEncryptionAlgorithms($encryption_algorithms)
     {
+        $unsupportedEncryptionAlgorithms = array_diff($encryption_algorithms, $this->encryption_algorithms);
+        if (count($unsupportedEncryptionAlgorithms) > 0) {
+            user_error(sprintf(
+                'Encryption algorithms are not supported: %s',
+                implode(',', $unsupportedEncryptionAlgorithms)
+            ));
+            return;
+        }
         $this->encryption_algorithms = $encryption_algorithms;
     }
 

--- a/tests/Unit/Net/SSH2Test.php
+++ b/tests/Unit/Net/SSH2Test.php
@@ -159,6 +159,16 @@ class Unit_Net_SSH2Test extends PhpseclibTestCase
         );
     }
 
+    public function testUnsupportedEncryptionAlgorithms()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Notice', 'Encryption algorithms are not supported: unsupported-algorithm');
+        $ssh = $this->createSSHMock();
+        $ssh->setEncryptionAlgorithms(array(
+            'aes128-ctr',
+            'unsupported-algorithm'
+        ));
+    }
+
     /**
      * @return \phpseclib\Net\SSH2
      */

--- a/tests/Unit/Net/SSH2Test.php
+++ b/tests/Unit/Net/SSH2Test.php
@@ -110,6 +110,55 @@ class Unit_Net_SSH2Test extends PhpseclibTestCase
         $this->assertFalse($ssh->isQuietModeEnabled());
     }
 
+    public function testDefaultEncryptionAlgorithms()
+    {
+        $ssh = $this->createSSHMock();
+
+        $this->assertSame(
+            array (
+                'arcfour256',
+                'arcfour128',
+                'aes128-ctr',
+                'aes192-ctr',
+                'aes256-ctr',
+                'twofish128-ctr',
+                'twofish192-ctr',
+                'twofish256-ctr',
+                'aes128-cbc',
+                'aes192-cbc',
+                'aes256-cbc',
+                'twofish128-cbc',
+                'twofish192-cbc',
+                'twofish256-cbc',
+                'twofish-cbc',
+                'blowfish-ctr',
+                'blowfish-cbc',
+                '3des-ctr',
+                '3des-cbc',
+            ),
+            $ssh->getEncryptionAlgorithms()
+        );
+    }
+
+    public function testOverwrittenEncryptionAlgorithms()
+    {
+        $ssh = $this->createSSHMock();
+        $ssh->setEncryptionAlgorithms(array(
+            'aes128-ctr',
+            'aes192-ctr',
+            'aes256-ctr',
+        ));
+
+        $this->assertSame(
+            array (
+                'aes128-ctr',
+                'aes192-ctr',
+                'aes256-ctr',
+            ),
+            $ssh->getEncryptionAlgorithms()
+        );
+    }
+
     /**
      * @return \phpseclib\Net\SSH2
      */


### PR DESCRIPTION
Given the amount of issues and bug reports where commenting out the `arcfour256` and `arcfour128` encryption algorithms seems to be the only solution it would make sense to make this variable configurable.

We're talking about this change:

```php
$encryption_algorithms = array(
    // from <http://tools.ietf.org/html/rfc4345#section-4>:
    //'arcfour256',
    //'arcfour128',
);
```

Just a few issues where this is being promoted:

- https://github.com/phpseclib/phpseclib/issues/1125 
- http://www.frostjedi.com/phpbb3/viewtopic.php?f=46&t=168945 
- https://github.com/phpseclib/phpseclib/issues/992

As (hopefully) the majority of PHP users is using composer nowadays, commenting out a piece of code isn't a valid solution anymore. By the upgrade to FreeBSD 11 and proftpd 1.3.6 we were also hit by a bug caused by these algorithms. Would be nice if this could be merged.

I've adapted the code style of the class as much as possible and didn't use visibility for methods and properties. 