### PR TITLE
Sometimes at php7 uniqid() return same result as their previous call.…

### DIFF
--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
@@ -169,14 +169,11 @@ abstract class EvalBarrett extends Base
             return 'return [];';
         }
 
-        $label = 'label_' . uniqid();
-
         $regular = '
             $length = count($' . $input . ');
             if (!$length) {
                 $' . $output . ' = [];
-                goto ' . $label . ';
-            }
+            }else{
             $' . $output . ' = array_fill(0, $length + ' . count($arr) . ', 0);
             $carry = 0;';
 
@@ -224,9 +221,7 @@ abstract class EvalBarrett extends Base
 
         $regular.= '$' . $output. '[++$k] = $carry; $carry = 0;';
 
-        $regular.= '}';
-
-        $regular.= $label . ':';
+        $regular.= '}}';
 
         //if (count($arr) < 2 * self::KARATSUBA_CUTOFF) {
         //}


### PR DESCRIPTION
… Here generates few equal labels wich makes error on eval. Does not know why uniqid() return same values but this is fact and my construction is more correct than previous. No need to call label id generation and use dirty goto :')