### PR TITLE
Fix x509 OpenSSL format when multiple OU's are present

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -1900,7 +1900,7 @@ class X509
             }
             $output.= $desc . '=' . $value;
             $result[$desc] = isset($result[$desc]) ?
-                array_merge((array) $dn[$prop], [$value]) :
+                array_merge((array) $result[$desc], [$value]) :
                 $value;
             $start = false;
         }


### PR DESCRIPTION
When formatting DN in OpenSSL format Multiple Organizational Unit Names (OU) in certificates throw `PHP Notice:  Undefined index: id-at-organizationalUnitName` and returned array only contains the last OU.