### PR TITLE
Add 'cfb8' cipher mode of operation support

### DIFF
--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -1128,14 +1128,14 @@ abstract class SymmetricKey
 
                 for ($i = 0; $i < $len; ++$i) {
                     $ciphertext .= ($c = $plaintext[$i] ^ $this->encryptBlock($iv));
-                    $iv = substr($iv, 1, $this->block_size - 1) . $c;
+                    $iv = substr($iv, 1) . $c;
                 }
 
                 if ($this->continuousBuffer) {
-                    if ($len >= $this->block_size) {
-                        $this->encryptIV = substr($ciphertext, -$this->block_size);
+                    if ($len >= $block_size) {
+                        $this->encryptIV = substr($ciphertext, -$block_size);
                     } else {
-                        $this->encryptIV = substr($this->encryptIV, $len - $this->block_size) . substr($ciphertext, -$len);
+                        $this->encryptIV = substr($this->encryptIV, $len - $block_size) . substr($ciphertext, -$len);
                     }
                 }
                 break;
@@ -1439,14 +1439,14 @@ abstract class SymmetricKey
 
                 for ($i = 0; $i < $len; ++$i) {
                     $plaintext .= $ciphertext[$i] ^ $this->encryptBlock($iv);
-                    $iv = substr($iv, 1, $this->block_size - 1) . $ciphertext[$i];
+                    $iv = substr($iv, 1) . $ciphertext[$i];
                 }
 
                 if ($this->continuousBuffer) {
-                    if ($len >= $this->block_size) {
-                        $this->decryptIV = substr($ciphertext, -$this->block_size);
+                    if ($len >= $block_size) {
+                        $this->decryptIV = substr($ciphertext, -$block_size);
                     } else {
-                        $this->decryptIV = substr($this->decryptIV, $len - $this->block_size) . substr($ciphertext, -$len);
+                        $this->decryptIV = substr($this->decryptIV, $len - $block_size) . substr($ciphertext, -$len);
                     }
                 }
                 break;
@@ -2571,7 +2571,7 @@ abstract class SymmetricKey
                         $in = $_iv;
                         '.$encrypt_block.'
                         $_ciphertext .= ($_c = $_text[$_i] ^ $in);
-                        $_iv = substr($_iv, 1, '.$block_size.' - 1) . $_c;
+                        $_iv = substr($_iv, 1) . $_c;
                     }
 
                     if ($this->continuousBuffer) {
@@ -2593,7 +2593,7 @@ abstract class SymmetricKey
                         $in = $_iv;
                         '.$encrypt_block.'
                         $_plaintext .= $_text[$_i] ^ $in;
-                        $_iv = substr($_iv, 1, '.$block_size.' - 1) . $_text[$_i];
+                        $_iv = substr($_iv, 1) . $_text[$_i];
                     }
 
                     if ($this->continuousBuffer) {

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -935,11 +935,11 @@ abstract class SymmetricKey
                 case self::MODE_CFB8:
                     $ciphertext = openssl_encrypt($plaintext, $this->cipher_name_openssl, $this->key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, $this->encryptIV);
                     if ($this->continuousBuffer) {
-                            if (($len = strlen($ciphertext)) >= $this->block_size) {
-                                    $this->encryptIV = substr($ciphertext, -$this->block_size);
-                            } else {
-                                    $this->encryptIV = substr($this->encryptIV, $len - $this->block_size) . substr($ciphertext, -$len);
-                            }
+                        if (($len = strlen($ciphertext)) >= $this->block_size) {
+                            $this->encryptIV = substr($ciphertext, -$this->block_size);
+                        } else {
+                            $this->encryptIV = substr($this->encryptIV, $len - $this->block_size) . substr($ciphertext, -$len);
+                        }
                     }
                     return $ciphertext;
                 case self::MODE_OFB:
@@ -1126,7 +1126,7 @@ abstract class SymmetricKey
                 $len = strlen($plaintext);
                 $iv = $this->encryptIV;
 
-                for ($i=0; $i < $len; ++$i) {
+                for ($i = 0; $i < $len; ++$i) {
                     $ciphertext .= ($c = $plaintext[$i] ^ $this->encryptBlock($iv));
                     $iv = substr($iv, 1, $this->block_size - 1) . $c;
                 }
@@ -1437,7 +1437,7 @@ abstract class SymmetricKey
                 $len = strlen($ciphertext);
                 $iv = $this->decryptIV;
 
-                for ($i=0; $i < $len; ++$i) {
+                for ($i = 0; $i < $len; ++$i) {
                     $plaintext .= $ciphertext[$i] ^ $this->encryptBlock($iv);
                     $iv = substr($iv, 1, $this->block_size - 1) . $ciphertext[$i];
                 }

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -2561,6 +2561,52 @@ abstract class SymmetricKey
                     return $_plaintext;
                     ';
                 break;
+            case self::MODE_CFB8:
+                $encrypt = $init_encrypt . '
+                    $_ciphertext = "";
+                    $_len = strlen($_text);
+                    $_iv = $this->encryptIV;
+
+                    for ($_i = 0; $_i < $_len; ++$_i) {
+                        $in = $_iv;
+                        '.$encrypt_block.'
+                        $_ciphertext .= ($_c = $_text[$_i] ^ $in);
+                        $_iv = substr($_iv, 1, '.$block_size.' - 1) . $_c;
+                    }
+
+                    if ($this->continuousBuffer) {
+                        if ($_len >= '.$block_size.') {
+                            $this->encryptIV = substr($_ciphertext, -'.$block_size.');
+                        } else {
+                            $this->encryptIV = substr($this->encryptIV, $_len - '.$block_size.') . substr($_ciphertext, -$_len);
+                        }
+                    }
+
+                    return $_ciphertext;
+                    ';
+                $decrypt = $init_encrypt . '
+                    $_plaintext = "";
+                    $_len = strlen($_text);
+                    $_iv = $this->decryptIV;
+
+                    for ($_i = 0; $_i < $_len; ++$_i) {
+                        $in = $_iv;
+                        '.$encrypt_block.'
+                        $_plaintext .= $_text[$_i] ^ $in;
+                        $_iv = substr($_iv, 1, '.$block_size.' - 1) . $_text[$_i];
+                    }
+
+                    if ($this->continuousBuffer) {
+                        if ($_len >= '.$block_size.') {
+                            $this->decryptIV = substr($_text, -'.$block_size.');
+                        } else {
+                            $this->decryptIV = substr($this->decryptIV, $_len - '.$block_size.') . substr($_text, -$_len);
+                        }
+                    }
+
+                    return $_plaintext;
+                    ';
+                break;
             case self::MODE_OFB:
                 $encrypt = $init_encrypt . '
                     $_ciphertext = "";

--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -31,6 +31,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
             'ctr',
             'ofb',
             'cfb',
+            'cfb8'
         );
         $plaintexts = array(
             '',
@@ -131,6 +132,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
             'ctr',
             'ofb',
             'cfb',
+            'cfb8',
         );
 
         $combos = array(


### PR DESCRIPTION
## What's this ?
This patch add 'cfb8' cipher mode of operation to SymmetricKey class.
This mode was intended to be used with AES128 (Rijndael) encryption.

This patch supports the engines as foollows
* OpenSSL
* mcrypt
* Eval
* PHP

## Why this mode needed?
**Becase I NEED!**

 mcrypt extension is planned to be removed from next release of php version 7.2. And I have some codebase which requires AES-128-CFB8 with mcrypt extension. So, I need to replace the code with mcrypt compatible 'cfb8' mode encryption / decryption library. And phpseclib has internal PHP / Eval engine.

## How to use
```php
<?php
use phpseclib\Crypt\AES;

$key = "VpwGPQ33RrgiEmMV";
$msg = "this is secret message";

$aes = new AES("CFB8");
$aes->enableContinuousBuffer();
$aes->setKey($key);
$aes->setIV($key);

$cipher = $aes->encrypt($msg);
$actual = $aes->decrypt($cipher);

assert($actual === $msg);
echo "    original message: $msg".PHP_EOL;
echo "decrypted message: $actual".PHP_EOL;
```

### Follow up
I carefully tested this patch and add this mode to the test case of AES.
But I'm not sure if this test is enough or not.

And It may contains some problem I didn't noticed.
Please tell me if u found any problem about this patch.