### PR TITLE
Fixed RSA loadKey type hint

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1506,7 +1506,7 @@ class RSA
      *
      * @access public
      * @param string|RSA|array $key
-     * @param bool $type optional
+     * @param bool|int $type optional
      * @return bool
      */
     function loadKey($key, $type = false)


### PR DESCRIPTION
My static analyzer failed due to this type hint. I did notice it was already corrected in the master branch.