### PR TITLE
ErrorException: fclose() expects parameter 1 to be resource, null given

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3154,7 +3154,10 @@ class SSH2
      */
     function disconnect()
     {
-        $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+        if($this->isConnected()){
+            $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
+        }
+       
         if (isset($this->realtime_log_file) && is_resource($this->realtime_log_file)) {
             fclose($this->realtime_log_file);
         }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3155,7 +3155,6 @@ class SSH2
     function disconnect()
     {
         $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);       
-        
         if (isset($this->realtime_log_file) && is_resource($this->realtime_log_file)) {
             fclose($this->realtime_log_file);
         }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3154,10 +3154,8 @@ class SSH2
      */
     function disconnect()
     {
-        if($this->isConnected()){
-            $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);
-        }
-       
+        $this->_disconnect(NET_SSH2_DISCONNECT_BY_APPLICATION);       
+        
         if (isset($this->realtime_log_file) && is_resource($this->realtime_log_file)) {
             fclose($this->realtime_log_file);
         }
@@ -4122,7 +4120,10 @@ class SSH2
         }
 
         $this->bitmap = 0;
-        fclose($this->fsock);
+
+        if (is_resource($this->fsock) && get_resource_type($this->fsock) == 'stream') {
+            fclose($this->fsock);
+        }
 
         return false;
     }


### PR DESCRIPTION
Trace

/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php:4122
/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php:3167
/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php:3157
/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php:3173

I get this issue by triggering an exception if a private key can not be found, this results this error, i can provide more details if you need.