### PR TITLE
Fix wrong doccomment annotation and Suggestion

### DIFF
--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -481,7 +481,7 @@ abstract class SymmetricKey
      *
      * - ofb
      *
-     * @param int $mode
+     * @param string $mode
      * @access public
      * @throws \InvalidArgumentException if an invalid / unsupported mode is provided
      */
@@ -1795,7 +1795,7 @@ abstract class SymmetricKey
      * If the preferred crypt engine is not available the fastest available one will be used
      *
      * @see self::__construct()
-     * @param int $engine
+     * @param string $engine
      * @access public
      */
     public function setPreferredEngine($engine)


### PR DESCRIPTION
Fix wrong doccomment annotations.

## Suggestion
It seems type of first argument of constructor and `setPreferredEngine()` method was changed by the commit 4171262b9

But I would rather wish I can use constants integer value like before.
May I wrote patch which accepts constants value in addition like below?

```php
<?php /* file: phpseclib/Crypt/Common/SymmetricKey.php */

/**
 * Default constructor
 * @param int|string $mode name of mode as string or constant integer value
 * @access public
 * @throws \InvalidArgumentException if an invalid / unsupported mode is provided
 */
 public function __construct($mode)
 {
  if (is_string($mode)) {
    $mode = strtolower($mode);
    // necessary because of 5.6 compatability; we can't do isset(self::MODE_MAP[$mode]) in 5.6
    $map = self::MODE_MAP;
    if (!isset($map[$mode])) {
      throw new \InvalidArgumentException('No valid mode has been specified');
    }
    $mode = self::MODE_MAP[$mode];
  }

  switch ($mode) {
    case self::MODE_ECB:
    case self::MODE_CBC:
      $this->paddable = true;
      break;
    case self::MODE_CTR:
    case self::MODE_CFB:
    case self::MODE_OFB:
    case self::MODE_STREAM:
      $this->paddable = false;
      break;
    default:
      throw new \InvalidArgumentException('No valid mode has been specified');
  }
  
  $this->mode = $mode;
 }
```


```php
<?php

// same all
new AES(AES::MODE_CFB);
new AES('CFB');
new AES('cfb');
```