### PR TITLE
Check phpinfo() is available before using

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -468,23 +468,27 @@ class RSA
                     break;
                 case extension_loaded('openssl') && file_exists($this->configFile):
                     // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
-                    ob_start();
-                    @phpinfo();
-                    $content = ob_get_contents();
-                    ob_end_clean();
-
-                    preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
-
                     $versions = array();
-                    if (!empty($matches[1])) {
-                        for ($i = 0; $i < count($matches[1]); $i++) {
-                            $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
 
-                            // Remove letter part in OpenSSL version
-                            if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
-                                $versions[$matches[1][$i]] = $fullVersion;
-                            } else {
-                                $versions[$matches[1][$i]] = $m[0];
+                    // avoid generating errors (even with suppression) when phpinfo() is disabled (common in production systems)
+                    if (strpos(ini_get('disable_functions'), 'phpinfo') === false) {
+                        ob_start();
+                        @phpinfo();
+                        $content = ob_get_contents();
+                        ob_end_clean();
+
+                        preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
+
+                        if (!empty($matches[1])) {
+                            for ($i = 0; $i < count($matches[1]); $i++) {
+                                $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
+
+                                // Remove letter part in OpenSSL version
+                                if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
+                                    $versions[$matches[1][$i]] = $fullVersion;
+                                } else {
+                                    $versions[$matches[1][$i]] = $m[0];
+                                }
                             }
                         }
                     }

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -266,23 +266,27 @@ class BigInteger
 
         if (extension_loaded('openssl') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
             // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
-            ob_start();
-            @phpinfo();
-            $content = ob_get_contents();
-            ob_end_clean();
-
-            preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
-
             $versions = array();
-            if (!empty($matches[1])) {
-                for ($i = 0; $i < count($matches[1]); $i++) {
-                    $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
 
-                    // Remove letter part in OpenSSL version
-                    if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
-                        $versions[$matches[1][$i]] = $fullVersion;
-                    } else {
-                        $versions[$matches[1][$i]] = $m[0];
+            // avoid generating errors (even with suppression) when phpinfo() is disabled (common in production systems)
+            if (strpos(ini_get('disable_functions'), 'phpinfo') === false) {
+                ob_start();
+                @phpinfo();
+                $content = ob_get_contents();
+                ob_end_clean();
+
+                preg_match_all('#OpenSSL (Header|Library) Version(.*)#im', $content, $matches);
+
+                if (!empty($matches[1])) {
+                    for ($i = 0; $i < count($matches[1]); $i++) {
+                        $fullVersion = trim(str_replace('=>', '', strip_tags($matches[2][$i])));
+
+                        // Remove letter part in OpenSSL version
+                        if (!preg_match('/(\d+\.\d+\.\d+)/i', $fullVersion, $m)) {
+                            $versions[$matches[1][$i]] = $fullVersion;
+                        } else {
+                            $versions[$matches[1][$i]] = $m[0];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes an issue I raised at https://github.com/phpseclib/phpseclib/issues/1255

Proof of logic at https://3v4l.org/RqrHt

I ended up moving more code than discussed in the issue - initially to avoid `$content` being undefined when it came to `preg_match_all()`, but also as it made sense grouping the code that way. Also, initialising `$versions` outside the check, right at the start ensures it's always defined for the `switch` code further down.