### PR TITLE
Call xml_parser_free and unset to avoid memory leaks

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1333,13 +1333,13 @@ class RSA
                 xml_set_character_data_handler($xml, '_data_handler');
                 // add <xml></xml> to account for "dangling" tags like <BitStrength>...</BitStrength> that are sometimes added
                 if (!xml_parse($xml, '<xml>' . $key . '</xml>')) {
-					xml_parser_free($xml);
-					unset($xml);
+                    xml_parser_free($xml);
+                    unset($xml);
                     return false;
                 }
 
-				xml_parser_free($xml);
-				unset($xml);
+                xml_parser_free($xml);
+                unset($xml);
 
                 return isset($this->components['modulus']) && isset($this->components['publicExponent']) ? $this->components : false;
             // from PuTTY's SSHPUBK.C

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1333,8 +1333,13 @@ class RSA
                 xml_set_character_data_handler($xml, '_data_handler');
                 // add <xml></xml> to account for "dangling" tags like <BitStrength>...</BitStrength> that are sometimes added
                 if (!xml_parse($xml, '<xml>' . $key . '</xml>')) {
+					xml_parser_free($xml);
+					unset($xml);
                     return false;
                 }
+
+				xml_parser_free($xml);
+				unset($xml);
 
                 return isset($this->components['modulus']) && isset($this->components['publicExponent']) ? $this->components : false;
             // from PuTTY's SSHPUBK.C


### PR DESCRIPTION
In php7+ it's required to unset the parser after calling xml_parser_free to avoid memory leaks.

I added xml_parser_free and the unset to force proper behavior around the xml parser.

https://secure.php.net/manual/en/function.xml-parser-free.php
https://bugs.php.net/bug.php?id=76874