### PR TITLE
Backport CFB8 support from master to 2.0

### DIFF
--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -39,6 +39,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
             Base::MODE_CTR,
             Base::MODE_OFB,
             Base::MODE_CFB,
+            Base::MODE_CFB8,
         );
         $plaintexts = array(
             '',
@@ -136,6 +137,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
             Base::MODE_CTR,
             Base::MODE_OFB,
             Base::MODE_CFB,
+            Base::MODE_CFB8,
         );
 
         $combos = array(


### PR DESCRIPTION
I need CFB8 in one of my projects but I’d rather not rely on an unstable API just for that, so I backported the changes from #1192 to the 2.0 branch.