### PR TITLE
Replace extension_loaded with forward compatible function exists check

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1267,7 +1267,7 @@ class SSH2
         $identifier = 'SSH-2.0-phpseclib_2.0';
 
         $ext = [];
-        if (extension_loaded('libsodium')) {
+        if (function_exists('\\Sodium\\library_version_major')) {
             $ext[] = 'libsodium';
         }
 

--- a/tests/Unit/Net/SSH2Test.php
+++ b/tests/Unit/Net/SSH2Test.php
@@ -41,7 +41,7 @@ class Unit_Net_SSH2Test extends PhpseclibTestCase
         $identifier = self::callFunc($this->createSSHMock(), 'generate_identifier');
         $this->assertStringStartsWith('SSH-2.0-phpseclib_2.0', $identifier);
 
-        if (extension_loaded('libsodium')) {
+        if (function_exists('\\Sodium\\library_version_major')) {
             $this->assertContains('libsodium', $identifier);
         }
 


### PR DESCRIPTION
Since libsodium will be replaced by the new sodium extension which has been accepted into PHP 7.2 the extension loaded will not work for us when we start using the new sodium package.
Reference: https://github.com/jedisct1/libsodium-php

So its replaced by function exists call to allow us to use some kind of polyfill to guarantee compatibility. We created such a polyfill: https://github.com/mollie/polyfill-libsodium
