### PR TITLE
Fixes #1296 parsing invalid certificate

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -333,6 +333,9 @@ abstract class ASN1
                 $remainingLength = $length;
                 while ($remainingLength > 0) {
                     $temp = self::decode_ber($content, $start, $content_pos);
+                    if (false == $temp) {
+                        break;
+                    }
                     $length = $temp['length'];
                     // end-of-content octets - see paragraph 8.1.5
                     if (substr($content, $content_pos + $length, 2) == "\0\0") {
@@ -384,6 +387,9 @@ abstract class ASN1
                     $current['content'] = substr($content, $content_pos);
                 } else {
                     $temp = self::decode_ber($content, $start, $content_pos);
+                    if (false === $temp) {
+                        break;
+                    }
                     $length-= (strlen($content) - $content_pos);
                     $last = count($temp) - 1;
                     for ($i = 0; $i < $last; $i++) {
@@ -408,6 +414,9 @@ abstract class ASN1
                     $length = 0;
                     while (substr($content, $content_pos, 2) != "\0\0") {
                         $temp = self::decode_ber($content, $length + $start, $content_pos);
+                        if (false === $temp) {
+                            break;
+                        }
                         $content_pos += $temp['length'];
                         // all subtags should be octet strings
                         //if ($temp['type'] != self::TYPE_OCTET_STRING) {
@@ -440,6 +449,9 @@ abstract class ASN1
                         break 2;
                     }
                     $temp = self::decode_ber($content, $start + $offset, $content_pos);
+                    if (false === $temp) {
+                        break;
+                    }
                     $content_pos += $temp['length'];
                     $current['content'][] = $temp;
                     $offset+= $temp['length'];

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -335,4 +335,13 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
 
         $this->assertSame($data, $arr);
     }
+
+    /**
+     * @group github1296
+     */
+    public function testInvalidCertificate()
+    {
+        $data = 'a' . base64_decode('MD6gJQYKKwYBBAGCNxQCA6AXDBVvZmZpY2VAY2VydGRpZ2l0YWwucm+BFW9mZmljZUBjZXJ0ZGlnaXRhbC5ybw==');
+        ASN1::decodeBER($data);
+    }
 }


### PR DESCRIPTION
When parsing invalid (ie corrupted) certificate ASN1::decode_ber() will go into an infinite loop as the result of recursive calls to decode_ber could be false (and not checked).  This will lead to a memory limit exception.

Tests and fixes Infinite loop in ASN1::decode_ber() #1296