### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Functional/Net/SCPSSH2UserStoryTest.php
+++ b/tests/Functional/Net/SCPSSH2UserStoryTest.php
@@ -42,8 +42,9 @@ class Functional_Net_SCPSSH2UserStoryTest extends PhpseclibFunctionalTestCase
     public function testConstructor($ssh)
     {
         $scp = new SCP($ssh);
-        $this->assertTrue(
-            is_object($scp),
+        $this->assertInternalType(
+            'object',
+            $scp,
             'Could not construct \phpseclib\Net\SCP object.'
         );
         return $scp;

--- a/tests/Functional/Net/SFTPStreamTest.php
+++ b/tests/Functional/Net/SFTPStreamTest.php
@@ -22,7 +22,7 @@ class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
             'sftp' => ['session' => $this->sftp],
         ]);
         $fp = fopen($this->buildUrl('fooo.txt'), 'wb', false, $context);
-        $this->assertTrue(is_resource($fp));
+        $this->assertInternalType('resource', $fp);
         fclose($fp);
         $this->assertSame(0, $this->sftp->size('fooo.txt'));
     }
@@ -39,7 +39,7 @@ class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
         fputs($fp, 'zzzz');
         fclose($fp);
 
-        $this->assertTrue(in_array('te#st.txt', $this->sftp->nlist()));
+        $this->assertContains('te#st.txt', $this->sftp->nlist());
     }
 
     /**

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -29,8 +29,9 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         $sftp = new SFTP($this->getEnv('SSH_HOSTNAME'));
 
-        $this->assertTrue(
-            is_object($sftp),
+        $this->assertInternalType(
+            'object',
+            $sftp,
             'Could not construct NET_SFTP object.'
         );
 

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -14,8 +14,9 @@ class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
     {
         $ssh = new SSH2($this->getEnv('SSH_HOSTNAME'));
 
-        $this->assertTrue(
-            is_object($ssh),
+        $this->assertInternalType(
+            'object',
+            $ssh,
             'Could not construct NET_SSH2 object.'
         );
 

--- a/tests/Unit/File/ANSITest.php
+++ b/tests/Unit/File/ANSITest.php
@@ -59,7 +59,7 @@ class Unit_File_ANSITest extends PhpseclibTestCase
         $screen = $ansi->getScreen();
 
         $lines = explode("\r\n", $screen);
-        $this->assertSame(24, count($lines));
+        $this->assertCount(24, $lines);
         $this->assertSame(str_repeat('z', 80), $lines[22]);
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertInternalType` instead of `is_*` functions;
- `assertContains` instead of `in_array` function;
- `assertCount` instead of `count` function.