### PR TITLE
Whitelist OID 1.3.6.1.4.1.11129.2.4.2

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -907,7 +907,7 @@ class X509
             // https://tools.ietf.org/html/rfc6962
             case '1.3.6.1.4.1.11129.2.4.2':
             // "Qualified Certificate statements"
-            // https://tools.ietf.org/html/draft-ietf-pkix-qc-03
+            // https://tools.ietf.org/html/rfc3739#section-3.2.6
             case '1.3.6.1.5.5.7.1.3':
                 return true;
 

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -906,6 +906,9 @@ class X509
             // "Certificate Transparency"
             // https://tools.ietf.org/html/rfc6962
             case '1.3.6.1.4.1.11129.2.4.2':
+            // "Qualified Certificate statements"
+            // https://tools.ietf.org/html/draft-ietf-pkix-qc-03
+            case '1.3.6.1.5.5.7.1.3':
                 return true;
 
             // CSR attributes


### PR DESCRIPTION
This OID is used in some intermediate certificates from the Dutch government and allows for parsing and saving/validating these certificates with phpseclib.

This is the certificate I encountered: [crt.sh](https://crt.sh/?id=54959165) / [Censys](https://censys.io/certificates/85363a24cb1b66e6cf6244e87d243dbb8306f607357c614cb9c4c224a0e04358)

Happy to add a test for this if needed.

Or if it's possible to disable the validation of the OID's that would also be a great solution. But this patches it for now.