### PR TITLE
Fix SymmetricKey and cipher class constructor mode types, and mapping execution order

### DIFF
--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -288,17 +288,17 @@ class Blowfish extends BlockCipher
     /**
      * Default Constructor.
      *
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      * @throws \InvalidArgumentException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
+        parent::__construct($mode);
+
         if ($mode == self::MODE_STREAM) {
             throw new \InvalidArgumentException('Block ciphers cannot be ran in stream mode');
         }
-
-        parent::__construct($mode);
     }
 
     /**

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -602,20 +602,22 @@ abstract class SymmetricKey
      *
      * - gcm
      *
-     * @param string $mode
+     * @param string|int $mode
      * @access public
      * @throws BadModeException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
-        $mode = strtolower($mode);
-        // necessary because of 5.6 compatibility; we can't do isset(self::MODE_MAP[$mode]) in 5.6
-        $map = self::MODE_MAP;
-        if (!isset($map[$mode])) {
-            throw new BadModeException('No valid mode has been specified');
-        }
+        if (!is_int($mode) || !in_array($mode, self::MODE_MAP, true)) {
+            $mode = strtolower($mode);
+            // necessary because of 5.6 compatibility; we can't do isset(self::MODE_MAP[$mode]) in 5.6
+            $map = self::MODE_MAP;
+            if (!isset($map[$mode])) {
+                throw new BadModeException('No valid mode has been specified');
+            }
 
-        $mode = self::MODE_MAP[$mode];
+            $mode = self::MODE_MAP[$mode];
+        }
 
         // $mode dependent settings
         switch ($mode) {

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -584,17 +584,17 @@ class DES extends BlockCipher
     /**
      * Default Constructor.
      *
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      * @throws BadModeException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
+        parent::__construct($mode);
+
         if ($mode == self::MODE_STREAM) {
             throw new BadModeException('Block ciphers cannot be ran in stream mode');
         }
-
-        parent::__construct($mode);
     }
 
     /**

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -265,17 +265,17 @@ class RC2 extends BlockCipher
     /**
      * Default Constructor.
      *
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      * @throws \InvalidArgumentException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
+        parent::__construct($mode);
+
         if ($mode == self::MODE_STREAM) {
             throw new BadModeException('Block ciphers cannot be ran in stream mode');
         }
-
-        parent::__construct($mode);
     }
 
     /**

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -168,17 +168,17 @@ class Rijndael extends BlockCipher
     /**
      * Default Constructor.
      *
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      * @throws \InvalidArgumentException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
+        parent::__construct($mode);
+
         if ($mode == self::MODE_STREAM) {
             throw new BadModeException('Block ciphers cannot be ran in stream mode');
         }
-
-        parent::__construct($mode);
     }
 
     /**

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -138,7 +138,7 @@ class TripleDES extends DES
      *
      * @see \phpseclib\Crypt\DES::__construct()
      * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      */
     public function __construct($mode)

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -374,17 +374,17 @@ class Twofish extends BlockCipher
     /**
      * Default Constructor.
      *
-     * @param int $mode
+     * @param int|string $mode
      * @access public
      * @throws BadModeException if an invalid / unsupported mode is provided
      */
     public function __construct($mode)
     {
+        parent::__construct($mode);
+
         if ($mode == self::MODE_STREAM) {
             throw new BadModeException('Block ciphers cannot be ran in stream mode');
         }
-
-        parent::__construct($mode);
     }
 
     /**


### PR DESCRIPTION
Addresses findings brought up in #1396. Ciphers extending the base SymmetricKey class expect integers in their constructor param and checks, but then pass the given value to the inherited constructor that expects string labels. This leads to a case where either the check, or the inherited mapper, can't function.

This PR addresses that by changing the SymmetricKey to accept both strings and the constants themselves, and fixes execution order; the inherited mapper is ran before the validation check so that it will function if a label is given instead of the constant's value.

Fixes #1396