### PR TITLE
Fix wrong doccomment annotation of return type

### DIFF
--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -1584,7 +1584,7 @@ abstract class SymmetricKey
      *
      * May need to be overwritten by classes extending this one in some cases
      *
-     * @return int
+     * @return string
      * @access private
      */
     protected function openssl_translate_mode()


### PR DESCRIPTION
Fix wrong DocComment annotation of return type declaration.

I'm new to this phseclib project. so I'm not sure if it's correct, but it seems there are many wrong DocComment annotations inconsistents with access modifier of php syntax (public / protected / private).
Must I wrote some patches to fix these wrong DocComment, or just my lack of understanding about this code base?