### PR TITLE
Ensure SFTP::rawlist gives same results regardless of statcache

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -866,7 +866,18 @@ class SFTP extends SSH2
                 unset($files[$key]);
                 continue;
             }
-            if ($key != '.' && $key != '..' && is_array($this->query_stat_cache($this->realpath($dir . '/' . $key)))) {
+
+            $is_directory = false;
+            if ($key != '.' && $key != '..') {
+                if ($this->use_stat_cache) {
+                    $is_directory = is_array($this->query_stat_cache($this->realpath($dir . '/' . $key)));
+                } else {
+                    $stat = $this->stat($dir . '/' . $key);
+                    $is_directory = $stat && $stat['type'] === NET_SFTP_TYPE_DIRECTORY;
+                }
+            }
+
+            if ($is_directory) {
                 $depth++;
                 $files[$key] = $this->rawlist($dir . '/' . $key, true);
                 $depth--;

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -725,5 +725,32 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         $sftp->exec('ping google.com -c 5');
         sleep(5);
         $sftp->nlist();
+
+        return $sftp;
+    }
+
+    /**
+     * @depends testExecNlist
+     */
+    public function testRawlistDisabledStatCache($sftp)
+    {
+        $this->assertTrue($sftp->chdir('unittests'));
+        $this->assertTrue($sftp->mkdir(self::$scratchDir));
+        $this->assertTrue($sftp->chdir(self::$scratchDir));
+        $this->assertTrue($sftp->put('text.txt', 'zzzzz'));
+        $this->assertTrue($sftp->mkdir('subdir'));
+        $this->assertTrue($sftp->chdir('subdir'));
+        $this->assertTrue($sftp->put('leaf.txt', 'yyyyy'));
+        $this->assertTrue($sftp->chdir('../../'));
+
+        $list_cache_enabled = $sftp->rawlist('.', true);
+
+        $sftp->clearStatCache();
+
+        $sftp->disableStatCache();
+
+        $list_cache_disabled = $sftp->rawlist('.', true);
+
+        $this->assertEquals($list_cache_enabled, $list_cache_disabled, 'The files should be the same regardless of stat cache', 0.0, 10, true);
     }
 }

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -734,7 +734,6 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testRawlistDisabledStatCache($sftp)
     {
-        $this->assertTrue($sftp->chdir('unittests'));
         $this->assertTrue($sftp->mkdir(self::$scratchDir));
         $this->assertTrue($sftp->chdir(self::$scratchDir));
         $this->assertTrue($sftp->put('text.txt', 'zzzzz'));


### PR DESCRIPTION
Previously SFTP::rawlist gave different results depending on whether the
stat cache was enabled or not. With the stat cache turned off it did not
treat directories correctly, as it relied on the stat cache even though
it was not populated.