### PR TITLE
rename phpseclib/phpseclib to phpseclib/phpseclib3 for 3.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
             "phpseclib/bootstrap.php"
         ],
         "psr-4": {
-            "phpseclib\\": "phpseclib/"
+            "phpseclib3\\": "phpseclib/"
         }
     }
 }

--- a/phpseclib/Common/Functions/Strings.php
+++ b/phpseclib/Common/Functions/Strings.php
@@ -13,10 +13,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Common\Functions;
+namespace phpseclib3\Common\Functions;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\Common\FiniteField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField;
 
 /**
  * Common String Functions
@@ -182,7 +182,7 @@ abstract class Strings
                     break;
                 case 'i':
                     if (!$element instanceof BigInteger && !$element instanceof FiniteField\Integer) {
-                        throw new \InvalidArgumentException('A phpseclib\Math\BigInteger or phpseclib\Math\Common\FiniteField\Integer object was expected.');
+                        throw new \InvalidArgumentException('A phpseclib3\Math\BigInteger or phpseclib3\Math\Common\FiniteField\Integer object was expected.');
                     }
                     $element = $element->toBytes(true);
                     $result.= pack('Na*', strlen($element), $element);

--- a/phpseclib/Crypt/AES.php
+++ b/phpseclib/Crypt/AES.php
@@ -16,7 +16,7 @@
  * it'll be null-padded to 192-bits and 192 bits will be the key length until {@link self::setKey() setKey()}
  * is called, again, at which point, it'll be recalculated.
  *
- * Since \phpseclib\Crypt\AES extends \phpseclib\Crypt\Rijndael, some functions are available to be called that, in the context of AES, don't
+ * Since \phpseclib3\Crypt\AES extends \phpseclib3\Crypt\Rijndael, some functions are available to be called that, in the context of AES, don't
  * make a whole lot of sense.  {@link self::setBlockLength() setBlockLength()}, for instance.  Calling that function,
  * however possible, won't do anything (AES has a fixed block length whereas Rijndael has a variable one).
  *
@@ -25,7 +25,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $aes = new \phpseclib\Crypt\AES();
+ *    $aes = new \phpseclib3\Crypt\AES();
  *
  *    $aes->setKey('abcdefghijklmnop');
  *
@@ -47,7 +47,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
 /**
  * Pure-PHP implementation of AES.
@@ -61,9 +61,9 @@ class AES extends Rijndael
     /**
      * Dummy function
      *
-     * Since \phpseclib\Crypt\AES extends \phpseclib\Crypt\Rijndael, this function is, technically, available, but it doesn't do anything.
+     * Since \phpseclib3\Crypt\AES extends \phpseclib3\Crypt\Rijndael, this function is, technically, available, but it doesn't do anything.
      *
-     * @see \phpseclib\Crypt\Rijndael::setBlockLength()
+     * @see \phpseclib3\Crypt\Rijndael::setBlockLength()
      * @access public
      * @param int $length
      * @throws \BadMethodCallException anytime it's called
@@ -78,7 +78,7 @@ class AES extends Rijndael
      *
      * Valid key lengths are 128, 192, and 256.  Set the link to bool(false) to disable a fixed key length
      *
-     * @see \phpseclib\Crypt\Rijndael:setKeyLength()
+     * @see \phpseclib3\Crypt\Rijndael:setKeyLength()
      * @access public
      * @param int $length
      * @throws \LengthException if the key length isn't supported
@@ -101,7 +101,7 @@ class AES extends Rijndael
      *
      * Rijndael supports five different key lengths, AES only supports three.
      *
-     * @see \phpseclib\Crypt\Rijndael:setKey()
+     * @see \phpseclib3\Crypt\Rijndael:setKey()
      * @see setKeyLength()
      * @access public
      * @param string $key

--- a/phpseclib/Crypt/Blowfish.php
+++ b/phpseclib/Crypt/Blowfish.php
@@ -16,7 +16,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $blowfish = new \phpseclib\Crypt\Blowfish();
+ *    $blowfish = new \phpseclib3\Crypt\Blowfish();
  *
  *    $blowfish->setKey('12345678901234567890123456789012');
  *
@@ -35,9 +35,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 /**
  * Pure-PHP implementation of Blowfish.
@@ -52,7 +52,7 @@ class Blowfish extends BlockCipher
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -61,7 +61,7 @@ class Blowfish extends BlockCipher
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -70,7 +70,7 @@ class Blowfish extends BlockCipher
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -275,7 +275,7 @@ class Blowfish extends BlockCipher
     /**
      * The Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setKeyLength()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setKeyLength()
      * @var int
      * @access private
      * @internal The max value is 256 / 8 = 32, the min value is 128 / 8 = 16.  Exists in conjunction with $Nk
@@ -323,9 +323,9 @@ class Blowfish extends BlockCipher
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      * @param int $engine
      * @access protected
      * @return bool
@@ -349,7 +349,7 @@ class Blowfish extends BlockCipher
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     protected function setupKey()
@@ -472,7 +472,7 @@ class Blowfish extends BlockCipher
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     protected function setupInlineCrypt()

--- a/phpseclib/Crypt/ChaCha20.php
+++ b/phpseclib/Crypt/ChaCha20.php
@@ -13,11 +13,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\StreamCipher;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Exception\BadDecryptionException;
+use phpseclib3\Crypt\Common\StreamCipher;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\BadDecryptionException;
 
 /**
  * Pure-PHP implementation of ChaCha20.
@@ -38,9 +38,9 @@ class ChaCha20 extends Salsa20
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access protected
      * @return bool
@@ -79,7 +79,7 @@ class ChaCha20 extends Salsa20
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @see self::crypt()
      * @param string $plaintext
      * @return string $ciphertext
@@ -101,7 +101,7 @@ class ChaCha20 extends Salsa20
      * $this->decrypt($this->encrypt($plaintext)) == $this->encrypt($this->encrypt($plaintext)).
      * At least if the continuous buffer is disabled.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @see self::crypt()
      * @param string $ciphertext
      * @return string $plaintext

--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -13,15 +13,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
-use phpseclib\Exception\UnsupportedFormatException;
-use phpseclib\Exception\NoKeyLoadedException;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\ECDSA;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\ECDSA;
 
 /**
  * Base Class for all stream cipher classes
@@ -34,7 +34,7 @@ abstract class AsymmetricKey
     /**
      * Precomputed Zero
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected static $zero;
@@ -42,7 +42,7 @@ abstract class AsymmetricKey
     /**
      * Precomputed One
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected static $one;
@@ -58,7 +58,7 @@ abstract class AsymmetricKey
     /**
      * Hash function
      *
-     * @var \phpseclib\Crypt\Hash
+     * @var \phpseclib3\Crypt\Hash
      * @access private
      */
     protected $hash;
@@ -66,7 +66,7 @@ abstract class AsymmetricKey
     /**
      * HMAC function
      *
-     * @var \phpseclib\Crypt\Hash
+     * @var \phpseclib3\Crypt\Hash
      * @access private
      */
     private $hmac;
@@ -249,7 +249,7 @@ abstract class AsymmetricKey
                     continue;
                 }
                 $name = $file->getBasename('.php');
-                $type = 'phpseclib\Crypt\\' . static::ALGORITHM . '\\Formats\\' . $format . '\\' . $name;
+                $type = 'phpseclib3\Crypt\\' . static::ALGORITHM . '\\Formats\\' . $format . '\\' . $name;
                 $reflect = new \ReflectionClass($type);
                 if ($reflect->isTrait()) {
                     continue;
@@ -440,7 +440,7 @@ abstract class AsymmetricKey
      * Integer to Octet String
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $v
+     * @param \phpseclib3\Math\BigInteger $v
      * @return string
      */
     private function int2octets($v)
@@ -461,7 +461,7 @@ abstract class AsymmetricKey
      *
      * @access private
      * @param string $in
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     protected function bits2int($in)
     {

--- a/phpseclib/Crypt/Common/BlockCipher.php
+++ b/phpseclib/Crypt/Common/BlockCipher.php
@@ -14,7 +14,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
 /**
  * Base Class for all block cipher classes

--- a/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
@@ -15,11 +15,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Keys;
+namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Random;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Random;
 
 /**
  * OpenSSH Formatted RSA Key Handler

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Keys;
+namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 /**
  * PKCS1 Formatted Key Handler

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
@@ -13,16 +13,16 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Keys;
+namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\DES;
-use phpseclib\Crypt\TripleDES;
-use phpseclib\File\ASN1;
-use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\DES;
+use phpseclib3\Crypt\TripleDES;
+use phpseclib3\File\ASN1;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**
  * PKCS1 Formatted Key Handler

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
@@ -25,19 +25,19 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Keys;
+namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Crypt\DES;
-use phpseclib\Crypt\RC2;
-use phpseclib\Crypt\RC4;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\TripleDES;
-use phpseclib\Crypt\Random;
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
-use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Crypt\DES;
+use phpseclib3\Crypt\RC2;
+use phpseclib3\Crypt\RC4;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\TripleDES;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**
  * PKCS#8 Formatted Key Handler
@@ -139,7 +139,7 @@ abstract class PKCS8 extends PKCS
     /**
      * Returns a SymmetricKey object based on a PBES1 $algo
      *
-     * @return \phpseclib\Crypt\Common\SymmetricKey
+     * @return \phpseclib3\Crypt\Common\SymmetricKey
      * @access public
      * @param string $algo
      */

--- a/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
@@ -13,15 +13,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Keys;
+namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**
  * PuTTY Formatted Key Handler

--- a/phpseclib/Crypt/Common/Formats/Signature/Raw.php
+++ b/phpseclib/Crypt/Common/Formats/Signature/Raw.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Formats\Signature;
+namespace phpseclib3\Crypt\Common\Formats\Signature;
 
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Raw Signature Handler
@@ -55,8 +55,8 @@ abstract class Raw
      * Returns a signature in the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $r
-     * @param \phpseclib\Math\BigInteger $s
+     * @param \phpseclib3\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $s
      * @return string
      */
     public static function save(BigInteger $r, BigInteger $s)

--- a/phpseclib/Crypt/Common/PrivateKey.php
+++ b/phpseclib/Crypt/Common/PrivateKey.php
@@ -11,7 +11,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
 /**
  * PrivateKey interface

--- a/phpseclib/Crypt/Common/PublicKey.php
+++ b/phpseclib/Crypt/Common/PublicKey.php
@@ -11,7 +11,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
 /**
  * PublicKey interface

--- a/phpseclib/Crypt/Common/StreamCipher.php
+++ b/phpseclib/Crypt/Common/StreamCipher.php
@@ -14,7 +14,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
 /**
  * Base Class for all stream cipher classes

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * Base Class for all \phpseclib\Crypt\* cipher classes
+ * Base Class for all \phpseclib3\Crypt\* cipher classes
  *
  * PHP version 5
  *
  * Internally for phpseclib developers:
  *  If you plan to add a new cipher class, please note following rules:
  *
- *  - The new \phpseclib\Crypt\* cipher class should extend \phpseclib\Crypt\Common\SymmetricKey
+ *  - The new \phpseclib3\Crypt\* cipher class should extend \phpseclib3\Crypt\Common\SymmetricKey
  *
  *  - Following methods are then required to be overridden/overloaded:
  *
@@ -20,7 +20,7 @@
  *
  *  - All other methods are optional to be overridden/overloaded
  *
- *  - Look at the source code of the current ciphers how they extend \phpseclib\Crypt\Common\SymmetricKey
+ *  - Look at the source code of the current ciphers how they extend \phpseclib3\Crypt\Common\SymmetricKey
  *    and take one of them as a start up for the new cipher class.
  *
  *  - Please read all the other comments/notes/hints here also for each class var/method
@@ -34,21 +34,21 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common;
+namespace phpseclib3\Crypt\Common;
 
-use phpseclib\Crypt\Hash;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\BinaryField;
-use phpseclib\Math\PrimeField;
-use phpseclib\Exception\BadDecryptionException;
-use phpseclib\Exception\BadModeException;
-use phpseclib\Exception\InconsistentSetupException;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BinaryField;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\Exception\BadDecryptionException;
+use phpseclib3\Exception\BadModeException;
+use phpseclib3\Exception\InconsistentSetupException;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**
- * Base Class for all \phpseclib\Crypt\* cipher classes
+ * Base Class for all \phpseclib3\Crypt\* cipher classes
  *
  * @package Base
  * @author  Jim Wigginton <terrafrost@php.net>
@@ -58,8 +58,8 @@ abstract class SymmetricKey
 {
     /**#@+
      * @access public
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      */
     /**
      * Encrypt / decrypt using the Counter mode.
@@ -113,7 +113,7 @@ abstract class SymmetricKey
      * Mode Map
      *
      * @access private
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      */
     const MODE_MAP = [
         'ctr'    => self::MODE_CTR,
@@ -128,7 +128,7 @@ abstract class SymmetricKey
 
     /**#@+
      * @access private
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      */
     /**
      * Base value for the internal implementation $engine switch
@@ -160,7 +160,7 @@ abstract class SymmetricKey
      * Engine Reverse Map
      *
      * @access private
-     * @see \phpseclib\Crypt\Common\SymmetricKey::getEngine()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::getEngine()
      */
     const ENGINE_MAP = [
         self::ENGINE_INTERNAL    => 'PHP',
@@ -282,8 +282,8 @@ abstract class SymmetricKey
     /**
      * Does the enmcrypt resource need to be (re)initialized?
      *
-     * @see \phpseclib\Crypt\Twofish::setKey()
-     * @see \phpseclib\Crypt\Twofish::setIV()
+     * @see \phpseclib3\Crypt\Twofish::setKey()
+     * @see \phpseclib3\Crypt\Twofish::setIV()
      * @var bool
      * @access private
      */
@@ -292,8 +292,8 @@ abstract class SymmetricKey
     /**
      * Does the demcrypt resource need to be (re)initialized?
      *
-     * @see \phpseclib\Crypt\Twofish::setKey()
-     * @see \phpseclib\Crypt\Twofish::setIV()
+     * @see \phpseclib3\Crypt\Twofish::setKey()
+     * @see \phpseclib3\Crypt\Twofish::setIV()
      * @var bool
      * @access private
      */
@@ -1028,7 +1028,7 @@ abstract class SymmetricKey
      * @see self::setPassword()
      * @access private
      * @param int $n
-     * @param \phpseclib\Crypt\Hash $hashObj
+     * @param \phpseclib3\Crypt\Hash $hashObj
      * @param string $i
      * @param string $d
      * @param int $count
@@ -2068,7 +2068,7 @@ abstract class SymmetricKey
      * outputs.  The reason is due to the fact that the initialization vector's change after every encryption /
      * decryption round when the continuous buffer is enabled.  When it's disabled, they remain constant.
      *
-     * Put another way, when the continuous buffer is enabled, the state of the \phpseclib\Crypt\*() object changes after each
+     * Put another way, when the continuous buffer is enabled, the state of the \phpseclib3\Crypt\*() object changes after each
      * encryption / decryption round, whereas otherwise, it'd remain constant.  For this reason, it's recommended that
      * continuous buffers not be used.  They do offer better security and are, in fact, sometimes required (SSH uses them),
      * however, they are also less intuitive and more likely to cause you problems.
@@ -2283,7 +2283,7 @@ abstract class SymmetricKey
     /**
      * Encrypts a block
      *
-     * Note: Must be extended by the child \phpseclib\Crypt\* class
+     * Note: Must be extended by the child \phpseclib3\Crypt\* class
      *
      * @access private
      * @param string $in
@@ -2294,7 +2294,7 @@ abstract class SymmetricKey
     /**
      * Decrypts a block
      *
-     * Note: Must be extended by the child \phpseclib\Crypt\* class
+     * Note: Must be extended by the child \phpseclib3\Crypt\* class
      *
      * @access private
      * @param string $in
@@ -2307,7 +2307,7 @@ abstract class SymmetricKey
      *
      * Only used if $engine == self::ENGINE_INTERNAL
      *
-     * Note: Must extend by the child \phpseclib\Crypt\* class
+     * Note: Must extend by the child \phpseclib3\Crypt\* class
      *
      * @see self::setup()
      * @access private
@@ -2522,7 +2522,7 @@ abstract class SymmetricKey
      *       - short (as good as possible)
      *
      * Note: - _setupInlineCrypt() is using _createInlineCryptFunction() to create the full callback function code.
-     *       - In case of using inline crypting, _setupInlineCrypt() must extend by the child \phpseclib\Crypt\* class.
+     *       - In case of using inline crypting, _setupInlineCrypt() must extend by the child \phpseclib3\Crypt\* class.
      *       - The following variable names are reserved:
      *         - $_*  (all variable names prefixed with an underscore)
      *         - $self (object reference to it self. Do not use $this, but $self instead)
@@ -2629,7 +2629,7 @@ abstract class SymmetricKey
      *    +----------------------------------------------------------------------------------------------+
      *    </code>
      *
-     *    See also the \phpseclib\Crypt\*::_setupInlineCrypt()'s for
+     *    See also the \phpseclib3\Crypt\*::_setupInlineCrypt()'s for
      *    productive inline $cipher_code's how they works.
      *
      *    Structure of:
@@ -2706,10 +2706,10 @@ abstract class SymmetricKey
                             if (strlen($_block) > strlen($_buffer["ciphertext"])) {
                                 $in = $_xor;
                                 '.$encrypt_block.'
-                                \phpseclib\Common\Functions\Strings::increment_str($_xor);
+                                \phpseclib3\Common\Functions\Strings::increment_str($_xor);
                                 $_buffer["ciphertext"].= $in;
                             }
-                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
+                            $_key = \phpseclib3\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
                             $_ciphertext.= $_block ^ $_key;
                         }
                     } else {
@@ -2717,7 +2717,7 @@ abstract class SymmetricKey
                             $_block = substr($_text, $_i, '.$block_size.');
                             $in = $_xor;
                             '.$encrypt_block.'
-                            \phpseclib\Common\Functions\Strings::increment_str($_xor);
+                            \phpseclib3\Common\Functions\Strings::increment_str($_xor);
                             $_key = $in;
                             $_ciphertext.= $_block ^ $_key;
                         }
@@ -2744,10 +2744,10 @@ abstract class SymmetricKey
                             if (strlen($_block) > strlen($_buffer["ciphertext"])) {
                                 $in = $_xor;
                                 '.$encrypt_block.'
-                                \phpseclib\Common\Functions\Strings::increment_str($_xor);
+                                \phpseclib3\Common\Functions\Strings::increment_str($_xor);
                                 $_buffer["ciphertext"].= $in;
                             }
-                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
+                            $_key = \phpseclib3\Common\Functions\Strings::shift($_buffer["ciphertext"], '.$block_size.');
                             $_plaintext.= $_block ^ $_key;
                         }
                     } else {
@@ -2755,7 +2755,7 @@ abstract class SymmetricKey
                             $_block = substr($_text, $_i, '.$block_size.');
                             $in = $_xor;
                             '.$encrypt_block.'
-                            \phpseclib\Common\Functions\Strings::increment_str($_xor);
+                            \phpseclib3\Common\Functions\Strings::increment_str($_xor);
                             $_key = $in;
                             $_plaintext.= $_block ^ $_key;
                         }
@@ -2931,7 +2931,7 @@ abstract class SymmetricKey
                                 $_xor = $in;
                                 $_buffer["xor"].= $_xor;
                             }
-                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
+                            $_key = \phpseclib3\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
                             $_ciphertext.= $_block ^ $_key;
                         }
                     } else {
@@ -2967,7 +2967,7 @@ abstract class SymmetricKey
                                 $_xor = $in;
                                 $_buffer["xor"].= $_xor;
                             }
-                            $_key = \phpseclib\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
+                            $_key = \phpseclib3\Common\Functions\Strings::shift($_buffer["xor"], '.$block_size.');
                             $_plaintext.= $_block ^ $_key;
                         }
                     } else {

--- a/phpseclib/Crypt/Common/Traits/Fingerprint.php
+++ b/phpseclib/Crypt/Common/Traits/Fingerprint.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Traits;
+namespace phpseclib3\Crypt\Common\Traits;
 
-use phpseclib\Crypt\Hash;
+use phpseclib3\Crypt\Hash;
 
 /**
  * Fingerprint Trait for Private Keys

--- a/phpseclib/Crypt/Common/Traits/PasswordProtected.php
+++ b/phpseclib/Crypt/Common/Traits/PasswordProtected.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\Common\Traits;
+namespace phpseclib3\Crypt\Common\Traits;
 
 /**
  * Password Protected Trait for Private Keys

--- a/phpseclib/Crypt/DES.php
+++ b/phpseclib/Crypt/DES.php
@@ -18,7 +18,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $des = new \phpseclib\Crypt\DES();
+ *    $des = new \phpseclib3\Crypt\DES();
  *
  *    $des->setKey('abcdefgh');
  *
@@ -40,10 +40,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\BlockCipher;
-use phpseclib\Exception\BadModeException;
+use phpseclib3\Crypt\Common\BlockCipher;
+use phpseclib3\Exception\BadModeException;
 
 /**
  * Pure-PHP implementation of DES.
@@ -56,8 +56,8 @@ class DES extends BlockCipher
 {
     /**#@+
      * @access private
-     * @see \phpseclib\Crypt\DES::setupKey()
-     * @see \phpseclib\Crypt\DES::processBlock()
+     * @see \phpseclib3\Crypt\DES::setupKey()
+     * @see \phpseclib3\Crypt\DES::processBlock()
      */
     /**
      * Contains $keys[self::ENCRYPT]
@@ -72,7 +72,7 @@ class DES extends BlockCipher
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -81,7 +81,7 @@ class DES extends BlockCipher
     /**
      * Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setKeyLength()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setKeyLength()
      * @var int
      * @access private
      */
@@ -90,7 +90,7 @@ class DES extends BlockCipher
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -99,7 +99,7 @@ class DES extends BlockCipher
     /**
      * The OpenSSL names of the cipher / modes
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::openssl_mode_names
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::openssl_mode_names
      * @var array
      * @access private
      */
@@ -114,7 +114,7 @@ class DES extends BlockCipher
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -600,9 +600,9 @@ class DES extends BlockCipher
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      * @param int $engine
      * @access protected
      * @return bool
@@ -626,7 +626,7 @@ class DES extends BlockCipher
      *
      * DES also requires that every eighth bit be a parity bit, however, we'll ignore that.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setKey()
      * @access public
      * @param string $key
      */
@@ -643,8 +643,8 @@ class DES extends BlockCipher
     /**
      * Encrypts a block
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encryptBlock()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encryptBlock()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @see self::encrypt()
      * @access private
      * @param string $in
@@ -658,8 +658,8 @@ class DES extends BlockCipher
     /**
      * Decrypts a block
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decryptBlock()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decryptBlock()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @see self::decrypt()
      * @access private
      * @param string $in
@@ -762,7 +762,7 @@ class DES extends BlockCipher
     /**
      * Creates the key schedule
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupKey()
      * @access private
      */
     protected function setupKey()
@@ -1297,7 +1297,7 @@ class DES extends BlockCipher
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupInlineCrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupInlineCrypt()
      * @access private
      */
     protected function setupInlineCrypt()

--- a/phpseclib/Crypt/DH.php
+++ b/phpseclib/Crypt/DH.php
@@ -10,7 +10,7 @@
  * <?php
  * include 'vendor/autoload.php';
  *
- * $ourPrivate = \phpseclib\Crypt\DH::createKey();
+ * $ourPrivate = \phpseclib3\Crypt\DH::createKey();
  * $secret = DH::computeSecret($ourPrivate, $theirPublic);
  *
  * ?>
@@ -24,15 +24,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Exception\NoKeyLoadedException;
-use phpseclib\Exception\UnsupportedOperationException;
-use phpseclib\Crypt\Common\AsymmetricKey;
-use phpseclib\Crypt\DH\PrivateKey;
-use phpseclib\Crypt\DH\PublicKey;
-use phpseclib\Crypt\DH\Parameters;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedOperationException;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\DH\PrivateKey;
+use phpseclib3\Crypt\DH\PublicKey;
+use phpseclib3\Crypt\DH\Parameters;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Pure-PHP (EC)DH implementation
@@ -54,7 +54,7 @@ abstract class DH extends AsymmetricKey
     /**
      * DH prime
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $prime;
@@ -64,7 +64,7 @@ abstract class DH extends AsymmetricKey
      *
      * Prime divisor of p-1
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $base;
@@ -78,7 +78,7 @@ abstract class DH extends AsymmetricKey
      *  - a string (eg. diffie-hellman-group14-sha1)
      *
      * @access public
-     * @return \phpseclib\Crypt\DH|bool
+     * @return \phpseclib3\Crypt\DH|bool
      */
     public static function createParameters(...$args)
     {

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
@@ -21,12 +21,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DH\Formats\Keys;
+namespace phpseclib3\Crypt\DH\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * "PKCS1" Formatted DH Key Handler

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
@@ -19,12 +19,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DH\Formats\Keys;
+namespace phpseclib3\Crypt\DH\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * PKCS#8 Formatted DH Key Handler
@@ -112,10 +112,10 @@ abstract class PKCS8 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $prime
-     * @param \phpseclib\Math\BigInteger $base
-     * @param \phpseclib\Math\BigInteger $privateKey
-     * @param \phpseclib\Math\BigInteger $publicKey
+     * @param \phpseclib3\Math\BigInteger $prime
+     * @param \phpseclib3\Math\BigInteger $base
+     * @param \phpseclib3\Math\BigInteger $privateKey
+     * @param \phpseclib3\Math\BigInteger $publicKey
      * @param string $password optional
      * @param array $options optional
      * @return string
@@ -136,9 +136,9 @@ abstract class PKCS8 extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $prime
-     * @param \phpseclib\Math\BigInteger $base
-     * @param \phpseclib\Math\BigInteger $publicKey
+     * @param \phpseclib3\Math\BigInteger $prime
+     * @param \phpseclib3\Math\BigInteger $base
+     * @param \phpseclib3\Math\BigInteger $publicKey
      * @param array $options optional
      * @return string
      */

--- a/phpseclib/Crypt/DH/Parameters.php
+++ b/phpseclib/Crypt/DH/Parameters.php
@@ -11,9 +11,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DH;
+namespace phpseclib3\Crypt\DH;
 
-use phpseclib\Crypt\DH;
+use phpseclib3\Crypt\DH;
 
 /**
  * DH Parameters

--- a/phpseclib/Crypt/DH/PrivateKey.php
+++ b/phpseclib/Crypt/DH/PrivateKey.php
@@ -11,10 +11,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DH;
+namespace phpseclib3\Crypt\DH;
 
-use phpseclib\Crypt\DH;
-use phpseclib\Crypt\Common;
+use phpseclib3\Crypt\DH;
+use phpseclib3\Crypt\Common;
 
 /**
  * DH Private Key
@@ -30,7 +30,7 @@ class PrivateKey extends DH
     /**
      * Private Key
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $privateKey;
@@ -38,7 +38,7 @@ class PrivateKey extends DH
     /**
      * Public Key
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $publicKey;

--- a/phpseclib/Crypt/DH/PublicKey.php
+++ b/phpseclib/Crypt/DH/PublicKey.php
@@ -11,10 +11,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DH;
+namespace phpseclib3\Crypt\DH;
 
-use phpseclib\Crypt\DH;
-use phpseclib\Crypt\Common;
+use phpseclib3\Crypt\DH;
+use phpseclib3\Crypt\Common;
 
 /**
  * DH Public Key
@@ -44,7 +44,7 @@ class PublicKey extends DH
     /**
      * Returns the public key as a BigInteger
      *
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     public function toBigInteger()
     {

--- a/phpseclib/Crypt/DSA.php
+++ b/phpseclib/Crypt/DSA.php
@@ -10,7 +10,7 @@
  * <?php
  * include 'vendor/autoload.php';
  *
- * $private = \phpseclib\Crypt\DSA::createKey();
+ * $private = \phpseclib3\Crypt\DSA::createKey();
  * $public = $private->getPublicKey();
  *
  * $plaintext = 'terrafrost';
@@ -29,14 +29,14 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\AsymmetricKey;
-use phpseclib\Crypt\DSA\PrivateKey;
-use phpseclib\Crypt\DSA\PublicKey;
-use phpseclib\Crypt\DSA\Parameters;
-use phpseclib\Math\BigInteger;
-use phpseclib\Exception\InsufficientSetupException;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\DSA\PrivateKey;
+use phpseclib3\Crypt\DSA\PublicKey;
+use phpseclib3\Crypt\DSA\Parameters;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Exception\InsufficientSetupException;
 
 /**
  * Pure-PHP FIPS 186-4 compliant implementation of DSA.
@@ -58,7 +58,7 @@ abstract class DSA extends AsymmetricKey
     /**
      * DSA Prime P
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $p;
@@ -68,7 +68,7 @@ abstract class DSA extends AsymmetricKey
      *
      * Prime divisor of p-1
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $q;
@@ -76,7 +76,7 @@ abstract class DSA extends AsymmetricKey
     /**
      * DSA Group Generator G
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $g;
@@ -84,7 +84,7 @@ abstract class DSA extends AsymmetricKey
     /**
      * DSA public key value y
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $y;
@@ -111,7 +111,7 @@ abstract class DSA extends AsymmetricKey
      * @access public
      * @param int $L
      * @param int $N
-     * @return \phpseclib\Crypt\DSA|bool
+     * @return \phpseclib3\Crypt\DSA|bool
      */
     public static function createParameters($L = 2048, $N = 224)
     {

--- a/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
@@ -15,12 +15,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
 
 /**
  * OpenSSH Formatted DSA Key Handler
@@ -72,10 +72,10 @@ abstract class OpenSSH extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @param array $options optional
      * @return string
      */
@@ -107,11 +107,11 @@ abstract class OpenSSH extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $x
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $y
      * @param string $password optional
      * @param array $options optional
      * @return string

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
@@ -27,12 +27,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 use ParagonIE\ConstantTime\Base64;
 
 /**
@@ -83,9 +83,9 @@ abstract class PKCS1 extends Progenitor
      * Convert DSA parameters to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
      * @return string
      */
     public static function saveParameters(BigInteger $p, BigInteger $q, BigInteger $g)
@@ -107,11 +107,11 @@ abstract class PKCS1 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $x
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $y
      * @param string $password optional
      * @param array $options optional
      * @return string
@@ -136,10 +136,10 @@ abstract class PKCS1 extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @return string
      */
     public static function savePublicKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y)

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
@@ -23,12 +23,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * PKCS#8 Formatted DSA Key Handler
@@ -121,11 +121,11 @@ abstract class PKCS8 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $x
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $y
      * @param string $password optional
      * @param array $options optional
      * @return string
@@ -147,10 +147,10 @@ abstract class PKCS8 extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @param array $options optional
      * @return string
      */

--- a/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
@@ -18,11 +18,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
 
 /**
  * PuTTY Formatted DSA Key Handler
@@ -39,7 +39,7 @@ abstract class PuTTY extends Progenitor
      * @var string
      * @access private
      */
-    const PUBLIC_HANDLER = 'phpseclib\Crypt\DSA\Formats\Keys\OpenSSH';
+    const PUBLIC_HANDLER = 'phpseclib3\Crypt\DSA\Formats\Keys\OpenSSH';
 
     /**
      * Algorithm Identifier
@@ -76,11 +76,11 @@ abstract class PuTTY extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
-     * @param \phpseclib\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $x
      * @param string $password optional
      * @param array $options optional
      * @return string
@@ -101,10 +101,10 @@ abstract class PuTTY extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @return string
      */
     public static function savePublicKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y)

--- a/phpseclib/Crypt/DSA/Formats/Keys/Raw.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/Raw.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Raw DSA Key Handler
@@ -62,11 +62,11 @@ abstract class Raw
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
-     * @param \phpseclib\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $x
      * @param string $password optional
      * @return string
      */
@@ -79,10 +79,10 @@ abstract class Raw
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @return string
      */
     public static function savePublicKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y)

--- a/phpseclib/Crypt/DSA/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/XML.php
@@ -19,10 +19,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Keys;
+namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 /**
  * XML Formatted DSA Key Handler
@@ -114,10 +114,10 @@ abstract class XML
      * See https://www.w3.org/TR/xmldsig-core/#sec-DSAKeyValue
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $p
-     * @param \phpseclib\Math\BigInteger $q
-     * @param \phpseclib\Math\BigInteger $g
-     * @param \phpseclib\Math\BigInteger $y
+     * @param \phpseclib3\Math\BigInteger $p
+     * @param \phpseclib3\Math\BigInteger $q
+     * @param \phpseclib3\Math\BigInteger $g
+     * @param \phpseclib3\Math\BigInteger $y
      * @return string
      */
     public static function savePublicKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y)

--- a/phpseclib/Crypt/DSA/Formats/Signature/ASN1.php
+++ b/phpseclib/Crypt/DSA/Formats/Signature/ASN1.php
@@ -16,11 +16,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Signature;
+namespace phpseclib3\Crypt\DSA\Formats\Signature;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1 as Encoder;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1 as Encoder;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * ASN1 Signature Handler
@@ -57,8 +57,8 @@ abstract class ASN1
      * Returns a signature in the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $r
-     * @param \phpseclib\Math\BigInteger $s
+     * @param \phpseclib3\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $s
      * @return string
      */
     public static function save(BigInteger $r, BigInteger $s)

--- a/phpseclib/Crypt/DSA/Formats/Signature/Raw.php
+++ b/phpseclib/Crypt/DSA/Formats/Signature/Raw.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Signature;
+namespace phpseclib3\Crypt\DSA\Formats\Signature;
 
-use phpseclib\Crypt\Common\Formats\Signature\Raw as Progenitor;
+use phpseclib3\Crypt\Common\Formats\Signature\Raw as Progenitor;
 
 /**
  * Raw DSA Signature Handler

--- a/phpseclib/Crypt/DSA/Formats/Signature/SSH2.php
+++ b/phpseclib/Crypt/DSA/Formats/Signature/SSH2.php
@@ -15,10 +15,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA\Formats\Signature;
+namespace phpseclib3\Crypt\DSA\Formats\Signature;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * SSH2 Signature Handler
@@ -61,8 +61,8 @@ abstract class SSH2
      * Returns a signature in the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $r
-     * @param \phpseclib\Math\BigInteger $s
+     * @param \phpseclib3\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $s
      * @return string
      */
     public static function save(BigInteger $r, BigInteger $s)

--- a/phpseclib/Crypt/DSA/Parameters.php
+++ b/phpseclib/Crypt/DSA/Parameters.php
@@ -11,9 +11,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA;
+namespace phpseclib3\Crypt\DSA;
 
-use phpseclib\Crypt\DSA;
+use phpseclib3\Crypt\DSA;
 
 /**
  * DSA Parameters

--- a/phpseclib/Crypt/DSA/PrivateKey.php
+++ b/phpseclib/Crypt/DSA/PrivateKey.php
@@ -11,12 +11,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA;
+namespace phpseclib3\Crypt\DSA;
 
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common;
 
 /**
  * DSA Private Key
@@ -32,7 +32,7 @@ class PrivateKey extends DSA implements Common\PrivateKey
     /**
      * DSA secret exponent x
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $x;

--- a/phpseclib/Crypt/DSA/PublicKey.php
+++ b/phpseclib/Crypt/DSA/PublicKey.php
@@ -11,11 +11,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\DSA;
+namespace phpseclib3\Crypt\DSA;
 
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib\Crypt\Common;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Crypt\Common;
 
 /**
  * DSA Public Key

--- a/phpseclib/Crypt/EC.php
+++ b/phpseclib/Crypt/EC.php
@@ -10,7 +10,7 @@
  * <?php
  * include 'vendor/autoload.php';
  *
- * $private = \phpseclib\Crypt\EC::createKey('secp256k1');
+ * $private = \phpseclib3\Crypt\EC::createKey('secp256k1');
  * $public = $private->getPublicKey();
  *
  * $plaintext = 'terrafrost';
@@ -29,24 +29,24 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\AsymmetricKey;
-use phpseclib\Crypt\EC\PrivateKey;
-use phpseclib\Crypt\EC\PublicKey;
-use phpseclib\Crypt\EC\Parameters;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Crypt\EC\Curves\Curve25519;
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Crypt\EC\Curves\Ed448;
-use phpseclib\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib\File\ASN1\Maps\ECParameters;
-use phpseclib\File\ASN1;
-use phpseclib\Math\BigInteger;
-use phpseclib\Exception\UnsupportedCurveException;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\Exception\UnsupportedOperationException;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\EC\PrivateKey;
+use phpseclib3\Crypt\EC\PublicKey;
+use phpseclib3\Crypt\EC\Parameters;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
+use phpseclib3\File\ASN1\Maps\ECParameters;
+use phpseclib3\File\ASN1;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\UnsupportedOperationException;
 
 /**
  * Pure-PHP implementation of EC.
@@ -75,7 +75,7 @@ abstract class EC extends AsymmetricKey
     /**
      * Curve
      *
-     * @var \phpseclib\Crypt\EC\BaseCurves\Base
+     * @var \phpseclib3\Crypt\EC\BaseCurves\Base
      */
     protected $curve;
 
@@ -107,7 +107,7 @@ abstract class EC extends AsymmetricKey
      *
      * Used for deterministic ECDSA
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      */
     protected $q;
 
@@ -119,7 +119,7 @@ abstract class EC extends AsymmetricKey
      * public key. But the x is different depending on which side of the equal sign
      * you're on. It's less ambiguous if you do dA * base point = (x, y)-coordinate.
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      */
     protected $x;
 
@@ -135,7 +135,7 @@ abstract class EC extends AsymmetricKey
      *
      * @access public
      * @param string $curve
-     * @return \phpseclib\Crypt\EC\PrivateKey
+     * @return \phpseclib3\Crypt\EC\PrivateKey
      */
     public static function createKey($curve)
     {
@@ -161,10 +161,10 @@ abstract class EC extends AsymmetricKey
         $privatekey = new PrivateKey;
 
         $curveName = $curve;
-        $curve = '\phpseclib\Crypt\EC\Curves\\' . $curveName;
+        $curve = '\phpseclib3\Crypt\EC\Curves\\' . $curveName;
         if (!class_exists($curve)) {
             $curveName = ucfirst($curveName);
-            $curve = '\phpseclib\Crypt\EC\Curves\\' . $curveName;
+            $curve = '\phpseclib3\Crypt\EC\Curves\\' . $curveName;
             if (!class_exists($curve)) {
                 throw new UnsupportedCurveException('Named Curve of ' . $curveName . ' is not supported');
             }

--- a/phpseclib/Crypt/EC/BaseCurves/Base.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Base.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Math\Common\FiniteField;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Base
@@ -51,7 +51,7 @@ abstract class Base
     /**
      * Finite Field Integer factory
      *
-     * @var \phpseclib\Math\FiniteField\Integer
+     * @var \phpseclib3\Math\FiniteField\Integer
      */
     protected $factory;
 
@@ -149,7 +149,7 @@ abstract class Base
     /**
      * Returns the Order
      *
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     public function getOrder()
     {

--- a/phpseclib/Crypt/EC/BaseCurves/Binary.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Binary.php
@@ -21,12 +21,12 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\BinaryField;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\BinaryField\Integer as BinaryInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BinaryField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BinaryField\Integer as BinaryInteger;
 
 /**
  * Curves over y^2 + x*y = x^3 + a*x^2 + b
@@ -40,7 +40,7 @@ class Binary extends Base
     /**
      * Binary Field Integer factory
      *
-     * @var \phpseclib\Math\BinaryFields
+     * @var \phpseclib3\Math\BinaryFields
      */
     protected $factory;
 
@@ -310,7 +310,7 @@ class Binary extends Base
     /**
      * Returns the modulo
      *
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     public function getModulo()
     {
@@ -320,7 +320,7 @@ class Binary extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getA()
     {
@@ -330,7 +330,7 @@ class Binary extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getB()
     {
@@ -344,7 +344,7 @@ class Binary extends Base
      * To convert a Jacobian Coordinate to an Affine Point
      * you do (x / z^2, y / z^3)
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToAffine(array $p)
     {
@@ -363,7 +363,7 @@ class Binary extends Base
     /**
      * Converts an affine point to a jacobian coordinate
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToInternal(array $p)
     {

--- a/phpseclib/Crypt/EC/BaseCurves/KoblitzPrime.php
+++ b/phpseclib/Crypt/EC/BaseCurves/KoblitzPrime.php
@@ -28,12 +28,12 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\PrimeField;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\PrimeField\Integer as PrimeInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**
  * Curves over y^2 = x^3 + b

--- a/phpseclib/Crypt/EC/BaseCurves/Montgomery.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Montgomery.php
@@ -24,14 +24,14 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\PrimeField;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\EC\Curves\Curve25519;
-use phpseclib\Math\PrimeField\Integer as PrimeInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**
  * Curves over y^2 = x^3 + a*x + x
@@ -45,7 +45,7 @@ class Montgomery extends Base
     /**
      * Prime Field Integer factory
      *
-     * @var \phpseclib\Math\PrimeFields
+     * @var \phpseclib3\Math\PrimeFields
      */
     protected $factory;
 
@@ -252,7 +252,7 @@ class Montgomery extends Base
      *
      *   x=X/Z
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToInternal(array $p)
     {
@@ -272,7 +272,7 @@ class Montgomery extends Base
     /**
      * Returns the affine point
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToAffine(array $p)
     {

--- a/phpseclib/Crypt/EC/BaseCurves/Prime.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Prime.php
@@ -21,13 +21,13 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\PrimeField;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\PrimeField\Integer as PrimeInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**
  * Curves over y^2 = x^3 + a*x + b
@@ -41,7 +41,7 @@ class Prime extends Base
     /**
      * Prime Field Integer factory
      *
-     * @var \phpseclib\Math\PrimeFields
+     * @var \phpseclib3\Math\PrimeFields
      */
     protected $factory;
 
@@ -475,7 +475,7 @@ class Prime extends Base
     /**
      * Returns the modulo
      *
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     public function getModulo()
     {
@@ -485,7 +485,7 @@ class Prime extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getA()
     {
@@ -495,7 +495,7 @@ class Prime extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getB()
     {
@@ -740,7 +740,7 @@ class Prime extends Base
      * To convert a Jacobian Coordinate to an Affine Point
      * you do (x / z^2, y / z^3)
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToAffine(array $p)
     {
@@ -759,7 +759,7 @@ class Prime extends Base
     /**
      * Converts an affine point to a jacobian coordinate
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToInternal(array $p)
     {

--- a/phpseclib/Crypt/EC/BaseCurves/TwistedEdwards.php
+++ b/phpseclib/Crypt/EC/BaseCurves/TwistedEdwards.php
@@ -26,11 +26,11 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\BaseCurves;
+namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib\Math\PrimeField;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\PrimeField\Integer as PrimeInteger;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**
  * Curves over a*x^2 + y^2 = 1 + d*x^2*y^2
@@ -137,7 +137,7 @@ class TwistedEdwards extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getA()
     {
@@ -147,7 +147,7 @@ class TwistedEdwards extends Base
     /**
      * Returns the a coefficient
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function getD()
     {
@@ -175,7 +175,7 @@ class TwistedEdwards extends Base
     /**
      * Returns the affine point
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToAffine(array $p)
     {
@@ -193,7 +193,7 @@ class TwistedEdwards extends Base
     /**
      * Returns the modulo
      *
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     public function getModulo()
     {

--- a/phpseclib/Crypt/EC/Curves/Curve25519.php
+++ b/phpseclib/Crypt/EC/Curves/Curve25519.php
@@ -13,11 +13,11 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery;
+use phpseclib3\Math\BigInteger;
 
 class Curve25519 extends Montgomery
 {

--- a/phpseclib/Crypt/EC/Curves/Curve448.php
+++ b/phpseclib/Crypt/EC/Curves/Curve448.php
@@ -13,11 +13,11 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery;
+use phpseclib3\Math\BigInteger;
 
 class Curve448 extends Montgomery
 {

--- a/phpseclib/Crypt/EC/Curves/Ed25519.php
+++ b/phpseclib/Crypt/EC/Curves/Ed25519.php
@@ -12,12 +12,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
 
 class Ed25519 extends TwistedEdwards
 {
@@ -158,7 +158,7 @@ class Ed25519 extends TwistedEdwards
      * Used by the various key handlers
      *
      * @param string $str
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function extractSecret($str)
     {
@@ -208,7 +208,7 @@ class Ed25519 extends TwistedEdwards
     /**
      * Creates a random scalar multiplier
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function createRandomMultiplier()
     {
@@ -223,7 +223,7 @@ class Ed25519 extends TwistedEdwards
      * A point (x,y) is represented in extended homogeneous coordinates (X, Y, Z, T),
      * with x = X/Z, y = Y/Z, x * y = T/Z.
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToInternal(array $p)
     {

--- a/phpseclib/Crypt/EC/Curves/Ed448.php
+++ b/phpseclib/Crypt/EC/Curves/Ed448.php
@@ -12,12 +12,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
 
 class Ed448 extends TwistedEdwards
 {
@@ -95,7 +95,7 @@ class Ed448 extends TwistedEdwards
      * Used by the various key handlers
      *
      * @param string $str
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function extractSecret($str)
     {
@@ -145,7 +145,7 @@ class Ed448 extends TwistedEdwards
     /**
      * Creates a random scalar multiplier
      *
-     * @return \phpseclib\Math\PrimeField\Integer
+     * @return \phpseclib3\Math\PrimeField\Integer
      */
     public function createRandomMultiplier()
     {
@@ -160,7 +160,7 @@ class Ed448 extends TwistedEdwards
      * A point (x,y) is represented in extended homogeneous coordinates (X, Y, Z, T),
      * with x = X/Z, y = Y/Z, x * y = T/Z.
      *
-     * @return \phpseclib\Math\PrimeField\Integer[]
+     * @return \phpseclib3\Math\PrimeField\Integer[]
      */
     public function convertToInternal(array $p)
     {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP160r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP160r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP160r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP160t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP160t1.php
@@ -26,10 +26,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP160t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP192r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP192r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP192r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP192t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP192t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP192t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP224r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP224r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP224r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP224t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP224t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP224t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP256r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP256r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP256r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP256t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP256t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP256t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP320r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP320r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP320r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP320t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP320t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP320t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP384r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP384r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP384r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP384t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP384t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP384t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP512r1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP512r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP512r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/brainpoolP512t1.php
+++ b/phpseclib/Crypt/EC/Curves/brainpoolP512t1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class brainpoolP512t1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/nistb233.php
+++ b/phpseclib/Crypt/EC/Curves/nistb233.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistb233 extends sect233r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistb409.php
+++ b/phpseclib/Crypt/EC/Curves/nistb409.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistb409 extends sect409r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistk163.php
+++ b/phpseclib/Crypt/EC/Curves/nistk163.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistk163 extends sect163k1
 {

--- a/phpseclib/Crypt/EC/Curves/nistk233.php
+++ b/phpseclib/Crypt/EC/Curves/nistk233.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistk233 extends sect233k1
 {

--- a/phpseclib/Crypt/EC/Curves/nistk283.php
+++ b/phpseclib/Crypt/EC/Curves/nistk283.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistk283 extends sect283k1
 {

--- a/phpseclib/Crypt/EC/Curves/nistk409.php
+++ b/phpseclib/Crypt/EC/Curves/nistk409.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistk409 extends sect409k1
 {

--- a/phpseclib/Crypt/EC/Curves/nistp192.php
+++ b/phpseclib/Crypt/EC/Curves/nistp192.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistp192 extends secp192r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistp224.php
+++ b/phpseclib/Crypt/EC/Curves/nistp224.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistp224 extends secp224r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistp256.php
+++ b/phpseclib/Crypt/EC/Curves/nistp256.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistp256 extends secp256r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistp384.php
+++ b/phpseclib/Crypt/EC/Curves/nistp384.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistp384 extends secp384r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistp521.php
+++ b/phpseclib/Crypt/EC/Curves/nistp521.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistp521 extends secp521r1
 {

--- a/phpseclib/Crypt/EC/Curves/nistt571.php
+++ b/phpseclib/Crypt/EC/Curves/nistt571.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class nistt571 extends sect571k1
 {

--- a/phpseclib/Crypt/EC/Curves/prime192v1.php
+++ b/phpseclib/Crypt/EC/Curves/prime192v1.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class prime192v1 extends secp192r1
 {

--- a/phpseclib/Crypt/EC/Curves/prime192v2.php
+++ b/phpseclib/Crypt/EC/Curves/prime192v2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class prime192v2 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/prime192v3.php
+++ b/phpseclib/Crypt/EC/Curves/prime192v3.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class prime192v3 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/prime239v1.php
+++ b/phpseclib/Crypt/EC/Curves/prime239v1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class prime239v1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/prime239v2.php
+++ b/phpseclib/Crypt/EC/Curves/prime239v2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class prime239v2 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/prime239v3.php
+++ b/phpseclib/Crypt/EC/Curves/prime239v3.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class prime239v3 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/prime256v1.php
+++ b/phpseclib/Crypt/EC/Curves/prime256v1.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
 final class prime256v1 extends secp256r1
 {

--- a/phpseclib/Crypt/EC/Curves/secp112r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp112r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp112r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp112r2.php
+++ b/phpseclib/Crypt/EC/Curves/secp112r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp112r2 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp128r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp128r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp128r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp128r2.php
+++ b/phpseclib/Crypt/EC/Curves/secp128r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp128r2 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp160k1.php
+++ b/phpseclib/Crypt/EC/Curves/secp160k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\KoblitzPrime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\KoblitzPrime;
+use phpseclib3\Math\BigInteger;
 
 class secp160k1 extends KoblitzPrime
 {

--- a/phpseclib/Crypt/EC/Curves/secp160r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp160r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp160r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp160r2.php
+++ b/phpseclib/Crypt/EC/Curves/secp160r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp160r2 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp192k1.php
+++ b/phpseclib/Crypt/EC/Curves/secp192k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\KoblitzPrime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\KoblitzPrime;
+use phpseclib3\Math\BigInteger;
 
 class secp192k1 extends KoblitzPrime
 {

--- a/phpseclib/Crypt/EC/Curves/secp192r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp192r1.php
@@ -15,10 +15,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp192r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp224k1.php
+++ b/phpseclib/Crypt/EC/Curves/secp224k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\KoblitzPrime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\KoblitzPrime;
+use phpseclib3\Math\BigInteger;
 
 class secp224k1 extends KoblitzPrime
 {

--- a/phpseclib/Crypt/EC/Curves/secp224r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp224r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp224r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp256k1.php
+++ b/phpseclib/Crypt/EC/Curves/secp256k1.php
@@ -15,11 +15,11 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-//use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Crypt\EC\BaseCurves\KoblitzPrime;
-use phpseclib\Math\BigInteger;
+//use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Crypt\EC\BaseCurves\KoblitzPrime;
+use phpseclib3\Math\BigInteger;
 
 //class secp256k1 extends Prime
 class secp256k1 extends KoblitzPrime

--- a/phpseclib/Crypt/EC/Curves/secp256r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp256r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp256r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp384r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp384r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp384r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/secp521r1.php
+++ b/phpseclib/Crypt/EC/Curves/secp521r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Prime;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Prime;
+use phpseclib3\Math\BigInteger;
 
 class secp521r1 extends Prime
 {

--- a/phpseclib/Crypt/EC/Curves/sect113r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect113r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect113r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect113r2.php
+++ b/phpseclib/Crypt/EC/Curves/sect113r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect113r2 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect131r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect131r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect131r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect131r2.php
+++ b/phpseclib/Crypt/EC/Curves/sect131r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect131r2 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect163k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect163k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect163k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect163r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect163r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect163r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect163r2.php
+++ b/phpseclib/Crypt/EC/Curves/sect163r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect163r2 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect193r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect193r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect193r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect193r2.php
+++ b/phpseclib/Crypt/EC/Curves/sect193r2.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect193r2 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect233k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect233k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect233k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect233r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect233r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect233r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect239k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect239k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect239k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect283k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect283k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect283k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect283r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect283r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect283r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect409k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect409k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect409k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect409r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect409r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect409r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect571k1.php
+++ b/phpseclib/Crypt/EC/Curves/sect571k1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect571k1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Curves/sect571r1.php
+++ b/phpseclib/Crypt/EC/Curves/sect571r1.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Crypt\EC\Curves;
+namespace phpseclib3\Crypt\EC\Curves;
 
-use phpseclib\Crypt\EC\BaseCurves\Binary;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Binary;
+use phpseclib3\Math\BigInteger;
 
 class sect571r1 extends Binary
 {

--- a/phpseclib/Crypt/EC/Formats/Keys/Common.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/Common.php
@@ -13,19 +13,19 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Crypt\EC\BaseCurves\Prime as PrimeCurve;
-use phpseclib\Crypt\EC\BaseCurves\Binary as BinaryCurve;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\PrimeField;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
-use phpseclib\Exception\UnsupportedCurveException;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Prime as PrimeCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Binary as BinaryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Exception\UnsupportedCurveException;
 
 /**
  * Generic EC Key Parsing Helper functions
@@ -189,7 +189,7 @@ trait Common
      * If the key contains an implicit curve phpseclib needs the curve
      * to be explicitly provided
      *
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
      */
     public static function setImplicitCurve(BaseCurve $curve)
     {
@@ -197,11 +197,11 @@ trait Common
     }
 
     /**
-     * Returns an instance of \phpseclib\Crypt\EC\BaseCurves\Base based
+     * Returns an instance of \phpseclib3\Crypt\EC\BaseCurves\Base based
      * on the curve parameters
      *
      * @param array $params
-     * @return \phpseclib\Crypt\EC\BaseCurves\Base|false
+     * @return \phpseclib3\Crypt\EC\BaseCurves\Base|false
      */
     protected static function loadCurveByParam(array $params)
     {
@@ -209,7 +209,7 @@ trait Common
             throw new \RuntimeException('No parameters are present');
         }
         if (isset($params['namedCurve'])) {
-            $curve = '\phpseclib\Crypt\EC\Curves\\' . $params['namedCurve'];
+            $curve = '\phpseclib3\Crypt\EC\Curves\\' . $params['namedCurve'];
             if (!class_exists($curve)) {
                 throw new UnsupportedCurveException('Named Curve of ' . $params['namedCurve'] . ' is not supported');
             }
@@ -275,7 +275,7 @@ trait Common
      * Supports both compressed and uncompressed points
      *
      * @param string $str
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
      * @return object[]
      */
     public static function extractPoint($str, BaseCurve $curve)
@@ -341,7 +341,7 @@ trait Common
      * Encode Parameters
      *
      * @todo Maybe at some point this could be moved to __toString() for each of the curves?
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
      * @param bool $returnArray optional
      * @param array $options optional
      * @return string|false
@@ -367,7 +367,7 @@ trait Common
                     continue;
                 }
                 $testName = $file->getBasename('.php');
-                $class = 'phpseclib\Crypt\EC\Curves\\' . $testName;
+                $class = 'phpseclib3\Crypt\EC\Curves\\' . $testName;
                 $reflect = new \ReflectionClass($class);
                 if ($reflect->isFinal()) {
                     continue;

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
@@ -20,13 +20,13 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib\Crypt\EC\Curves\Curve25519;
-use phpseclib\Crypt\EC\Curves\Curve448;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Crypt\EC\Curves\Curve448;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Montgomery Curve Private Key Handler
@@ -77,8 +77,8 @@ abstract class MontgomeryPrivate
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\Curves\MontgomeryCurve $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\Curves\MontgomeryCurve $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @return string
      */
     public static function savePublicKey(MontgomeryCurve $curve, array $publicKey)
@@ -90,9 +90,9 @@ abstract class MontgomeryPrivate
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\Curves\Montgomery $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\Curves\Montgomery $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @return string
      */

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
@@ -13,13 +13,13 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib\Crypt\EC\Curves\Curve25519;
-use phpseclib\Crypt\EC\Curves\Curve448;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Crypt\EC\Curves\Curve448;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Montgomery Public Key Handler
@@ -68,8 +68,8 @@ abstract class MontgomeryPublic
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\Curves\Montgomery $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\Curves\Montgomery $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @return string
      */
     public static function savePublicKey(MontgomeryCurve $curve, array $publicKey)

--- a/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
@@ -15,16 +15,16 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Exception\UnsupportedCurveException;
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Math\Common\FiniteField\Integer;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Math\Common\FiniteField\Integer;
 
 /**
  * OpenSSH Formatted EC Key Handler
@@ -92,7 +92,7 @@ abstract class OpenSSH extends Progenitor
             $qa = self::extractPoint($parsed['publicKey'], $curve);
         } else {
             list($curveName, $publicKey) = Strings::unpackSSH2('ss', $parsed['publicKey']);
-            $curveName = '\phpseclib\Crypt\EC\Curves\\' . $curveName;
+            $curveName = '\phpseclib3\Crypt\EC\Curves\\' . $curveName;
             $curve = new $curveName();
 
             $qa = self::extractPoint("\0" . $publicKey, $curve);
@@ -141,8 +141,8 @@ abstract class OpenSSH extends Progenitor
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param array $options optional
      * @return string
      */
@@ -179,9 +179,9 @@ abstract class OpenSSH extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\Curves\Ed25519 $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\Curves\Ed25519 $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @param array $options optional
      * @return string

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
@@ -25,18 +25,18 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Math\BigInteger;
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Exception\UnsupportedCurveException;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Exception\UnsupportedCurveException;
 
 /**
  * "PKCS1" (RFC5915) Formatted EC Key Handler
@@ -112,9 +112,9 @@ abstract class PKCS1 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @param array $options optional
      * @return string

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
@@ -23,19 +23,19 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Crypt\EC\Curves\Ed448;
-use phpseclib\Exception\UnsupportedCurveException;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+use phpseclib3\Exception\UnsupportedCurveException;
 
 /**
  * PKCS#8 Formatted EC Key Handler
@@ -169,8 +169,8 @@ abstract class PKCS8 extends Progenitor
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param array $optiona optional
      * @return string
      */
@@ -201,9 +201,9 @@ abstract class PKCS8 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @param array $options optional
      * @return string

--- a/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
@@ -13,15 +13,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Math\Common\FiniteField\Integer;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 
 /**
  * PuTTY Formatted EC Key Handler
@@ -40,7 +40,7 @@ abstract class PuTTY extends Progenitor
      * @var string
      * @access private
      */
-    const PUBLIC_HANDLER = 'phpseclib\Crypt\EC\Formats\Keys\OpenSSH';
+    const PUBLIC_HANDLER = 'phpseclib3\Crypt\EC\Formats\Keys\OpenSSH';
 
     /**
      * Supported Key Types
@@ -92,9 +92,9 @@ abstract class PuTTY extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @param array $options optional
      * @return string
@@ -129,8 +129,8 @@ abstract class PuTTY extends Progenitor
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField[] $publicKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField[] $publicKey
      * @return string
      */
     public static function savePublicKey(BaseCurve $curve, array $publicKey)

--- a/phpseclib/Crypt/EC/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/XML.php
@@ -18,15 +18,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib\Crypt\EC\BaseCurves\Prime as PrimeCurve;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Exception\UnsupportedCurveException;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Prime as PrimeCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Exception\UnsupportedCurveException;
 
 /**
  * XML Formatted EC Key Handler
@@ -169,7 +169,7 @@ abstract class XML
      * Extract points from an XML document
      *
      * @param \DOMXPath $xpath
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
      * @return object[]
      */
     private static function extractPointRFC4050(\DOMXPath $xpath, BaseCurve $curve)
@@ -193,11 +193,11 @@ abstract class XML
     }
 
     /**
-     * Returns an instance of \phpseclib\Crypt\EC\BaseCurves\Base based
+     * Returns an instance of \phpseclib3\Crypt\EC\BaseCurves\Base based
      * on the curve parameters
      *
      * @param \DomXPath $xpath
-     * @return \phpseclib\Crypt\EC\BaseCurves\Base|false
+     * @return \phpseclib3\Crypt\EC\BaseCurves\Base|false
      */
     private static function loadCurveByParam(\DOMXPath $xpath)
     {
@@ -210,7 +210,7 @@ abstract class XML
                 throw new UnsupportedCurveException('Curve with OID of ' . $oid . ' is not supported');
             }
 
-            $curve = '\phpseclib\Crypt\EC\Curves\\' . $name;
+            $curve = '\phpseclib3\Crypt\EC\Curves\\' . $name;
             if (!class_exists($curve)) {
                 throw new UnsupportedCurveException('Named Curve of ' . $name . ' is not supported');
             }
@@ -273,11 +273,11 @@ abstract class XML
     }
 
     /**
-     * Returns an instance of \phpseclib\Crypt\EC\BaseCurves\Base based
+     * Returns an instance of \phpseclib3\Crypt\EC\BaseCurves\Base based
      * on the curve parameters
      *
      * @param \DomXPath $xpath
-     * @return \phpseclib\Crypt\EC\BaseCurves\Base|false
+     * @return \phpseclib3\Crypt\EC\BaseCurves\Base|false
      */
     private static function loadCurveByParamRFC4050(\DOMXPath $xpath)
     {
@@ -364,8 +364,8 @@ abstract class XML
     /**
      * Convert a public key to the appropriate format
      *
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param array $options optional
      * @return string
      */
@@ -405,7 +405,7 @@ abstract class XML
     /**
      * Encode Parameters
      *
-     * @param \phpseclib\Crypt\EC\BaseCurves\Base $curve
+     * @param \phpseclib3\Crypt\EC\BaseCurves\Base $curve
      * @param string $pre
      * @param array $options optional
      * @return string|false

--- a/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
@@ -17,10 +17,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Keys;
+namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Math\Common\FiniteField\Integer;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Math\Common\FiniteField\Integer;
 
 /**
  * libsodium Key Handler
@@ -86,8 +86,8 @@ abstract class libsodium
      * Convert an EC public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Crypt\EC\Curves\Ed25519 $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Crypt\EC\Curves\Ed25519 $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @return string
      */
     public static function savePublicKey(Ed25519 $curve, array $publicKey)
@@ -99,9 +99,9 @@ abstract class libsodium
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\Common\FiniteField\Integer $privateKey
-     * @param \phpseclib\Crypt\EC\Curves\Ed25519 $curve
-     * @param \phpseclib\Math\Common\FiniteField\Integer[] $publicKey
+     * @param \phpseclib3\Math\Common\FiniteField\Integer $privateKey
+     * @param \phpseclib3\Crypt\EC\Curves\Ed25519 $curve
+     * @param \phpseclib3\Math\Common\FiniteField\Integer[] $publicKey
      * @param string $password optional
      * @return string
      */

--- a/phpseclib/Crypt/EC/Formats/Signature/ASN1.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/ASN1.php
@@ -16,11 +16,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Signature;
+namespace phpseclib3\Crypt\EC\Formats\Signature;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1 as Encoder;
-use phpseclib\File\ASN1\Maps\EcdsaSigValue;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1 as Encoder;
+use phpseclib3\File\ASN1\Maps\EcdsaSigValue;
 
 /**
  * ASN1 Signature Handler
@@ -57,8 +57,8 @@ abstract class ASN1
      * Returns a signature in the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $r
-     * @param \phpseclib\Math\BigInteger $s
+     * @param \phpseclib3\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $s
      * @return string
      */
     public static function save(BigInteger $r, BigInteger $s)

--- a/phpseclib/Crypt/EC/Formats/Signature/Raw.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/Raw.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Signature;
+namespace phpseclib3\Crypt\EC\Formats\Signature;
 
-use phpseclib\Crypt\Common\Formats\Signature\Raw as Progenitor;
+use phpseclib3\Crypt\Common\Formats\Signature\Raw as Progenitor;
 
 /**
  * Raw DSA Signature Handler

--- a/phpseclib/Crypt/EC/Formats/Signature/SSH2.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/SSH2.php
@@ -15,10 +15,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC\Formats\Signature;
+namespace phpseclib3\Crypt\EC\Formats\Signature;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * SSH2 Signature Handler
@@ -72,8 +72,8 @@ abstract class SSH2
      * Returns a signature in the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $r
-     * @param \phpseclib\Math\BigInteger $s
+     * @param \phpseclib3\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $s
      * @param string $curve
      * @return string
      */

--- a/phpseclib/Crypt/EC/Parameters.php
+++ b/phpseclib/Crypt/EC/Parameters.php
@@ -11,9 +11,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC;
+namespace phpseclib3\Crypt\EC;
 
-use phpseclib\Crypt\EC;
+use phpseclib3\Crypt\EC;
 
 /**
  * EC Parameters

--- a/phpseclib/Crypt/EC/PrivateKey.php
+++ b/phpseclib/Crypt/EC/PrivateKey.php
@@ -11,19 +11,19 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC;
+namespace phpseclib3\Crypt\EC;
 
-use phpseclib\Crypt\EC;
-use phpseclib\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Crypt\EC\Curves\Curve25519;
-use phpseclib\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib\Crypt\Common;
-use phpseclib\Exception\UnsupportedOperationException;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\Common;
+use phpseclib3\Exception\UnsupportedOperationException;
 
 /**
  * EC Private Key

--- a/phpseclib/Crypt/EC/PublicKey.php
+++ b/phpseclib/Crypt/EC/PublicKey.php
@@ -11,18 +11,18 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\EC;
+namespace phpseclib3\Crypt\EC;
 
-use phpseclib\Crypt\EC;
-use phpseclib\Crypt\Hash;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib\Crypt\EC\Curves\Ed25519;
-use phpseclib\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib\Crypt\Common;
-use phpseclib\Exception\UnsupportedOperationException;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\Common;
+use phpseclib3\Exception\UnsupportedOperationException;
 
 /**
  * EC Public Key

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -13,7 +13,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $hash = new \phpseclib\Crypt\Hash('sha512');
+ *    $hash = new \phpseclib3\Crypt\Hash('sha512');
  *
  *    $hash->setKey('abcdefg');
  *
@@ -31,14 +31,14 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\AES;
-use phpseclib\Math\PrimeField;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Math\PrimeField;
 
 /**
  * @package Hash
@@ -167,7 +167,7 @@ class Hash
      * umac cipher object
      *
      * @see self::hash()
-     * @var \phpseclib\Crypt\AES
+     * @var \phpseclib3\Crypt\AES
      * @access private
      */
     private $c;
@@ -404,7 +404,7 @@ class Hash
                     'length' => $this->length,
                     'padding' => $this->paddingType
                 ];
-                $hash = ['phpseclib\Crypt\Hash', PHP_INT_SIZE == 8 ? 'sha3_64' : 'sha3_32'];
+                $hash = ['phpseclib3\Crypt\Hash', PHP_INT_SIZE == 8 ? 'sha3_64' : 'sha3_32'];
             }
         }
 
@@ -429,7 +429,7 @@ class Hash
 
                 $this->parameters = compact('initial');
 
-                $hash = ['phpseclib\Crypt\Hash', 'sha512'];
+                $hash = ['phpseclib3\Crypt\Hash', 'sha512'];
             }
         }
 
@@ -1455,7 +1455,7 @@ class Hash
         }
 
         // Produce the final hash value (big-endian)
-        // (\phpseclib\Crypt\Hash::hash() trims the output for hashes but not for HMACs.  as such, we trim the output here)
+        // (\phpseclib3\Crypt\Hash::hash() trims the output for hashes but not for HMACs.  as such, we trim the output here)
         $temp = $hash[0]->toBytes() . $hash[1]->toBytes() . $hash[2]->toBytes() . $hash[3]->toBytes() .
                 $hash[4]->toBytes() . $hash[5]->toBytes() . $hash[6]->toBytes() . $hash[7]->toBytes();
 

--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -13,11 +13,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Exception\NoKeyLoadedException;
-use phpseclib\Crypt\Common\PrivateKey;
-use phpseclib\File\X509;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\File\X509;
 
 /**
  * PublicKeyLoader

--- a/phpseclib/Crypt/RC2.php
+++ b/phpseclib/Crypt/RC2.php
@@ -16,7 +16,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $rc2 = new \phpseclib\Crypt\RC2();
+ *    $rc2 = new \phpseclib3\Crypt\RC2();
  *
  *    $rc2->setKey('abcdefgh');
  *
@@ -33,10 +33,10 @@
  * @link     http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\BlockCipher;
-use phpseclib\Exception\BadModeException;
+use phpseclib3\Crypt\Common\BlockCipher;
+use phpseclib3\Exception\BadModeException;
 
 /**
  * Pure-PHP implementation of RC2.
@@ -49,7 +49,7 @@ class RC2 extends BlockCipher
     /**
      * Block Length of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -58,7 +58,7 @@ class RC2 extends BlockCipher
     /**
      * The Key
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::key
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::key
      * @see self::setKey()
      * @var string
      * @access private
@@ -68,7 +68,7 @@ class RC2 extends BlockCipher
     /**
      * The Original (unpadded) Key
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::key
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::key
      * @see self::setKey()
      * @see self::encrypt()
      * @see self::decrypt()
@@ -80,7 +80,7 @@ class RC2 extends BlockCipher
     /**
      * Don't truncate / null pad key
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::clearBuffers()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::clearBuffers()
      * @var bool
      * @access private
      */
@@ -89,7 +89,7 @@ class RC2 extends BlockCipher
     /**
      * Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\RC2::setKeyLength()
+     * @see \phpseclib3\Crypt\RC2::setKeyLength()
      * @var int
      * @access private
      */
@@ -98,7 +98,7 @@ class RC2 extends BlockCipher
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -107,7 +107,7 @@ class RC2 extends BlockCipher
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -281,9 +281,9 @@ class RC2 extends BlockCipher
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access protected
      * @return bool
@@ -307,7 +307,7 @@ class RC2 extends BlockCipher
      *
      * Valid key lengths are 8 to 1024.
      * Calling this function after setting the key has no effect until the next
-     *  \phpseclib\Crypt\RC2::setKey() call.
+     *  \phpseclib3\Crypt\RC2::setKey() call.
      *
      * @access public
      * @param int $length in bits
@@ -342,7 +342,7 @@ class RC2 extends BlockCipher
      * has more then 128 bytes in it, and set $key to a single null byte if
      * it is empty.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setKey()
      * @access public
      * @param string $key
      * @param int|boolean $t1 optional Effective key length in bits.
@@ -402,7 +402,7 @@ class RC2 extends BlockCipher
     /**
      * Encrypts a message.
      *
-     * Mostly a wrapper for \phpseclib\Crypt\Common\SymmetricKey::encrypt, with some additional OpenSSL handling code
+     * Mostly a wrapper for \phpseclib3\Crypt\Common\SymmetricKey::encrypt, with some additional OpenSSL handling code
      *
      * @see self::decrypt()
      * @access public
@@ -425,7 +425,7 @@ class RC2 extends BlockCipher
     /**
      * Decrypts a message.
      *
-     * Mostly a wrapper for \phpseclib\Crypt\Common\SymmetricKey::decrypt, with some additional OpenSSL handling code
+     * Mostly a wrapper for \phpseclib3\Crypt\Common\SymmetricKey::decrypt, with some additional OpenSSL handling code
      *
      * @see self::encrypt()
      * @access public
@@ -448,8 +448,8 @@ class RC2 extends BlockCipher
     /**
      * Encrypts a block
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encryptBlock()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encryptBlock()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @access private
      * @param string $in
      * @return string
@@ -493,8 +493,8 @@ class RC2 extends BlockCipher
     /**
      * Decrypts a block
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decryptBlock()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decryptBlock()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @access private
      * @param string $in
      * @return string
@@ -538,7 +538,7 @@ class RC2 extends BlockCipher
     /**
      * Creates the key schedule
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupKey()
      * @access private
      */
     protected function setupKey()
@@ -547,7 +547,7 @@ class RC2 extends BlockCipher
             $this->setKey('');
         }
 
-        // Key has already been expanded in \phpseclib\Crypt\RC2::setKey():
+        // Key has already been expanded in \phpseclib3\Crypt\RC2::setKey():
         // Only the first value must be altered.
         $l = unpack('Ca/Cb/v*', $this->key);
         array_unshift($l, self::$pitable[$l['a']] | ($l['b'] << 8));
@@ -559,7 +559,7 @@ class RC2 extends BlockCipher
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupInlineCrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupInlineCrypt()
      * @access private
      */
     protected function setupInlineCrypt()

--- a/phpseclib/Crypt/RC4.php
+++ b/phpseclib/Crypt/RC4.php
@@ -20,7 +20,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $rc4 = new \phpseclib\Crypt\RC4();
+ *    $rc4 = new \phpseclib3\Crypt\RC4();
  *
  *    $rc4->setKey('abcdefgh');
  *
@@ -42,9 +42,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\StreamCipher;
+use phpseclib3\Crypt\Common\StreamCipher;
 
 /**
  * Pure-PHP implementation of RC4.
@@ -57,7 +57,7 @@ class RC4 extends StreamCipher
 {
     /**#@+
      * @access private
-     * @see \phpseclib\Crypt\RC4::_crypt()
+     * @see \phpseclib3\Crypt\RC4::_crypt()
     */
     const ENCRYPT = 0;
     const DECRYPT = 1;
@@ -69,7 +69,7 @@ class RC4 extends StreamCipher
      * RC4 is a stream cipher
      * so we the block_size to 0
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::block_size
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::block_size
      * @var int
      * @access private
      */
@@ -78,7 +78,7 @@ class RC4 extends StreamCipher
     /**
      * Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\RC4::setKeyLength()
+     * @see \phpseclib3\Crypt\RC4::setKeyLength()
      * @var int
      * @access private
      */
@@ -87,7 +87,7 @@ class RC4 extends StreamCipher
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -114,8 +114,8 @@ class RC4 extends StreamCipher
     /**
      * Default Constructor.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
-     * @return \phpseclib\Crypt\RC4
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
+     * @return \phpseclib3\Crypt\RC4
      * @access public
      */
     public function __construct()
@@ -126,9 +126,9 @@ class RC4 extends StreamCipher
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access protected
      * @return bool
@@ -213,7 +213,7 @@ class RC4 extends StreamCipher
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @see self::crypt()
      * @access public
      * @param string $plaintext
@@ -233,7 +233,7 @@ class RC4 extends StreamCipher
      * $this->decrypt($this->encrypt($plaintext)) == $this->encrypt($this->encrypt($plaintext)).
      * At least if the continuous buffer is disabled.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @see self::crypt()
      * @access public
      * @param string $ciphertext
@@ -272,7 +272,7 @@ class RC4 extends StreamCipher
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     protected function setupKey()

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -10,7 +10,7 @@
  * <?php
  * include 'vendor/autoload.php';
  *
- * $private = \phpseclib\Crypt\RSA::createKey();
+ * $private = \phpseclib3\Crypt\RSA::createKey();
  * $public = $private->getPublicKey();
  *
  * $plaintext = 'terrafrost';
@@ -26,7 +26,7 @@
  * <?php
  * include 'vendor/autoload.php';
  *
- * $private = \phpseclib\Crypt\RSA::createKey();
+ * $private = \phpseclib3\Crypt\RSA::createKey();
  * $public = $private->getPublicKey();
  *
  * $plaintext = 'terrafrost';
@@ -45,15 +45,15 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\AsymmetricKey;
-use phpseclib\Crypt\RSA\PrivateKey;
-use phpseclib\Crypt\RSA\PublicKey;
-use phpseclib\Math\BigInteger;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\Exception\InconsistentSetupException;
-use phpseclib\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\RSA\PrivateKey;
+use phpseclib3\Crypt\RSA\PublicKey;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\InconsistentSetupException;
+use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
 
 /**
  * Pure-PHP PKCS#1 compliant implementation of RSA.
@@ -178,7 +178,7 @@ abstract class RSA extends AsymmetricKey
     /**
      * Hash function for the Mask Generation Function
      *
-     * @var \phpseclib\Crypt\Hash
+     * @var \phpseclib3\Crypt\Hash
      * @access private
      */
     protected $mgfHash;
@@ -194,7 +194,7 @@ abstract class RSA extends AsymmetricKey
     /**
      * Modulus (ie. n)
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $modulus;
@@ -202,7 +202,7 @@ abstract class RSA extends AsymmetricKey
     /**
      * Modulus length
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $k;
@@ -210,7 +210,7 @@ abstract class RSA extends AsymmetricKey
     /**
      * Exponent (ie. e or d)
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      * @access private
      */
     protected $exponent;
@@ -457,7 +457,7 @@ abstract class RSA extends AsymmetricKey
      * See {@link http://tools.ietf.org/html/rfc3447#section-4.1 RFC3447#section-4.1}.
      *
      * @access private
-     * @param bool|\phpseclib\Math\BigInteger $x
+     * @param bool|\phpseclib3\Math\BigInteger $x
      * @param int $xLen
      * @return bool|string
      */
@@ -480,7 +480,7 @@ abstract class RSA extends AsymmetricKey
      *
      * @access private
      * @param string $x
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     protected function os2ip($x)
     {
@@ -596,7 +596,7 @@ abstract class RSA extends AsymmetricKey
     {
         $new = clone $this;
 
-        // \phpseclib\Crypt\Hash supports algorithms that PKCS#1 doesn't support.  md5-96 and sha1-96, for example.
+        // \phpseclib3\Crypt\Hash supports algorithms that PKCS#1 doesn't support.  md5-96 and sha1-96, for example.
         switch (strtolower($hash)) {
             case 'md2':
             case 'md5':
@@ -632,7 +632,7 @@ abstract class RSA extends AsymmetricKey
     {
         $new = clone $this;
 
-        // \phpseclib\Crypt\Hash supports algorithms that PKCS#1 doesn't support.  md5-96 and sha1-96, for example.
+        // \phpseclib3\Crypt\Hash supports algorithms that PKCS#1 doesn't support.  md5-96 and sha1-96, for example.
         switch (strtolower($hash)) {
             case 'md2':
             case 'md5':

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -17,11 +17,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Microsoft BLOB Formatted RSA Key Handler
@@ -176,9 +176,9 @@ abstract class MSBLOB
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -210,8 +210,8 @@ abstract class MSBLOB
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @return string
      */
     public static function savePublicKey(BigInteger $n, BigInteger $e)

--- a/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
@@ -15,12 +15,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
 
 /**
  * OpenSSH Formatted RSA Key Handler
@@ -97,8 +97,8 @@ abstract class OpenSSH extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @param array $options optional
      * @return string
      */
@@ -120,9 +120,9 @@ abstract class OpenSSH extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
@@ -22,12 +22,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * PKCS#1 Formatted RSA Key Handler
@@ -94,9 +94,9 @@ abstract class PKCS1 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -135,8 +135,8 @@ abstract class PKCS1 extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @return string
      */
     public static function savePublicKey(BigInteger $n, BigInteger $e)

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
@@ -25,11 +25,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib\File\ASN1;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
+use phpseclib3\File\ASN1;
 
 /**
  * PKCS#8 Formatted RSA Key Handler
@@ -97,9 +97,9 @@ abstract class PKCS8 extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -118,8 +118,8 @@ abstract class PKCS8 extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @param array $options optional
      * @return string
      */

--- a/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
@@ -23,12 +23,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
 
 /**
  * PKCS#8 Formatted RSA-PSS Key Handler
@@ -156,9 +156,9 @@ abstract class PSS extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -180,8 +180,8 @@ abstract class PSS extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @param array $options optional
      * @return string
      */

--- a/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
@@ -13,11 +13,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
 
 /**
  * PuTTY Formatted RSA Key Handler
@@ -34,7 +34,7 @@ abstract class PuTTY extends Progenitor
      * @var string
      * @access private
      */
-    const PUBLIC_HANDLER = 'phpseclib\Crypt\RSA\Formats\Keys\OpenSSH';
+    const PUBLIC_HANDLER = 'phpseclib3\Crypt\RSA\Formats\Keys\OpenSSH';
 
     /**
      * Algorithm Identifier
@@ -93,9 +93,9 @@ abstract class PuTTY extends Progenitor
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -119,8 +119,8 @@ abstract class PuTTY extends Progenitor
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @return string
      */
     public static function savePublicKey(BigInteger $n, BigInteger $e)

--- a/phpseclib/Crypt/RSA/Formats/Keys/Raw.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/Raw.php
@@ -5,7 +5,7 @@
  *
  * PHP version 5
  *
- * An array containing two \phpseclib\Math\BigInteger objects.
+ * An array containing two \phpseclib3\Math\BigInteger objects.
  *
  * The exponent can be indexed with any of the following:
  *
@@ -23,9 +23,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Raw RSA Key Handler
@@ -97,8 +97,8 @@ abstract class Raw
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @return array
      */
     public static function savePublicKey(BigInteger $n, BigInteger $e)

--- a/phpseclib/Crypt/RSA/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/XML.php
@@ -20,10 +20,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA\Formats\Keys;
+namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 /**
  * XML Formatted RSA Key Handler
@@ -122,9 +122,9 @@ abstract class XML
      * Convert a private key to the appropriate format.
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
-     * @param \phpseclib\Math\BigInteger $d
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $d
      * @param array $primes
      * @param array $exponents
      * @param array $coefficients
@@ -152,8 +152,8 @@ abstract class XML
      * Convert a public key to the appropriate format
      *
      * @access public
-     * @param \phpseclib\Math\BigInteger $n
-     * @param \phpseclib\Math\BigInteger $e
+     * @param \phpseclib3\Math\BigInteger $n
+     * @param \phpseclib3\Math\BigInteger $e
      * @return string
      */
     public static function savePublicKey(BigInteger $n, BigInteger $e)

--- a/phpseclib/Crypt/RSA/PrivateKey.php
+++ b/phpseclib/Crypt/RSA/PrivateKey.php
@@ -11,18 +11,18 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA;
+namespace phpseclib3\Crypt\RSA;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Hash;
-use phpseclib\Exceptions\NoKeyLoadedException;
-use phpseclib\Exception\UnsupportedFormatException;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\Common;
-use phpseclib\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Exceptions\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
 
 /**
  * Raw RSA Key Handler
@@ -73,8 +73,8 @@ class PrivateKey extends RSA implements Common\PrivateKey
      * See {@link http://tools.ietf.org/html/rfc3447#section-5.1.2 RFC3447#section-5.1.2}.
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $c
-     * @return bool|\phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $c
+     * @return bool|\phpseclib3\Math\BigInteger
      */
     private function rsadp($c)
     {
@@ -90,8 +90,8 @@ class PrivateKey extends RSA implements Common\PrivateKey
      * See {@link http://tools.ietf.org/html/rfc3447#section-5.2.1 RFC3447#section-5.2.1}.
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $m
-     * @return bool|\phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $m
+     * @return bool|\phpseclib3\Math\BigInteger
      */
     private function rsasp1($m)
     {
@@ -104,8 +104,8 @@ class PrivateKey extends RSA implements Common\PrivateKey
     /**
      * Exponentiate
      *
-     * @param \phpseclib\Math\BigInteger $x
-     * @return \phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $x
+     * @return \phpseclib3\Math\BigInteger
      */
     protected function exponentiate(BigInteger $x)
     {
@@ -186,10 +186,10 @@ class PrivateKey extends RSA implements Common\PrivateKey
      * Returns $x->modPow($this->exponents[$i], $this->primes[$i])
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $x
-     * @param \phpseclib\Math\BigInteger $r
+     * @param \phpseclib3\Math\BigInteger $x
+     * @param \phpseclib3\Math\BigInteger $r
      * @param int $i
-     * @return \phpseclib\Math\BigInteger
+     * @return \phpseclib3\Math\BigInteger
      */
     private function blind($x, $r, $i)
     {
@@ -331,7 +331,7 @@ class PrivateKey extends RSA implements Common\PrivateKey
      * to be 2 regardless of which key is used.  For compatibility purposes, we'll just check to make sure the
      * second byte is 2 or less.  If it is, we'll accept the decrypted string as valid.
      *
-     * As a consequence of this, a private key encrypted ciphertext produced with \phpseclib\Crypt\RSA may not decrypt
+     * As a consequence of this, a private key encrypted ciphertext produced with \phpseclib3\Crypt\RSA may not decrypt
      * with a strictly PKCS#1 v1.5 compliant RSA implementation.  Public key encrypted ciphertext's should but
      * not private key encrypted ciphertext's.
      *

--- a/phpseclib/Crypt/RSA/PublicKey.php
+++ b/phpseclib/Crypt/RSA/PublicKey.php
@@ -11,19 +11,19 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt\RSA;
+namespace phpseclib3\Crypt\RSA;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Hash;
-use phpseclib\Exception\NoKeyLoadedException;
-use phpseclib\Exception\UnsupportedFormatException;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\Common;
-use phpseclib\File\ASN1\Maps\DigestInfo;
-use phpseclib\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\Common;
+use phpseclib3\File\ASN1\Maps\DigestInfo;
+use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
 
 /**
  * Raw RSA Key Handler
@@ -39,8 +39,8 @@ class PublicKey extends RSA implements Common\PublicKey
     /**
      * Exponentiate
      *
-     * @param \phpseclib\Math\BigInteger $x
-     * @return \phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $x
+     * @return \phpseclib3\Math\BigInteger
      */
     private function exponentiate(BigInteger $x)
     {
@@ -53,8 +53,8 @@ class PublicKey extends RSA implements Common\PublicKey
      * See {@link http://tools.ietf.org/html/rfc3447#section-5.2.2 RFC3447#section-5.2.2}.
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $s
-     * @return bool|\phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $s
+     * @return bool|\phpseclib3\Math\BigInteger
      */
     private function rsavp1($s)
     {
@@ -400,8 +400,8 @@ class PublicKey extends RSA implements Common\PublicKey
      * See {@link http://tools.ietf.org/html/rfc3447#section-5.1.1 RFC3447#section-5.1.1}.
      *
      * @access private
-     * @param \phpseclib\Math\BigInteger $m
-     * @return bool|\phpseclib\Math\BigInteger
+     * @param \phpseclib3\Math\BigInteger $m
+     * @return bool|\phpseclib3\Math\BigInteger
      */
     private function rsaep($m)
     {

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -10,7 +10,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    echo bin2hex(\phpseclib\Crypt\Random::string(8));
+ *    echo bin2hex(\phpseclib3\Crypt\Random::string(8));
  * ?>
  * </code>
  *
@@ -22,7 +22,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
 /**
  * Pure-PHP Random Number Generator
@@ -142,22 +142,22 @@ abstract class Random
             //
             // http://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator#Designs_based_on_cryptographic_primitives
             switch (true) {
-                case class_exists('\phpseclib\Crypt\AES'):
+                case class_exists('\phpseclib3\Crypt\AES'):
                     $crypto = new AES('ctr');
                     break;
-                case class_exists('\phpseclib\Crypt\Twofish'):
+                case class_exists('\phpseclib3\Crypt\Twofish'):
                     $crypto = new Twofish('ctr');
                     break;
-                case class_exists('\phpseclib\Crypt\Blowfish'):
+                case class_exists('\phpseclib3\Crypt\Blowfish'):
                     $crypto = new Blowfish('ctr');
                     break;
-                case class_exists('\phpseclib\Crypt\TripleDES'):
+                case class_exists('\phpseclib3\Crypt\TripleDES'):
                     $crypto = new TripleDES('ctr');
                     break;
-                case class_exists('\phpseclib\Crypt\DES'):
+                case class_exists('\phpseclib3\Crypt\DES'):
                     $crypto = new DES('ctr');
                     break;
-                case class_exists('\phpseclib\Crypt\RC4'):
+                case class_exists('\phpseclib3\Crypt\RC4'):
                     $crypto = new RC4();
                     break;
                 default:

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -30,7 +30,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $rijndael = new \phpseclib\Crypt\Rijndael();
+ *    $rijndael = new \phpseclib3\Crypt\Rijndael();
  *
  *    $rijndael->setKey('abcdefghijklmnop');
  *
@@ -52,14 +52,14 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Exception\BadModeException;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Exception\BadDecryptionException;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Exception\BadModeException;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\BadDecryptionException;
 
 /**
  * Pure-PHP implementation of Rijndael.
@@ -74,12 +74,12 @@ class Rijndael extends BlockCipher
      * The mcrypt specific name of the cipher
      *
      * Mcrypt is useable for 128/192/256-bit $block_size/$key_length. For 160/224 not.
-     * \phpseclib\Crypt\Rijndael determines automatically whether mcrypt is useable
+     * \phpseclib3\Crypt\Rijndael determines automatically whether mcrypt is useable
      * or not for the current $block_size/$key_length.
      * In case of, $cipher_name_mcrypt will be set dynamically at run time accordingly.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
-     * @see \phpseclib\Crypt\Common\SymmetricKey::engine
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::engine
      * @see self::isValidEngine()
      * @var string
      * @access private
@@ -274,9 +274,9 @@ class Rijndael extends BlockCipher
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access protected
      * @return bool
@@ -490,7 +490,7 @@ class Rijndael extends BlockCipher
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupKey()
      * @access private
      */
     protected function setupKey()
@@ -796,7 +796,7 @@ class Rijndael extends BlockCipher
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupInlineCrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupInlineCrypt()
      * @access private
      */
     protected function setupInlineCrypt()

--- a/phpseclib/Crypt/Salsa20.php
+++ b/phpseclib/Crypt/Salsa20.php
@@ -13,12 +13,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\StreamCipher;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Exception\BadDecryptionException;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\StreamCipher;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\BadDecryptionException;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementation of Salsa20.
@@ -62,7 +62,7 @@ class Salsa20 extends StreamCipher
 
     /**#@+
      * @access private
-     * @see \phpseclib\Crypt\Salsa20::crypt()
+     * @see \phpseclib3\Crypt\Salsa20::crypt()
     */
     const ENCRYPT = 0;
     const DECRYPT = 1;
@@ -99,8 +99,8 @@ class Salsa20 extends StreamCipher
     /**
      * Default Constructor.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
-     * @return \phpseclib\Crypt\Salsa20
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
+     * @return \phpseclib3\Crypt\Salsa20
      */
     public function __construct()
     {
@@ -269,7 +269,7 @@ class Salsa20 extends StreamCipher
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @see self::crypt()
      * @param string $plaintext
      * @return string $ciphertext
@@ -289,7 +289,7 @@ class Salsa20 extends StreamCipher
      * $this->decrypt($this->encrypt($plaintext)) == $this->encrypt($this->encrypt($plaintext)).
      * At least if the continuous buffer is disabled.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @see self::crypt()
      * @param string $ciphertext
      * @return string $plaintext

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -12,7 +12,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $des = new \phpseclib\Crypt\TripleDES();
+ *    $des = new \phpseclib3\Crypt\TripleDES();
  *
  *    $des->setKey('abcdefghijklmnopqrstuvwx');
  *
@@ -34,7 +34,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
 /**
  * Pure-PHP implementation of Triple DES.
@@ -55,14 +55,14 @@ class TripleDES extends DES
     /**
      * Encrypt / decrypt using outer chaining
      *
-     * Outer chaining is used by SSH-2 and when the mode is set to \phpseclib\Crypt\Common\BlockCipher::MODE_CBC.
+     * Outer chaining is used by SSH-2 and when the mode is set to \phpseclib3\Crypt\Common\BlockCipher::MODE_CBC.
      */
     const MODE_CBC3 = self::MODE_CBC;
 
     /**
      * Key Length (in bytes)
      *
-     * @see \phpseclib\Crypt\TripleDES::setKeyLength()
+     * @see \phpseclib3\Crypt\TripleDES::setKeyLength()
      * @var int
      * @access private
      */
@@ -71,8 +71,8 @@ class TripleDES extends DES
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\DES::cipher_name_mcrypt
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\DES::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -81,7 +81,7 @@ class TripleDES extends DES
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -91,7 +91,7 @@ class TripleDES extends DES
      * max possible size of $key
      *
      * @see self::setKey()
-     * @see \phpseclib\Crypt\DES::setKey()
+     * @see \phpseclib3\Crypt\DES::setKey()
      * @var string
      * @access private
      */
@@ -106,7 +106,7 @@ class TripleDES extends DES
     private $mode_3cbc;
 
     /**
-     * The \phpseclib\Crypt\DES objects
+     * The \phpseclib3\Crypt\DES objects
      *
      * Used only if $mode_3cbc === true
      *
@@ -136,8 +136,8 @@ class TripleDES extends DES
      *
      * - cbc3 (same as cbc)
      *
-     * @see \phpseclib\Crypt\DES::__construct()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\DES::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param string $mode
      * @access public
      */
@@ -157,7 +157,7 @@ class TripleDES extends DES
                     new DES('cbc'),
                 ];
 
-                // we're going to be doing the padding, ourselves, so disable it in the \phpseclib\Crypt\DES objects
+                // we're going to be doing the padding, ourselves, so disable it in the \phpseclib3\Crypt\DES objects
                 $this->des[0]->disablePadding();
                 $this->des[1]->disablePadding();
                 $this->des[2]->disablePadding();
@@ -177,9 +177,9 @@ class TripleDES extends DES
     /**
      * Test for engine validity
      *
-     * This is mainly just a wrapper to set things up for \phpseclib\Crypt\Common\SymmetricKey::isValidEngine()
+     * This is mainly just a wrapper to set things up for \phpseclib3\Crypt\Common\SymmetricKey::isValidEngine()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
      * @param int $engine
      * @access protected
      * @return bool
@@ -198,9 +198,9 @@ class TripleDES extends DES
     /**
      * Sets the initialization vector.
      *
-     * SetIV is not required when \phpseclib\Crypt\Common\SymmetricKey::MODE_ECB is being used.
+     * SetIV is not required when \phpseclib3\Crypt\Common\SymmetricKey::MODE_ECB is being used.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setIV()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setIV()
      * @access public
      * @param string $iv
      */
@@ -221,7 +221,7 @@ class TripleDES extends DES
      *
      * If you want to use a 64-bit key use DES.php
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey:setKeyLength()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey:setKeyLength()
      * @access public
      * @throws \LengthException if the key length is invalid
      * @param int $length
@@ -247,8 +247,8 @@ class TripleDES extends DES
      * DES also requires that every eighth bit be a parity bit, however, we'll ignore that.
      *
      * @access public
-     * @see \phpseclib\Crypt\DES::setKey()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setKey()
+     * @see \phpseclib3\Crypt\DES::setKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setKey()
      * @throws \LengthException if the key length is invalid
      * @param string $key
      */
@@ -284,7 +284,7 @@ class TripleDES extends DES
     /**
      * Encrypts a message.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::encrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::encrypt()
      * @access public
      * @param string $plaintext
      * @return string $cipertext
@@ -311,7 +311,7 @@ class TripleDES extends DES
     /**
      * Decrypts a message.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::decrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::decrypt()
      * @access public
      * @param string $ciphertext
      * @return string $plaintext
@@ -362,12 +362,12 @@ class TripleDES extends DES
      * outputs.  The reason is due to the fact that the initialization vector's change after every encryption /
      * decryption round when the continuous buffer is enabled.  When it's disabled, they remain constant.
      *
-     * Put another way, when the continuous buffer is enabled, the state of the \phpseclib\Crypt\DES() object changes after each
+     * Put another way, when the continuous buffer is enabled, the state of the \phpseclib3\Crypt\DES() object changes after each
      * encryption / decryption round, whereas otherwise, it'd remain constant.  For this reason, it's recommended that
      * continuous buffers not be used.  They do offer better security and are, in fact, sometimes required (SSH uses them),
      * however, they are also less intuitive and more likely to cause you problems.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::enableContinuousBuffer()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::enableContinuousBuffer()
      * @see self::disableContinuousBuffer()
      * @access public
      */
@@ -386,7 +386,7 @@ class TripleDES extends DES
      *
      * The default behavior.
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::disableContinuousBuffer()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::disableContinuousBuffer()
      * @see self::enableContinuousBuffer()
      * @access public
      */
@@ -403,8 +403,8 @@ class TripleDES extends DES
     /**
      * Creates the key schedule
      *
-     * @see \phpseclib\Crypt\DES::setupKey()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setupKey()
+     * @see \phpseclib3\Crypt\DES::setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setupKey()
      * @access private
      */
     protected function setupKey()
@@ -438,8 +438,8 @@ class TripleDES extends DES
     /**
      * Sets the internal crypt engine
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::__construct()
-     * @see \phpseclib\Crypt\Common\SymmetricKey::setPreferredEngine()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::__construct()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::setPreferredEngine()
      * @param int $engine
      * @access public
      */

--- a/phpseclib/Crypt/Twofish.php
+++ b/phpseclib/Crypt/Twofish.php
@@ -16,7 +16,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $twofish = new \phpseclib\Crypt\Twofish();
+ *    $twofish = new \phpseclib3\Crypt\Twofish();
  *
  *    $twofish->setKey('12345678901234567890123456789012');
  *
@@ -35,10 +35,10 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Crypt;
+namespace phpseclib3\Crypt;
 
-use phpseclib\Crypt\Common\BlockCipher;
-use phpseclib\Exception\BadModeException;
+use phpseclib3\Crypt\Common\BlockCipher;
+use phpseclib3\Exception\BadModeException;
 
 /**
  * Pure-PHP implementation of Twofish.
@@ -53,7 +53,7 @@ class Twofish extends BlockCipher
     /**
      * The mcrypt specific name of the cipher
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cipher_name_mcrypt
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cipher_name_mcrypt
      * @var string
      * @access private
      */
@@ -62,7 +62,7 @@ class Twofish extends BlockCipher
     /**
      * Optimizing value while CFB-encrypting
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::cfb_init_len
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::cfb_init_len
      * @var int
      * @access private
      */
@@ -436,7 +436,7 @@ class Twofish extends BlockCipher
     /**
      * Setup the key (expansion)
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupKey()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::_setupKey()
      * @access private
      */
     protected function setupKey()
@@ -709,7 +709,7 @@ class Twofish extends BlockCipher
     /**
      * Setup the performance-optimized function for de/encrypt()
      *
-     * @see \phpseclib\Crypt\Common\SymmetricKey::_setupInlineCrypt()
+     * @see \phpseclib3\Crypt\Common\SymmetricKey::_setupInlineCrypt()
      * @access private
      */
     protected function setupInlineCrypt()

--- a/phpseclib/Exception/BadConfigurationException.php
+++ b/phpseclib/Exception/BadConfigurationException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * BadConfigurationException

--- a/phpseclib/Exception/BadDecryptionException.php
+++ b/phpseclib/Exception/BadDecryptionException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * BadDecryptionException

--- a/phpseclib/Exception/BadModeException.php
+++ b/phpseclib/Exception/BadModeException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * BadModeException

--- a/phpseclib/Exception/ConnectionClosedException.php
+++ b/phpseclib/Exception/ConnectionClosedException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * ConnectionClosedException

--- a/phpseclib/Exception/FileNotFoundException.php
+++ b/phpseclib/Exception/FileNotFoundException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * FileNotFoundException

--- a/phpseclib/Exception/InconsistentSetupException.php
+++ b/phpseclib/Exception/InconsistentSetupException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * InconsistentSetupException

--- a/phpseclib/Exception/InsufficientSetupException.php
+++ b/phpseclib/Exception/InsufficientSetupException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * InsufficientSetupException

--- a/phpseclib/Exception/NoKeyLoadedException.php
+++ b/phpseclib/Exception/NoKeyLoadedException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * NoKeyLoadedException

--- a/phpseclib/Exception/NoSupportedAlgorithmsException.php
+++ b/phpseclib/Exception/NoSupportedAlgorithmsException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * NoSupportedAlgorithmsException

--- a/phpseclib/Exception/UnableToConnectException.php
+++ b/phpseclib/Exception/UnableToConnectException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * UnableToConnectException

--- a/phpseclib/Exception/UnsupportedAlgorithmException.php
+++ b/phpseclib/Exception/UnsupportedAlgorithmException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * UnsupportedAlgorithmException

--- a/phpseclib/Exception/UnsupportedCurveException.php
+++ b/phpseclib/Exception/UnsupportedCurveException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * UnsupportedCurveException

--- a/phpseclib/Exception/UnsupportedFormatException.php
+++ b/phpseclib/Exception/UnsupportedFormatException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * UnsupportedFormatException

--- a/phpseclib/Exception/UnsupportedOperationException.php
+++ b/phpseclib/Exception/UnsupportedOperationException.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Exception;
+namespace phpseclib3\Exception;
 
 /**
  * UnsupportedOperationException

--- a/phpseclib/File/ANSI.php
+++ b/phpseclib/File/ANSI.php
@@ -5,10 +5,10 @@
  *
  * PHP version 5
  *
- * If you call read() in \phpseclib\Net\SSH2 you may get {@link http://en.wikipedia.org/wiki/ANSI_escape_code ANSI escape codes} back.
+ * If you call read() in \phpseclib3\Net\SSH2 you may get {@link http://en.wikipedia.org/wiki/ANSI_escape_code ANSI escape codes} back.
  * They'd look like chr(0x1B) . '[00m' or whatever (0x1B = ESC).  They tell a
  * {@link http://en.wikipedia.org/wiki/Terminal_emulator terminal emulator} how to format the characters, what
- * color to display them in, etc. \phpseclib\File\ANSI is a {@link http://en.wikipedia.org/wiki/VT100 VT100} terminal emulator.
+ * color to display them in, etc. \phpseclib3\File\ANSI is a {@link http://en.wikipedia.org/wiki/VT100 VT100} terminal emulator.
  *
  * @category  File
  * @package   ANSI
@@ -18,7 +18,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File;
+namespace phpseclib3\File;
 
 /**
  * Pure-PHP ANSI Decoder
@@ -160,7 +160,7 @@ class ANSI
     /**
      * Default Constructor.
      *
-     * @return \phpseclib\File\ANSI
+     * @return \phpseclib3\File\ANSI
      * @access public
      */
     public function __construct()

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -9,7 +9,7 @@
  * utilized scheme is DER or the "Distinguished Encoding Rules".  PEM's are base64 encoded
  * DER blobs.
  *
- * \phpseclib\File\ASN1 decodes and encodes DER formatted messages and places them in a semantic context.
+ * \phpseclib3\File\ASN1 decodes and encodes DER formatted messages and places them in a semantic context.
  *
  * Uses the 1988 ASN.1 syntax.
  *
@@ -21,12 +21,12 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File;
+namespace phpseclib3\File;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib\File\ASN1\Element;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\File\ASN1\Element;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use DateTime;
 use DateTimeZone;
 
@@ -167,7 +167,7 @@ abstract class ASN1
     /**
      * Type mapping table for the ANY type.
      *
-     * Structured or unknown types are mapped to a \phpseclib\File\ASN1\Element.
+     * Structured or unknown types are mapped to a \phpseclib3\File\ASN1\Element.
      * Unambiguous types get the direct mapping (int/real/bool).
      * Others are mapped as a choice, with an extra indexing level.
      *
@@ -1325,7 +1325,7 @@ abstract class ASN1
     /**
      * Set filters
      *
-     * See \phpseclib\File\X509, etc, for an example.
+     * See \phpseclib3\File\X509, etc, for an example.
      * Previously loaded filters are not retained.
      *
      * @access public

--- a/phpseclib/File/ASN1/Element.php
+++ b/phpseclib/File/ASN1/Element.php
@@ -13,7 +13,7 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1;
+namespace phpseclib3\File\ASN1;
 
 /**
  * ASN.1 Raw Element
@@ -39,7 +39,7 @@ class Element
      * Constructor
      *
      * @param string $encoded
-     * @return \phpseclib\File\ASN1\Element
+     * @return \phpseclib3\File\ASN1\Element
      * @access public
      */
     public function __construct($encoded)

--- a/phpseclib/File/ASN1/Maps/AccessDescription.php
+++ b/phpseclib/File/ASN1/Maps/AccessDescription.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AccessDescription

--- a/phpseclib/File/ASN1/Maps/AdministrationDomainName.php
+++ b/phpseclib/File/ASN1/Maps/AdministrationDomainName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AdministrationDomainName
@@ -28,8 +28,8 @@ abstract class AdministrationDomainName
 {
     const MAP = [
         'type'     => ASN1::TYPE_CHOICE,
-        // if class isn't present it's assumed to be \phpseclib\File\ASN1::CLASS_UNIVERSAL or
-        // (if constant is present) \phpseclib\File\ASN1::CLASS_CONTEXT_SPECIFIC
+        // if class isn't present it's assumed to be \phpseclib3\File\ASN1::CLASS_UNIVERSAL or
+        // (if constant is present) \phpseclib3\File\ASN1::CLASS_CONTEXT_SPECIFIC
         'class'    => ASN1::CLASS_APPLICATION,
         'cast'     => 2,
         'children' => [

--- a/phpseclib/File/ASN1/Maps/AlgorithmIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/AlgorithmIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AlgorithmIdentifier

--- a/phpseclib/File/ASN1/Maps/AnotherName.php
+++ b/phpseclib/File/ASN1/Maps/AnotherName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AnotherName

--- a/phpseclib/File/ASN1/Maps/Attribute.php
+++ b/phpseclib/File/ASN1/Maps/Attribute.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Attribute

--- a/phpseclib/File/ASN1/Maps/AttributeType.php
+++ b/phpseclib/File/ASN1/Maps/AttributeType.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AttributeType

--- a/phpseclib/File/ASN1/Maps/AttributeTypeAndValue.php
+++ b/phpseclib/File/ASN1/Maps/AttributeTypeAndValue.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AttributeTypeAndValue

--- a/phpseclib/File/ASN1/Maps/AttributeValue.php
+++ b/phpseclib/File/ASN1/Maps/AttributeValue.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AttributeValue

--- a/phpseclib/File/ASN1/Maps/Attributes.php
+++ b/phpseclib/File/ASN1/Maps/Attributes.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Attributes

--- a/phpseclib/File/ASN1/Maps/AuthorityInfoAccessSyntax.php
+++ b/phpseclib/File/ASN1/Maps/AuthorityInfoAccessSyntax.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AuthorityInfoAccessSyntax

--- a/phpseclib/File/ASN1/Maps/AuthorityKeyIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/AuthorityKeyIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * AuthorityKeyIdentifier

--- a/phpseclib/File/ASN1/Maps/BaseDistance.php
+++ b/phpseclib/File/ASN1/Maps/BaseDistance.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * BaseDistance

--- a/phpseclib/File/ASN1/Maps/BasicConstraints.php
+++ b/phpseclib/File/ASN1/Maps/BasicConstraints.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * BasicConstraints

--- a/phpseclib/File/ASN1/Maps/BuiltInDomainDefinedAttribute.php
+++ b/phpseclib/File/ASN1/Maps/BuiltInDomainDefinedAttribute.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * BuiltInDomainDefinedAttribute

--- a/phpseclib/File/ASN1/Maps/BuiltInDomainDefinedAttributes.php
+++ b/phpseclib/File/ASN1/Maps/BuiltInDomainDefinedAttributes.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * BuiltInDomainDefinedAttributes

--- a/phpseclib/File/ASN1/Maps/BuiltInStandardAttributes.php
+++ b/phpseclib/File/ASN1/Maps/BuiltInStandardAttributes.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * BuiltInStandardAttributes

--- a/phpseclib/File/ASN1/Maps/CPSuri.php
+++ b/phpseclib/File/ASN1/Maps/CPSuri.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CPSuri

--- a/phpseclib/File/ASN1/Maps/CRLDistributionPoints.php
+++ b/phpseclib/File/ASN1/Maps/CRLDistributionPoints.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CRLDistributionPoints

--- a/phpseclib/File/ASN1/Maps/CRLNumber.php
+++ b/phpseclib/File/ASN1/Maps/CRLNumber.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CRLNumber

--- a/phpseclib/File/ASN1/Maps/CRLReason.php
+++ b/phpseclib/File/ASN1/Maps/CRLReason.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CRLReason

--- a/phpseclib/File/ASN1/Maps/CertPolicyId.php
+++ b/phpseclib/File/ASN1/Maps/CertPolicyId.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertPolicyId

--- a/phpseclib/File/ASN1/Maps/Certificate.php
+++ b/phpseclib/File/ASN1/Maps/Certificate.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Certificate

--- a/phpseclib/File/ASN1/Maps/CertificateIssuer.php
+++ b/phpseclib/File/ASN1/Maps/CertificateIssuer.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificateIssuer

--- a/phpseclib/File/ASN1/Maps/CertificateList.php
+++ b/phpseclib/File/ASN1/Maps/CertificateList.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificateList

--- a/phpseclib/File/ASN1/Maps/CertificatePolicies.php
+++ b/phpseclib/File/ASN1/Maps/CertificatePolicies.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificatePolicies

--- a/phpseclib/File/ASN1/Maps/CertificateSerialNumber.php
+++ b/phpseclib/File/ASN1/Maps/CertificateSerialNumber.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificateSerialNumber

--- a/phpseclib/File/ASN1/Maps/CertificationRequest.php
+++ b/phpseclib/File/ASN1/Maps/CertificationRequest.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificationRequest

--- a/phpseclib/File/ASN1/Maps/CertificationRequestInfo.php
+++ b/phpseclib/File/ASN1/Maps/CertificationRequestInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CertificationRequestInfo

--- a/phpseclib/File/ASN1/Maps/Characteristic_two.php
+++ b/phpseclib/File/ASN1/Maps/Characteristic_two.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Characteristic_two

--- a/phpseclib/File/ASN1/Maps/CountryName.php
+++ b/phpseclib/File/ASN1/Maps/CountryName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * CountryName
@@ -28,8 +28,8 @@ abstract class CountryName
 {
     const MAP = [
         'type'     => ASN1::TYPE_CHOICE,
-        // if class isn't present it's assumed to be \phpseclib\File\ASN1::CLASS_UNIVERSAL or
-        // (if constant is present) \phpseclib\File\ASN1::CLASS_CONTEXT_SPECIFIC
+        // if class isn't present it's assumed to be \phpseclib3\File\ASN1::CLASS_UNIVERSAL or
+        // (if constant is present) \phpseclib3\File\ASN1::CLASS_CONTEXT_SPECIFIC
         'class'    => ASN1::CLASS_APPLICATION,
         'cast'     => 1,
         'children' => [

--- a/phpseclib/File/ASN1/Maps/Curve.php
+++ b/phpseclib/File/ASN1/Maps/Curve.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Curve

--- a/phpseclib/File/ASN1/Maps/DHParameter.php
+++ b/phpseclib/File/ASN1/Maps/DHParameter.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DHParameter

--- a/phpseclib/File/ASN1/Maps/DSAParams.php
+++ b/phpseclib/File/ASN1/Maps/DSAParams.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DSAParams

--- a/phpseclib/File/ASN1/Maps/DSAPrivateKey.php
+++ b/phpseclib/File/ASN1/Maps/DSAPrivateKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DSAPrivateKey

--- a/phpseclib/File/ASN1/Maps/DSAPublicKey.php
+++ b/phpseclib/File/ASN1/Maps/DSAPublicKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DSAPublicKey

--- a/phpseclib/File/ASN1/Maps/DigestInfo.php
+++ b/phpseclib/File/ASN1/Maps/DigestInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DigestInfo

--- a/phpseclib/File/ASN1/Maps/DirectoryString.php
+++ b/phpseclib/File/ASN1/Maps/DirectoryString.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DirectoryString

--- a/phpseclib/File/ASN1/Maps/DisplayText.php
+++ b/phpseclib/File/ASN1/Maps/DisplayText.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DisplayText

--- a/phpseclib/File/ASN1/Maps/DistributionPoint.php
+++ b/phpseclib/File/ASN1/Maps/DistributionPoint.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DistributionPoint

--- a/phpseclib/File/ASN1/Maps/DistributionPointName.php
+++ b/phpseclib/File/ASN1/Maps/DistributionPointName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DistributionPointName

--- a/phpseclib/File/ASN1/Maps/DssSigValue.php
+++ b/phpseclib/File/ASN1/Maps/DssSigValue.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * DssSigValue

--- a/phpseclib/File/ASN1/Maps/ECParameters.php
+++ b/phpseclib/File/ASN1/Maps/ECParameters.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ECParameters

--- a/phpseclib/File/ASN1/Maps/ECPoint.php
+++ b/phpseclib/File/ASN1/Maps/ECPoint.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ECPoint

--- a/phpseclib/File/ASN1/Maps/ECPrivateKey.php
+++ b/phpseclib/File/ASN1/Maps/ECPrivateKey.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ECPrivateKey

--- a/phpseclib/File/ASN1/Maps/EDIPartyName.php
+++ b/phpseclib/File/ASN1/Maps/EDIPartyName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * EDIPartyName
@@ -34,7 +34,7 @@ abstract class EDIPartyName
                                 'optional' => true,
                                 'implicit' => true
                             ] + DirectoryString::MAP,
-             // partyName is technically required but \phpseclib\File\ASN1 doesn't currently support non-optional constants and
+             // partyName is technically required but \phpseclib3\File\ASN1 doesn't currently support non-optional constants and
              // setting it to optional gets the job done in any event.
              'partyName'    => [
                                 'constant' => 1,

--- a/phpseclib/File/ASN1/Maps/EcdsaSigValue.php
+++ b/phpseclib/File/ASN1/Maps/EcdsaSigValue.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * EcdsaSigValue

--- a/phpseclib/File/ASN1/Maps/EncryptedData.php
+++ b/phpseclib/File/ASN1/Maps/EncryptedData.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * EncryptedData

--- a/phpseclib/File/ASN1/Maps/EncryptedPrivateKeyInfo.php
+++ b/phpseclib/File/ASN1/Maps/EncryptedPrivateKeyInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * EncryptedPrivateKeyInfo

--- a/phpseclib/File/ASN1/Maps/ExtKeyUsageSyntax.php
+++ b/phpseclib/File/ASN1/Maps/ExtKeyUsageSyntax.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ExtKeyUsageSyntax

--- a/phpseclib/File/ASN1/Maps/Extension.php
+++ b/phpseclib/File/ASN1/Maps/Extension.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Extension

--- a/phpseclib/File/ASN1/Maps/ExtensionAttribute.php
+++ b/phpseclib/File/ASN1/Maps/ExtensionAttribute.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ExtensionAttribute

--- a/phpseclib/File/ASN1/Maps/ExtensionAttributes.php
+++ b/phpseclib/File/ASN1/Maps/ExtensionAttributes.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ExtensionAttributes

--- a/phpseclib/File/ASN1/Maps/Extensions.php
+++ b/phpseclib/File/ASN1/Maps/Extensions.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Extensions

--- a/phpseclib/File/ASN1/Maps/FieldElement.php
+++ b/phpseclib/File/ASN1/Maps/FieldElement.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * FieldElement

--- a/phpseclib/File/ASN1/Maps/FieldID.php
+++ b/phpseclib/File/ASN1/Maps/FieldID.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * FieldID

--- a/phpseclib/File/ASN1/Maps/GeneralName.php
+++ b/phpseclib/File/ASN1/Maps/GeneralName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * GeneralName

--- a/phpseclib/File/ASN1/Maps/GeneralNames.php
+++ b/phpseclib/File/ASN1/Maps/GeneralNames.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * GeneralNames

--- a/phpseclib/File/ASN1/Maps/GeneralSubtree.php
+++ b/phpseclib/File/ASN1/Maps/GeneralSubtree.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * GeneralSubtree

--- a/phpseclib/File/ASN1/Maps/GeneralSubtrees.php
+++ b/phpseclib/File/ASN1/Maps/GeneralSubtrees.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * GeneralSubtrees

--- a/phpseclib/File/ASN1/Maps/HashAlgorithm.php
+++ b/phpseclib/File/ASN1/Maps/HashAlgorithm.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * HashAglorithm

--- a/phpseclib/File/ASN1/Maps/HoldInstructionCode.php
+++ b/phpseclib/File/ASN1/Maps/HoldInstructionCode.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * HoldInstructionCode

--- a/phpseclib/File/ASN1/Maps/InvalidityDate.php
+++ b/phpseclib/File/ASN1/Maps/InvalidityDate.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * InvalidityDate

--- a/phpseclib/File/ASN1/Maps/IssuerAltName.php
+++ b/phpseclib/File/ASN1/Maps/IssuerAltName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * IssuerAltName

--- a/phpseclib/File/ASN1/Maps/IssuingDistributionPoint.php
+++ b/phpseclib/File/ASN1/Maps/IssuingDistributionPoint.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * IssuingDistributionPoint

--- a/phpseclib/File/ASN1/Maps/KeyIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/KeyIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * KeyIdentifier

--- a/phpseclib/File/ASN1/Maps/KeyPurposeId.php
+++ b/phpseclib/File/ASN1/Maps/KeyPurposeId.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * KeyPurposeId

--- a/phpseclib/File/ASN1/Maps/KeyUsage.php
+++ b/phpseclib/File/ASN1/Maps/KeyUsage.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * KeyUsage

--- a/phpseclib/File/ASN1/Maps/MaskGenAlgorithm.php
+++ b/phpseclib/File/ASN1/Maps/MaskGenAlgorithm.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * MaskGenAglorithm

--- a/phpseclib/File/ASN1/Maps/Name.php
+++ b/phpseclib/File/ASN1/Maps/Name.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Name

--- a/phpseclib/File/ASN1/Maps/NameConstraints.php
+++ b/phpseclib/File/ASN1/Maps/NameConstraints.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * NameConstraints

--- a/phpseclib/File/ASN1/Maps/NetworkAddress.php
+++ b/phpseclib/File/ASN1/Maps/NetworkAddress.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * NetworkAddress

--- a/phpseclib/File/ASN1/Maps/NoticeReference.php
+++ b/phpseclib/File/ASN1/Maps/NoticeReference.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * NoticeReference

--- a/phpseclib/File/ASN1/Maps/NumericUserIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/NumericUserIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * NumericUserIdentifier

--- a/phpseclib/File/ASN1/Maps/ORAddress.php
+++ b/phpseclib/File/ASN1/Maps/ORAddress.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ORAddress

--- a/phpseclib/File/ASN1/Maps/OneAsymmetricKey.php
+++ b/phpseclib/File/ASN1/Maps/OneAsymmetricKey.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * OneAsymmetricKey

--- a/phpseclib/File/ASN1/Maps/OrganizationName.php
+++ b/phpseclib/File/ASN1/Maps/OrganizationName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * OrganizationName

--- a/phpseclib/File/ASN1/Maps/OrganizationalUnitNames.php
+++ b/phpseclib/File/ASN1/Maps/OrganizationalUnitNames.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * OrganizationalUnitNames

--- a/phpseclib/File/ASN1/Maps/OtherPrimeInfo.php
+++ b/phpseclib/File/ASN1/Maps/OtherPrimeInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * OtherPrimeInfo

--- a/phpseclib/File/ASN1/Maps/OtherPrimeInfos.php
+++ b/phpseclib/File/ASN1/Maps/OtherPrimeInfos.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * OtherPrimeInfos

--- a/phpseclib/File/ASN1/Maps/PBEParameter.php
+++ b/phpseclib/File/ASN1/Maps/PBEParameter.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PBEParameter

--- a/phpseclib/File/ASN1/Maps/PBES2params.php
+++ b/phpseclib/File/ASN1/Maps/PBES2params.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PBES2params

--- a/phpseclib/File/ASN1/Maps/PBKDF2params.php
+++ b/phpseclib/File/ASN1/Maps/PBKDF2params.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PBKDF2params

--- a/phpseclib/File/ASN1/Maps/PBMAC1params.php
+++ b/phpseclib/File/ASN1/Maps/PBMAC1params.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PBMAC1params

--- a/phpseclib/File/ASN1/Maps/PKCS9String.php
+++ b/phpseclib/File/ASN1/Maps/PKCS9String.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PKCS9String 

--- a/phpseclib/File/ASN1/Maps/Pentanomial.php
+++ b/phpseclib/File/ASN1/Maps/Pentanomial.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Pentanomial

--- a/phpseclib/File/ASN1/Maps/PersonalName.php
+++ b/phpseclib/File/ASN1/Maps/PersonalName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PersonalName

--- a/phpseclib/File/ASN1/Maps/PolicyInformation.php
+++ b/phpseclib/File/ASN1/Maps/PolicyInformation.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PolicyInformation

--- a/phpseclib/File/ASN1/Maps/PolicyMappings.php
+++ b/phpseclib/File/ASN1/Maps/PolicyMappings.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PolicyMappings

--- a/phpseclib/File/ASN1/Maps/PolicyQualifierId.php
+++ b/phpseclib/File/ASN1/Maps/PolicyQualifierId.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PolicyQualifierId

--- a/phpseclib/File/ASN1/Maps/PolicyQualifierInfo.php
+++ b/phpseclib/File/ASN1/Maps/PolicyQualifierInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PolicyQualifierInfo

--- a/phpseclib/File/ASN1/Maps/PostalAddress.php
+++ b/phpseclib/File/ASN1/Maps/PostalAddress.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PostalAddress

--- a/phpseclib/File/ASN1/Maps/Prime_p.php
+++ b/phpseclib/File/ASN1/Maps/Prime_p.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Prime_p

--- a/phpseclib/File/ASN1/Maps/PrivateDomainName.php
+++ b/phpseclib/File/ASN1/Maps/PrivateDomainName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PrivateDomainName

--- a/phpseclib/File/ASN1/Maps/PrivateKey.php
+++ b/phpseclib/File/ASN1/Maps/PrivateKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PrivateKey

--- a/phpseclib/File/ASN1/Maps/PrivateKeyInfo.php
+++ b/phpseclib/File/ASN1/Maps/PrivateKeyInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PrivateKeyInfo

--- a/phpseclib/File/ASN1/Maps/PrivateKeyUsagePeriod.php
+++ b/phpseclib/File/ASN1/Maps/PrivateKeyUsagePeriod.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PrivateKeyUsagePeriod

--- a/phpseclib/File/ASN1/Maps/PublicKey.php
+++ b/phpseclib/File/ASN1/Maps/PublicKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PublicKey

--- a/phpseclib/File/ASN1/Maps/PublicKeyAndChallenge.php
+++ b/phpseclib/File/ASN1/Maps/PublicKeyAndChallenge.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PublicKeyAndChallenge

--- a/phpseclib/File/ASN1/Maps/PublicKeyInfo.php
+++ b/phpseclib/File/ASN1/Maps/PublicKeyInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * PublicKeyInfo

--- a/phpseclib/File/ASN1/Maps/RC2CBCParameter.php
+++ b/phpseclib/File/ASN1/Maps/RC2CBCParameter.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RC2CBCParameter

--- a/phpseclib/File/ASN1/Maps/RDNSequence.php
+++ b/phpseclib/File/ASN1/Maps/RDNSequence.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RDNSequence

--- a/phpseclib/File/ASN1/Maps/RSAPrivateKey.php
+++ b/phpseclib/File/ASN1/Maps/RSAPrivateKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RSAPrivateKey

--- a/phpseclib/File/ASN1/Maps/RSAPublicKey.php
+++ b/phpseclib/File/ASN1/Maps/RSAPublicKey.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RSAPublicKey

--- a/phpseclib/File/ASN1/Maps/RSASSA_PSS_params.php
+++ b/phpseclib/File/ASN1/Maps/RSASSA_PSS_params.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RSASSA_PSS_params

--- a/phpseclib/File/ASN1/Maps/ReasonFlags.php
+++ b/phpseclib/File/ASN1/Maps/ReasonFlags.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * ReasonFlags

--- a/phpseclib/File/ASN1/Maps/RelativeDistinguishedName.php
+++ b/phpseclib/File/ASN1/Maps/RelativeDistinguishedName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RelativeDistinguishedName

--- a/phpseclib/File/ASN1/Maps/RevokedCertificate.php
+++ b/phpseclib/File/ASN1/Maps/RevokedCertificate.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * RevokedCertificate

--- a/phpseclib/File/ASN1/Maps/SignedPublicKeyAndChallenge.php
+++ b/phpseclib/File/ASN1/Maps/SignedPublicKeyAndChallenge.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SignedPublicKeyAndChallenge

--- a/phpseclib/File/ASN1/Maps/SpecifiedECDomain.php
+++ b/phpseclib/File/ASN1/Maps/SpecifiedECDomain.php
@@ -15,9 +15,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SpecifiedECDomain

--- a/phpseclib/File/ASN1/Maps/SubjectAltName.php
+++ b/phpseclib/File/ASN1/Maps/SubjectAltName.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SubjectAltName

--- a/phpseclib/File/ASN1/Maps/SubjectDirectoryAttributes.php
+++ b/phpseclib/File/ASN1/Maps/SubjectDirectoryAttributes.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SubjectDirectoryAttributes

--- a/phpseclib/File/ASN1/Maps/SubjectInfoAccessSyntax.php
+++ b/phpseclib/File/ASN1/Maps/SubjectInfoAccessSyntax.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SubjectInfoAccessSyntax

--- a/phpseclib/File/ASN1/Maps/SubjectPublicKeyInfo.php
+++ b/phpseclib/File/ASN1/Maps/SubjectPublicKeyInfo.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * SubjectPublicKeyInfo

--- a/phpseclib/File/ASN1/Maps/TBSCertList.php
+++ b/phpseclib/File/ASN1/Maps/TBSCertList.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * TBSCertList

--- a/phpseclib/File/ASN1/Maps/TBSCertificate.php
+++ b/phpseclib/File/ASN1/Maps/TBSCertificate.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * TBSCertificate

--- a/phpseclib/File/ASN1/Maps/TerminalIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/TerminalIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * TerminalIdentifier

--- a/phpseclib/File/ASN1/Maps/Time.php
+++ b/phpseclib/File/ASN1/Maps/Time.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Time

--- a/phpseclib/File/ASN1/Maps/Trinomial.php
+++ b/phpseclib/File/ASN1/Maps/Trinomial.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Trinomial

--- a/phpseclib/File/ASN1/Maps/UniqueIdentifier.php
+++ b/phpseclib/File/ASN1/Maps/UniqueIdentifier.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * UniqueIdentifier

--- a/phpseclib/File/ASN1/Maps/UserNotice.php
+++ b/phpseclib/File/ASN1/Maps/UserNotice.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * UserNotice

--- a/phpseclib/File/ASN1/Maps/Validity.php
+++ b/phpseclib/File/ASN1/Maps/Validity.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * Validity

--- a/phpseclib/File/ASN1/Maps/netscape_ca_policy_url.php
+++ b/phpseclib/File/ASN1/Maps/netscape_ca_policy_url.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * netscape_ca_policy_url

--- a/phpseclib/File/ASN1/Maps/netscape_cert_type.php
+++ b/phpseclib/File/ASN1/Maps/netscape_cert_type.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * netscape_cert_type

--- a/phpseclib/File/ASN1/Maps/netscape_comment.php
+++ b/phpseclib/File/ASN1/Maps/netscape_comment.php
@@ -13,9 +13,9 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File\ASN1\Maps;
+namespace phpseclib3\File\ASN1\Maps;
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 /**
  * netscape_comment

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -24,21 +24,21 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\File;
+namespace phpseclib3\File;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\EC;
-use phpseclib\Crypt\Common\PublicKey;
-use phpseclib\Crypt\Common\PrivateKey;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\File\ASN1\Element;
-use phpseclib\Math\BigInteger;
-use phpseclib\File\ASN1\Maps;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\Common\PublicKey;
+use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\File\ASN1\Element;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\File\ASN1\Maps;
 use DateTime;
 use DateTimeZone;
 
@@ -62,7 +62,7 @@ class X509
 
     /**#@+
      * @access public
-     * @see \phpseclib\File\X509::getDN()
+     * @see \phpseclib3\File\X509::getDN()
     */
     /**
      * Return internal array representation
@@ -92,9 +92,9 @@ class X509
 
     /**#@+
      * @access public
-     * @see \phpseclib\File\X509::saveX509()
-     * @see \phpseclib\File\X509::saveCSR()
-     * @see \phpseclib\File\X509::saveCRL()
+     * @see \phpseclib3\File\X509::saveX509()
+     * @see \phpseclib3\File\X509::saveCSR()
+     * @see \phpseclib3\File\X509::saveCRL()
     */
     /**
      * Save as PEM
@@ -180,7 +180,7 @@ class X509
     /**
      * The signature subject
      *
-     * There's no guarantee \phpseclib\File\X509 is going to re-encode an X.509 cert in the same way it was originally
+     * There's no guarantee \phpseclib3\File\X509 is going to re-encode an X.509 cert in the same way it was originally
      * encoded so we take save the portion of the original cert that the signature would have made for.
      *
      * @var string
@@ -266,7 +266,7 @@ class X509
     /**
      * Default Constructor.
      *
-     * @return \phpseclib\File\X509
+     * @return \phpseclib3\File\X509
      * @access public
      */
     public function __construct()
@@ -530,8 +530,8 @@ class X509
         $filters['distributionPoint']['fullName']['directoryName']['rdnSequence']['value'] = $type_utf8_string;
         $filters['directoryName']['rdnSequence']['value'] = $type_utf8_string;
 
-        /* in the case of policyQualifiers/qualifier, the type has to be \phpseclib\File\ASN1::TYPE_IA5_STRING.
-           \phpseclib\File\ASN1::TYPE_PRINTABLE_STRING will cause OpenSSL's X.509 parser to spit out random
+        /* in the case of policyQualifiers/qualifier, the type has to be \phpseclib3\File\ASN1::TYPE_IA5_STRING.
+           \phpseclib3\File\ASN1::TYPE_PRINTABLE_STRING will cause OpenSSL's X.509 parser to spit out random
            characters.
          */
         $filters['policyQualifiers']['qualifier']
@@ -636,8 +636,8 @@ class X509
                                 $map = $this->getMapping($subid);
                                 $subvalue = &$value[$j]['policyQualifiers'][$k]['qualifier'];
                                 if ($map !== false) {
-                                    // by default \phpseclib\File\ASN1 will try to render qualifier as a \phpseclib\File\ASN1::TYPE_IA5_STRING since it's
-                                    // actual type is \phpseclib\File\ASN1::TYPE_ANY
+                                    // by default \phpseclib3\File\ASN1 will try to render qualifier as a \phpseclib3\File\ASN1::TYPE_IA5_STRING since it's
+                                    // actual type is \phpseclib3\File\ASN1::TYPE_ANY
                                     $subvalue = new Element(ASN1::encodeDER($subvalue, $map));
                                 }
                             }
@@ -818,7 +818,7 @@ class X509
      */
     private function getMapping($extnId)
     {
-        if (!is_string($extnId)) { // eg. if it's a \phpseclib\File\ASN1\Element object
+        if (!is_string($extnId)) { // eg. if it's a \phpseclib3\File\ASN1\Element object
             return true;
         }
 
@@ -1354,7 +1354,7 @@ class X509
      * @param string $signature
      * @param string $signatureSubject
      * @access private
-     * @throws \phpseclib\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
+     * @throws \phpseclib3\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
      * @return bool
      */
     private function validateSignatureHelper($publicKeyAlgorithm, $publicKey, $signatureAlgorithm, $signature, $signatureSubject)
@@ -2044,7 +2044,7 @@ class X509
     /**
      * Set public key
      *
-     * Key needs to be a \phpseclib\Crypt\RSA object
+     * Key needs to be a \phpseclib3\Crypt\RSA object
      *
      * @param object $key
      * @access public
@@ -2058,7 +2058,7 @@ class X509
     /**
      * Set private key
      *
-     * Key needs to be a \phpseclib\Crypt\RSA object
+     * Key needs to be a \phpseclib3\Crypt\RSA object
      *
      * @param object $key
      * @access public
@@ -2084,7 +2084,7 @@ class X509
     /**
      * Gets the public key
      *
-     * Returns a \phpseclib\Crypt\RSA object or a false.
+     * Returns a \phpseclib3\Crypt\RSA object or a false.
      *
      * @access public
      * @return mixed
@@ -2501,8 +2501,8 @@ class X509
      * $subject can be either an existing X.509 cert (if you want to resign it),
      * a CSR or something with the DN and public key explicitly set.
      *
-     * @param \phpseclib\File\X509 $issuer
-     * @param \phpseclib\File\X509 $subject
+     * @param \phpseclib3\File\X509 $issuer
+     * @param \phpseclib3\File\X509 $subject
      * @param string $signatureAlgorithm optional
      * @access public
      * @return mixed
@@ -2620,7 +2620,7 @@ class X509
         $altName = [];
 
         if (isset($subject->domains) && count($subject->domains)) {
-            $altName = array_map(['\phpseclib\File\X509', 'dnsName'], $subject->domains);
+            $altName = array_map(['\phpseclib3\File\X509', 'dnsName'], $subject->domains);
         }
 
         if (isset($subject->ipAddresses) && count($subject->ipAddresses)) {
@@ -2670,7 +2670,7 @@ class X509
         }
 
         // resync $this->signatureSubject
-        // save $tbsCertificate in case there are any \phpseclib\File\ASN1\Element objects in it
+        // save $tbsCertificate in case there are any \phpseclib3\File\ASN1\Element objects in it
         $tbsCertificate = $this->currentCert['tbsCertificate'];
         $this->loadX509($this->saveX509($this->currentCert));
 
@@ -2726,7 +2726,7 @@ class X509
         }
 
         // resync $this->signatureSubject
-        // save $certificationRequestInfo in case there are any \phpseclib\File\ASN1\Element objects in it
+        // save $certificationRequestInfo in case there are any \phpseclib3\File\ASN1\Element objects in it
         $certificationRequestInfo = $this->currentCert['certificationRequestInfo'];
         $this->loadCSR($this->saveCSR($this->currentCert));
 
@@ -2788,7 +2788,7 @@ class X509
         }
 
         // resync $this->signatureSubject
-        // save $publicKeyAndChallenge in case there are any \phpseclib\File\ASN1\Element objects in it
+        // save $publicKeyAndChallenge in case there are any \phpseclib3\File\ASN1\Element objects in it
         $publicKeyAndChallenge = $this->currentCert['publicKeyAndChallenge'];
         $this->loadSPKAC($this->saveSPKAC($this->currentCert));
 
@@ -2807,8 +2807,8 @@ class X509
      *
      * $issuer's private key needs to be loaded.
      *
-     * @param \phpseclib\File\X509 $issuer
-     * @param \phpseclib\File\X509 $crl
+     * @param \phpseclib3\File\X509 $issuer
+     * @param \phpseclib3\File\X509 $crl
      * @param string $signatureAlgorithm optional
      * @access public
      * @return mixed
@@ -2923,7 +2923,7 @@ class X509
         unset($tbsCertList);
 
         // resync $this->signatureSubject
-        // save $tbsCertList in case there are any \phpseclib\File\ASN1\Element objects in it
+        // save $tbsCertList in case there are any \phpseclib3\File\ASN1\Element objects in it
         $tbsCertList = $this->currentCert['tbsCertList'];
         $this->loadCRL($this->saveCRL($this->currentCert));
 
@@ -2942,7 +2942,7 @@ class X509
      *
      * @param object $key
      * @access private
-     * @throws \phpseclib\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
+     * @throws \phpseclib3\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
      * @return string
      */
     private static function identifySignatureAlgorithm(PrivateKey $key)
@@ -3590,9 +3590,9 @@ class X509
      * recommended methods (4.2.1.2 RFC 3280).
      * Highly polymorphic: try to accept all possible forms of key:
      * - Key object
-     * - \phpseclib\File\X509 object with public or private key defined
+     * - \phpseclib3\File\X509 object with public or private key defined
      * - Certificate or CSR array
-     * - \phpseclib\File\ASN1\Element object
+     * - \phpseclib3\File\ASN1\Element object
      * - PEM or DER string
      *
      * @param mixed $key optional
@@ -3646,7 +3646,7 @@ class X509
                     return $this->computeKeyIdentifier($key->currentCert, $method);
                 }
                 return false;
-            default: // Should be a key object (i.e.: \phpseclib\Crypt\RSA).
+            default: // Should be a key object (i.e.: \phpseclib3\Crypt\RSA).
                 $key = $key->getPublicKey();
                 break;
         }

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -11,8 +11,8 @@
  * Here's an example of how to use this library:
  * <code>
  * <?php
- *    $a = new \phpseclib\Math\BigInteger(2);
- *    $b = new \phpseclib\Math\BigInteger(3);
+ *    $a = new \phpseclib3\Math\BigInteger(2);
+ *    $b = new \phpseclib3\Math\BigInteger(3);
  *
  *    $c = $a->add($b);
  *
@@ -27,9 +27,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math;
+namespace phpseclib3\Math;
 
-use phpseclib\Exception\BadConfigurationException;
+use phpseclib3\Exception\BadConfigurationException;
 
 /**
  * Pure-PHP arbitrary precision integer arithmetic library. Supports base-2, base-10, base-16, and base-256
@@ -81,7 +81,7 @@ class BigInteger implements \Serializable
     {
         self::$engines = [];
 
-        $fqmain = 'phpseclib\\Math\\BigInteger\\Engines\\' . $main;
+        $fqmain = 'phpseclib3\\Math\\BigInteger\\Engines\\' . $main;
         if (!class_exists($fqmain) || !method_exists($fqmain, 'isValidEngine')) {
             throw new \InvalidArgumentException("$main is not a valid engine");
         }
@@ -279,8 +279,8 @@ class BigInteger implements \Serializable
      * Here's an example:
      * <code>
      * <?php
-     *    $a = new \phpseclib\Math\BigInteger('10');
-     *    $b = new \phpseclib\Math\BigInteger('20');
+     *    $a = new \phpseclib3\Math\BigInteger('10');
+     *    $b = new \phpseclib3\Math\BigInteger('20');
      *
      *    list($quotient, $remainder) = $a->divide($b);
      *
@@ -852,7 +852,7 @@ class BigInteger implements \Serializable
      * Splits BigInteger's into chunks of $split bits
      *
      * @param int $split
-     * @return \phpseclib\Math\BigInteger[]
+     * @return \phpseclib3\Math\BigInteger[]
      */
     public function bitwise_split($split)
     {

--- a/phpseclib/Math/BigInteger/Engines/BCMath.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Exception\BadConfigurationException;
+use phpseclib3\Exception\BadConfigurationException;
 
 /**
  * BCMath Engine.
@@ -61,21 +61,21 @@ class BCMath extends Engine
     /**
      * BigInteger(0)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\BCMath
+     * @var \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     protected static $zero;
 
     /**
      * BigInteger(1)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\BCMath
+     * @var \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     protected static $one;
 
     /**
      * BigInteger(2)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\BCMath
+     * @var \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     protected static $two;
 
@@ -103,7 +103,7 @@ class BCMath extends Engine
      * @param mixed $x integer Base-10 number or base-$base number if $base set.
      * @param int $base
      * @see parent::__construct()
-     * @return \phpseclib\Math\BigInteger\Engines\BCMath
+     * @return \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     public function __construct($x = 0, $base = 10)
     {
@@ -275,7 +275,7 @@ class BCMath extends Engine
      * Say you have (30 mod 17 * x mod 17) mod 17 == 1.  x can be found using modular inverses.
      *
      * @return false|BCMath
-     * @param \phpseclib\Math\BigInteger\Engines\BCMath $n
+     * @param \phpseclib3\Math\BigInteger\Engines\BCMath $n
      */
     public function modInverse(BCMath $n)
     {
@@ -348,7 +348,7 @@ class BCMath extends Engine
     /**
      * Absolute value.
      *
-     * @return \phpseclib\Math\BigInteger\Engines\BCMath
+     * @return \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     public function abs()
     {
@@ -399,7 +399,7 @@ class BCMath extends Engine
      * Shifts BigInteger's by $shift bits, effectively dividing by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\BCMath
+     * @return \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     public function bitwise_rightShift($shift)
     {
@@ -415,7 +415,7 @@ class BCMath extends Engine
      * Shifts BigInteger's by $shift bits, effectively multiplying by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\BCMath
+     * @return \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     public function bitwise_leftShift($shift)
     {

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Base.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Base.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath;
 
-use phpseclib\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\BCMath;
 
 /**
  * Sliding Window Exponentiation Engine
@@ -54,11 +54,11 @@ abstract class Base extends BCMath
     /**
      * Performs modular exponentiation.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\BCMath $x
-     * @param \phpseclib\Math\BigInteger\Engines\BCMath $e
-     * @param \phpseclib\Math\BigInteger\Engines\BCMath $n
+     * @param \phpseclib3\Math\BigInteger\Engines\BCMath $x
+     * @param \phpseclib3\Math\BigInteger\Engines\BCMath $e
+     * @param \phpseclib3\Math\BigInteger\Engines\BCMath $n
      * @param string $class
-     * @return \phpseclib\Math\BigInteger\Engines\BCMath
+     * @return \phpseclib3\Math\BigInteger\Engines\BCMath
      */
     protected static function powModHelper(BCMath $x, BCMath $e, BCMath $n, $class)
     {

--- a/phpseclib/Math/BigInteger/Engines/BCMath/BuiltIn.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/BuiltIn.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath;
 
-use phpseclib\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\BCMath;
 
 /**
  * Built-In BCMath Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/BCMath/DefaultEngine.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/DefaultEngine.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath;
 
-use phpseclib\Math\BigInteger\Engines\BCMath\Reductions\Barrett;
+use phpseclib3\Math\BigInteger\Engines\BCMath\Reductions\Barrett;
 
 /**
  * PHP Default Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/BCMath/OpenSSL.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/OpenSSL.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath;
 
-use phpseclib\Math\BigInteger\Engines\OpenSSL as Progenitor;
+use phpseclib3\Math\BigInteger\Engines\OpenSSL as Progenitor;
 
 /**
  * OpenSSL Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\BCMath\Base;
+use phpseclib3\Math\BigInteger\Engines\BCMath\Base;
 
 /**
  * PHP Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\BCMath\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\BCMath\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\BCMath\Base;
-use phpseclib\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\BCMath\Base;
+use phpseclib3\Math\BigInteger\Engines\BCMath;
 
 /**
  * PHP Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -13,13 +13,13 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Exception\BadConfigurationException;
-use phpseclib\Crypt\Random;
-use phpseclib\Math\BigInteger;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Exception\BadConfigurationException;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Base Engine.
@@ -180,7 +180,7 @@ abstract class Engine implements \Serializable
      */
     public static function setModExpEngine($engine)
     {
-        $fqengine = '\\phpseclib\\Math\\BigInteger\\Engines\\' . static::ENGINE_DIR . '\\' . $engine;
+        $fqengine = '\\phpseclib3\\Math\\BigInteger\\Engines\\' . static::ENGINE_DIR . '\\' . $engine;
         if (!class_exists($fqengine) || !method_exists($fqengine, 'isValidEngine')) {
             throw new \InvalidArgumentException("$engine is not a valid engine");
         }
@@ -257,8 +257,8 @@ abstract class Engine implements \Serializable
      *
      * Say you have (30 mod 17 * x mod 17) mod 17 == 1.  x can be found using modular inverses.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $n
-     * @return \phpseclib\Math\BigInteger\Engines\Engine|false
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $n
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine|false
      * @internal See {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf#page=21 HAC 14.64} for more information.
      */
     protected function modInverseHelper(Engine $n)
@@ -463,7 +463,7 @@ abstract class Engine implements \Serializable
      * Instead of the top x bits being dropped they're appended to the shifted bit string.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     public function bitwise_leftRotate($shift)
     {
@@ -507,7 +507,7 @@ abstract class Engine implements \Serializable
      * Instead of the bottom x bits being dropped they're prepended to the shifted bit string.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     public function bitwise_rightRotate($shift)
     {
@@ -518,7 +518,7 @@ abstract class Engine implements \Serializable
      * Returns the smallest and largest n-bit number
      *
      * @param int $bits
-     * @return \phpseclib\Math\BigInteger\Engines\Engine[]
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine[]
      */
     public static function minMaxBits($bits)
     {
@@ -591,11 +591,11 @@ abstract class Engine implements \Serializable
      * however, this function performs a modular reduction after every multiplication and squaring operation.
      * As such, this function has the same preconditions that the reductions being used do.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $x
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $e
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $n
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $x
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $e
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $n
      * @param string $class
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     protected static function slidingWindow(Engine $x, Engine $e, Engine $n, $class)
     {
@@ -666,7 +666,7 @@ abstract class Engine implements \Serializable
      * Bit length is equal to $size
      *
      * @param int $size
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     public static function random($size)
     {
@@ -684,7 +684,7 @@ abstract class Engine implements \Serializable
      * Bit length is equal to $size
      *
      * @param int $size
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     public static function randomPrime($size)
     {
@@ -930,7 +930,7 @@ abstract class Engine implements \Serializable
      * Performs a few preliminary checks on root
      *
      * @param int $n
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     protected function rootHelper($n)
     {
@@ -953,7 +953,7 @@ abstract class Engine implements \Serializable
      * Returns the nth root of a positive biginteger, where n defaults to 2
      *
      * @param int $n
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      * @internal This function is based off of {@link http://mathforum.org/library/drmath/view/52605.html this page} and {@link http://stackoverflow.com/questions/11242920/calculating-nth-root-with-bcmath-in-php this stackoverflow question}.
      */
     protected function rootInner($n)
@@ -1068,7 +1068,7 @@ abstract class Engine implements \Serializable
         $class = static::class;
 
         $fqengine = !method_exists(static::$modexpEngine, 'reduce') ?
-            '\\phpseclib\\Math\\BigInteger\\Engines\\' . static::ENGINE_DIR . '\\DefaultEngine' :
+            '\\phpseclib3\\Math\\BigInteger\\Engines\\' . static::ENGINE_DIR . '\\DefaultEngine' :
             static::$modexpEngine;
         if (method_exists($fqengine, 'generateCustomReduction')) {
             $func = $fqengine::generateCustomReduction($this, static::class);
@@ -1136,7 +1136,7 @@ abstract class Engine implements \Serializable
      * Splits BigInteger's into chunks of $split bits
      *
      * @param int $split
-     * @return \phpseclib\Math\BigInteger\Engine[]
+     * @return \phpseclib3\Math\BigInteger\Engine[]
      */
     public function bitwise_split($split)
     {

--- a/phpseclib/Math/BigInteger/Engines/GMP.php
+++ b/phpseclib/Math/BigInteger/Engines/GMP.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Exception\BadConfigurationException;
+use phpseclib3\Exception\BadConfigurationException;
 
 /**
  * GMP Engine.
@@ -61,21 +61,21 @@ class GMP extends Engine
     /**
      * BigInteger(0)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\GMP
+     * @var \phpseclib3\Math\BigInteger\Engines\GMP
      */
     protected static $zero;
 
     /**
      * BigInteger(1)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\GMP
+     * @var \phpseclib3\Math\BigInteger\Engines\GMP
      */
     protected static $one;
 
     /**
      * BigInteger(2)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\GMP
+     * @var \phpseclib3\Math\BigInteger\Engines\GMP
      */
     protected static $two;
 
@@ -105,7 +105,7 @@ class GMP extends Engine
      * @param mixed $x integer Base-10 number or base-$base number if $base set.
      * @param int $base
      * @see parent::__construct()
-     * @return \phpseclib\Math\BigInteger\Engines\GMP
+     * @return \phpseclib3\Math\BigInteger\Engines\GMP
      */
     public function __construct($x = 0, $base = 10)
     {
@@ -343,8 +343,8 @@ class GMP extends Engine
      * combination is returned is dependent upon which mode is in use.  See
      * {@link http://en.wikipedia.org/wiki/B%C3%A9zout%27s_identity Bezout's identity - Wikipedia} for more information.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\GMP $n
-     * @return \phpseclib\Math\BigInteger\Engines\GMP[]
+     * @param \phpseclib3\Math\BigInteger\Engines\GMP $n
+     * @return \phpseclib3\Math\BigInteger\Engines\GMP[]
      */
     public function extendedGCD(GMP $n)
     {
@@ -374,7 +374,7 @@ class GMP extends Engine
     /**
      * Absolute value.
      *
-     * @return \phpseclib\Math\BigInteger\Engines\GMP
+     * @return \phpseclib3\Math\BigInteger\Engines\GMP
      * @access public
      */
     public function abs()
@@ -433,7 +433,7 @@ class GMP extends Engine
      * Shifts BigInteger's by $shift bits, effectively dividing by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\GMP
+     * @return \phpseclib3\Math\BigInteger\Engines\GMP
      */
     public function bitwise_rightShift($shift)
     {
@@ -452,7 +452,7 @@ class GMP extends Engine
      * Shifts BigInteger's by $shift bits, effectively multiplying by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\GMP
+     * @return \phpseclib3\Math\BigInteger\Engines\GMP
      */
     public function bitwise_leftShift($shift)
     {

--- a/phpseclib/Math/BigInteger/Engines/GMP/DefaultEngine.php
+++ b/phpseclib/Math/BigInteger/Engines/GMP/DefaultEngine.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\GMP;
+namespace phpseclib3\Math\BigInteger\Engines\GMP;
 
-use phpseclib\Math\BigInteger\Engines\GMP;
+use phpseclib3\Math\BigInteger\Engines\GMP;
 
 /**
  * GMP Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/OpenSSL.php
+++ b/phpseclib/Math/BigInteger/Engines/OpenSSL.php
@@ -13,11 +13,11 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\RSA\Formats\Keys\PKCS8;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
+use phpseclib3\Math\BigInteger;
 
 /**
  * OpenSSL Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Exception\BadConfigurationException;
+use phpseclib3\Exception\BadConfigurationException;
 
 /**
  * Pure-PHP Engine.
@@ -77,7 +77,7 @@ abstract class PHP extends Engine
      * @param mixed $x integer Base-10 number or base-$base number if $base set.
      * @param int $base
      * @see parent::__construct()
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     public function __construct($x = 0, $base = 10)
     {
@@ -515,7 +515,7 @@ abstract class PHP extends Engine
      * same.  If the remainder would be negative, the "common residue" is equal to the sum of the remainder
      * and the divisor (basically, the "common residue" is the first positive modulo).
      *
-     * @param \phpseclib\Math\BigInteger\engines\PHP $y
+     * @param \phpseclib3\Math\BigInteger\engines\PHP $y
      * @return array
      * @internal This function is based off of {@link http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf#page=9 HAC 14.20}.
      */
@@ -710,7 +710,7 @@ abstract class PHP extends Engine
      * Convert an array / boolean to a PHP BigInteger object
      *
      * @param array $arr
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     protected function convertToObj(array $arr)
     {
@@ -795,7 +795,7 @@ abstract class PHP extends Engine
     /**
      * Absolute value.
      *
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     public function abs()
     {
@@ -831,7 +831,7 @@ abstract class PHP extends Engine
      * Shifts BigInteger's by $shift bits, effectively dividing by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     public function bitwise_rightShift($shift)
     {
@@ -851,7 +851,7 @@ abstract class PHP extends Engine
      * Shifts BigInteger's by $shift bits, effectively multiplying by 2**$shift.
      *
      * @param int $shift
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     public function bitwise_leftShift($shift)
     {
@@ -1204,7 +1204,7 @@ abstract class PHP extends Engine
      * Splits BigInteger's into chunks of $split bits
      *
      * @param int $split
-     * @return \phpseclib\Math\BigInteger\Engines\PHP[]
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP[]
      */
     public function bitwise_split($split)
     {
@@ -1271,7 +1271,7 @@ abstract class PHP extends Engine
      * Bitwise Split where $split < static::BASE
      *
      * @param int $split
-     * @return \phpseclib\Math\BigInteger\Engines\PHP[]
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP[]
      */
     private function bitwise_small_split($split)
     {

--- a/phpseclib/Math/BigInteger/Engines/PHP/Base.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Base.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP;
+namespace phpseclib3\Math\BigInteger\Engines\PHP;
 
-use phpseclib\Math\BigInteger\Engines\PHP;
+use phpseclib3\Math\BigInteger\Engines\PHP;
 
 /**
  * PHP Modular Exponentiation Engine
@@ -74,11 +74,11 @@ abstract class Base extends PHP
      * the other, a power of two - and recombine them, later.  This is the method that this modPow function uses.
      * {@link http://islab.oregonstate.edu/papers/j34monex.pdf Montgomery Reduction with Even Modulus} elaborates.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\PHP $x
-     * @param \phpseclib\Math\BigInteger\Engines\PHP $e
-     * @param \phpseclib\Math\BigInteger\Engines\PHP $n
+     * @param \phpseclib3\Math\BigInteger\Engines\PHP $x
+     * @param \phpseclib3\Math\BigInteger\Engines\PHP $e
+     * @param \phpseclib3\Math\BigInteger\Engines\PHP $n
      * @param string $class
-     * @return \phpseclib\Math\BigInteger\Engines\PHP
+     * @return \phpseclib3\Math\BigInteger\Engines\PHP
      */
     protected static function powModHelper(PHP $x, PHP $e, PHP $n, $class)
     {

--- a/phpseclib/Math/BigInteger/Engines/PHP/DefaultEngine.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/DefaultEngine.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP;
+namespace phpseclib3\Math\BigInteger\Engines\PHP;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Reductions\EvalBarrett;
+use phpseclib3\Math\BigInteger\Engines\PHP\Reductions\EvalBarrett;
 
 /**
  * PHP Default Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Montgomery.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Montgomery.php
@@ -13,12 +13,12 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP;
+namespace phpseclib3\Math\BigInteger\Engines\PHP;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Reductions\PowerOfTwo;
-use phpseclib\Math\BigInteger\Engines\PHP;
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
-use phpseclib\Math\BigInteger\Engines\Engine;
+use phpseclib3\Math\BigInteger\Engines\PHP\Reductions\PowerOfTwo;
+use phpseclib3\Math\BigInteger\Engines\PHP;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\Engine;
 
 /**
  * PHP Montgomery Modular Exponentiation Engine
@@ -42,11 +42,11 @@ abstract class Montgomery extends Base
     /**
      * Performs modular exponentiation.
      *
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $x
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $e
-     * @param \phpseclib\Math\BigInteger\Engines\Engine $n
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $x
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $e
+     * @param \phpseclib3\Math\BigInteger\Engines\Engine $n
      * @param string $class
-     * @return \phpseclib\Math\BigInteger\Engines\Engine
+     * @return \phpseclib3\Math\BigInteger\Engines\Engine
      */
     protected static function slidingWindow(Engine $x, Engine $e, Engine $n, $class)
     {

--- a/phpseclib/Math/BigInteger/Engines/PHP/OpenSSL.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/OpenSSL.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP;
+namespace phpseclib3\Math\BigInteger\Engines\PHP;
 
-use phpseclib\Math\BigInteger\Engines\OpenSSL as Progenitor;
+use phpseclib3\Math\BigInteger\Engines\OpenSSL as Progenitor;
 
 /**
  * OpenSSL Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Classic.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Classic.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Classic Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
@@ -13,10 +13,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
-use phpseclib\Math\BigInteger\Engines\PHP;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\PHP;
 
 /**
  * PHP Dynamic Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Montgomery.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Montgomery.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Montgomery as Progenitor;
+use phpseclib3\Math\BigInteger\Engines\PHP\Montgomery as Progenitor;
 
 /**
  * PHP Montgomery Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/MontgomeryMult.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/MontgomeryMult.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Montgomery Modular Exponentiation Engine with interleaved multiplication

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/PowerOfTwo.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/PowerOfTwo.php
@@ -13,9 +13,9 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines\PHP\Reductions;
+namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib\Math\BigInteger\Engines\PHP\Base;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Power Of Two Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP32.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP32.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
 
@@ -74,21 +74,21 @@ class PHP32 extends PHP
     /**
      * BigInteger(0)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP32
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP32
      */
     protected static $zero;
 
     /**
      * BigInteger(1)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP32
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP32
      */
     protected static $one;
 
     /**
      * BigInteger(2)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP32
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP32
      */
     protected static $two;
 

--- a/phpseclib/Math/BigInteger/Engines/PHP64.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP64.php
@@ -13,7 +13,7 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math\BigInteger\Engines;
+namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
 
@@ -74,21 +74,21 @@ class PHP64 extends PHP
     /**
      * BigInteger(0)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP64
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP64
      */
     protected static $zero;
 
     /**
      * BigInteger(1)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP64
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP64
      */
     protected static $one;
 
     /**
      * BigInteger(2)
      *
-     * @var \phpseclib\Math\BigInteger\Engines\PHP64
+     * @var \phpseclib3\Math\BigInteger\Engines\PHP64
      */
     protected static $two;
 

--- a/phpseclib/Math/BinaryField.php
+++ b/phpseclib/Math/BinaryField.php
@@ -14,12 +14,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math;
+namespace phpseclib3\Math;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Math\Common\FiniteField;
-use phpseclib\Math\BinaryField\Integer;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Math\Common\FiniteField;
+use phpseclib3\Math\BinaryField\Integer;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Binary Finite Fields

--- a/phpseclib/Math/BinaryField/Integer.php
+++ b/phpseclib/Math/BinaryField/Integer.php
@@ -20,11 +20,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math\BinaryField;
+namespace phpseclib3\Math\BinaryField;
 
-use phpseclib\Math\Common\FiniteField\Integer as Base;
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\BinaryField;
+use phpseclib3\Math\Common\FiniteField\Integer as Base;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BinaryField;
 use ParagonIE\ConstantTime\Hex;
 
 /**

--- a/phpseclib/Math/Common/FiniteField.php
+++ b/phpseclib/Math/Common/FiniteField.php
@@ -12,7 +12,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math\Common;
+namespace phpseclib3\Math\Common;
 
 /**
  * Finite Fields

--- a/phpseclib/Math/Common/FiniteField/Integer.php
+++ b/phpseclib/Math/Common/FiniteField/Integer.php
@@ -12,7 +12,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math\Common\FiniteField;
+namespace phpseclib3\Math\Common\FiniteField;
 
 /**
  * Finite Field Integer

--- a/phpseclib/Math/PrimeField.php
+++ b/phpseclib/Math/PrimeField.php
@@ -15,10 +15,10 @@
  * @link      http://pear.php.net/package/Math_BigInteger
  */
 
-namespace phpseclib\Math;
+namespace phpseclib3\Math;
 
-use phpseclib\Math\Common\FiniteField;
-use phpseclib\Math\PrimeField\Integer;
+use phpseclib3\Math\Common\FiniteField;
+use phpseclib3\Math\PrimeField\Integer;
 
 /**
  * Prime Finite Fields

--- a/phpseclib/Math/PrimeField/Integer.php
+++ b/phpseclib/Math/PrimeField/Integer.php
@@ -12,10 +12,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-namespace phpseclib\Math\PrimeField;
+namespace phpseclib3\Math\PrimeField;
 
-use phpseclib\Math\Common\FiniteField\Integer as Base;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer as Base;
+use phpseclib3\Math\BigInteger;
 use ParagonIE\ConstantTime\Hex;
 
 /**
@@ -30,7 +30,7 @@ class Integer extends Base
     /**
      * Holds the PrimeField's value
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      */
     protected $value;
 
@@ -44,7 +44,7 @@ class Integer extends Base
     /**
      * Holds the PrimeField's modulo
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      */
     protected static $modulo;
 
@@ -58,7 +58,7 @@ class Integer extends Base
     /**
      * Zero
      *
-     * @var \phpseclib\Math\BigInteger
+     * @var \phpseclib3\Math\BigInteger
      */
     protected static $zero;
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -16,7 +16,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $sftp = new \phpseclib\Net\SFTP('www.domain.tld');
+ *    $sftp = new \phpseclib3\Net\SFTP('www.domain.tld');
  *    if (!$sftp->login('username', 'password')) {
  *        exit('Login Failed');
  *    }
@@ -35,11 +35,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Net;
+namespace phpseclib3\Net;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib\Exception\FileNotFoundException;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Exception\FileNotFoundException;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementations of SFTP.
@@ -53,17 +53,17 @@ class SFTP extends SSH2
     /**
      * SFTP channel constant
      *
-     * \phpseclib\Net\SSH2::exec() uses 0 and \phpseclib\Net\SSH2::read() / \phpseclib\Net\SSH2::write() use 1.
+     * \phpseclib3\Net\SSH2::exec() uses 0 and \phpseclib3\Net\SSH2::read() / \phpseclib3\Net\SSH2::write() use 1.
      *
-     * @see \phpseclib\Net\SSH2::send_channel_packet()
-     * @see \phpseclib\Net\SSH2::get_channel_packet()
+     * @see \phpseclib3\Net\SSH2::send_channel_packet()
+     * @see \phpseclib3\Net\SSH2::get_channel_packet()
      * @access private
      */
     const CHANNEL = 0x100;
 
     /**#@+
      * @access public
-     * @see \phpseclib\Net\SFTP::put()
+     * @see \phpseclib3\Net\SFTP::put()
     */
     /**
      * Reads data from a local file.
@@ -271,7 +271,7 @@ class SFTP extends SSH2
      * @param string $host
      * @param int $port
      * @param int $timeout
-     * @return \phpseclib\Net\SFTP
+     * @return \phpseclib3\Net\SFTP
      * @access public
      */
     public function __construct($host, $port = 22, $timeout = 10)
@@ -352,7 +352,7 @@ class SFTP extends SSH2
             31 => 'NET_SFTP_STATUS_NO_MATCHING_BYTE_RANGE_LOCK'
         ];
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-7.1
-        // the order, in this case, matters quite a lot - see \phpseclib\Net\SFTP::_parseAttributes() to understand why
+        // the order, in this case, matters quite a lot - see \phpseclib3\Net\SFTP::_parseAttributes() to understand why
         $this->attributes = [
             0x00000001 => 'NET_SFTP_ATTR_SIZE',
             0x00000002 => 'NET_SFTP_ATTR_UIDGID', // defined in SFTPv3, removed in SFTPv4+
@@ -376,7 +376,7 @@ class SFTP extends SSH2
             0x00000020 => 'NET_SFTP_OPEN_EXCL'
         ];
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-04#section-5.2
-        // see \phpseclib\Net\SFTP::_parseLongname() for an explanation
+        // see \phpseclib3\Net\SFTP::_parseLongname() for an explanation
         $this->file_types = [
             1 => 'NET_SFTP_TYPE_REGULAR',
             2 => 'NET_SFTP_TYPE_DIRECTORY',
@@ -531,7 +531,7 @@ class SFTP extends SSH2
          So what do you do if you have a client whose initial SSH_FXP_INIT packet says it implements v3 and
          a server whose initial SSH_FXP_VERSION reply says it implements v4 and only v4?  If it only implements
          v4, the "versions" extension is likely not going to have been sent so version re-negotiation as discussed
-         in draft-ietf-secsh-filexfer-13 would be quite impossible.  As such, what \phpseclib\Net\SFTP would do is close the
+         in draft-ietf-secsh-filexfer-13 would be quite impossible.  As such, what \phpseclib3\Net\SFTP would do is close the
          channel and reopen it with a new and updated SSH_FXP_INIT packet.
         */
         switch ($this->version) {
@@ -739,7 +739,7 @@ class SFTP extends SSH2
             return false;
         }
 
-        // see \phpseclib\Net\SFTP::nlist() for a more thorough explanation of the following
+        // see \phpseclib3\Net\SFTP::nlist() for a more thorough explanation of the following
         $response = $this->get_sftp_packet();
         switch ($this->packet_type) {
             case NET_SFTP_HANDLE:
@@ -1300,7 +1300,7 @@ class SFTP extends SSH2
     /**
      * Returns general information about a file or symbolic link
      *
-     * Determines information without calling \phpseclib\Net\SFTP::realpath().
+     * Determines information without calling \phpseclib3\Net\SFTP::realpath().
      * The second parameter can be either NET_SFTP_STAT or NET_SFTP_LSTAT.
      *
      * @param string $filename
@@ -1814,8 +1814,8 @@ class SFTP extends SSH2
     /**
      * Uploads a file to the SFTP server.
      *
-     * By default, \phpseclib\Net\SFTP::put() does not read from the local filesystem.  $data is dumped directly into $remote_file.
-     * So, for example, if you set $data to 'filename.ext' and then do \phpseclib\Net\SFTP::get(), you will get a file, twelve bytes
+     * By default, \phpseclib3\Net\SFTP::put() does not read from the local filesystem.  $data is dumped directly into $remote_file.
+     * So, for example, if you set $data to 'filename.ext' and then do \phpseclib3\Net\SFTP::get(), you will get a file, twelve bytes
      * long, containing 'filename.ext' as its contents.
      *
      * Setting $mode to self::SOURCE_LOCAL_FILE will change the above behavior.  With self::SOURCE_LOCAL_FILE, $remote_file will
@@ -1854,10 +1854,10 @@ class SFTP extends SSH2
      * @param callable|null $progressCallback
      * @throws \UnexpectedValueException on receipt of unexpected packets
      * @throws \BadFunctionCallException if you're uploading via a callback and the callback function is invalid
-     * @throws \phpseclib\Exception\FileNotFoundException if you're uploading via a file and the file doesn't exist
+     * @throws \phpseclib3\Exception\FileNotFoundException if you're uploading via a file and the file doesn't exist
      * @return bool
      * @access public
-     * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - \phpseclib\Net\SFTP::setMode().
+     * @internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - \phpseclib3\Net\SFTP::setMode().
      */
     public function put($remote_file, $data, $mode = self::SOURCE_STRING, $start = -1, $local_start = -1, $progressCallback = null)
     {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -15,11 +15,11 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Net\SFTP;
+namespace phpseclib3\Net\SFTP;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Net\SFTP;
-use phpseclib\Net\SSH2;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Net\SFTP;
+use phpseclib3\Net\SSH2;
 
 /**
  * SFTP Stream Wrapper
@@ -212,7 +212,7 @@ class Stream
                 return false;
             }
 
-            // casting $pass to a string is necessary in the event that it's a \phpseclib\Crypt\RSA object
+            // casting $pass to a string is necessary in the event that it's a \phpseclib3\Crypt\RSA object
             if (isset(self::$instances[$host][$port][$user][(string) $pass])) {
                 $this->sftp = self::$instances[$host][$port][$user][(string) $pass];
             } else {
@@ -488,7 +488,7 @@ class Stream
      * Renames a file or directory
      *
      * Attempts to rename oldname to newname, moving it between directories if necessary.
-     * If newname exists, it will be overwritten.  This is a departure from what \phpseclib\Net\SFTP
+     * If newname exists, it will be overwritten.  This is a departure from what \phpseclib3\Net\SFTP
      * does.
      *
      * @param string $path_from
@@ -643,7 +643,7 @@ class Stream
     /**
      * Flushes the output
      *
-     * See <http://php.net/fflush>. Always returns true because \phpseclib\Net\SFTP doesn't cache stuff before writing
+     * See <http://php.net/fflush>. Always returns true because \phpseclib3\Net\SFTP doesn't cache stuff before writing
      *
      * @return bool
      * @access public
@@ -688,7 +688,7 @@ class Stream
     /**
      * Retrieve information about a file
      *
-     * Ignores the STREAM_URL_STAT_QUIET flag because the entirety of \phpseclib\Net\SFTP\Stream is quiet by default
+     * Ignores the STREAM_URL_STAT_QUIET flag because the entirety of \phpseclib3\Net\SFTP\Stream is quiet by default
      * might be worthwhile to reconstruct bits 12-16 (ie. the file type) if mode doesn't have them but we'll
      * cross that bridge when and if it's reached
      *
@@ -735,7 +735,7 @@ class Stream
      * Change stream options
      *
      * STREAM_OPTION_WRITE_BUFFER isn't supported for the same reason stream_flush isn't.
-     * The other two aren't supported because of limitations in \phpseclib\Net\SFTP.
+     * The other two aren't supported because of limitations in \phpseclib3\Net\SFTP.
      *
      * @param int $option
      * @param int $arg1

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -10,7 +10,7 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $ssh = new \phpseclib\Net\SSH2('www.domain.tld');
+ *    $ssh = new \phpseclib3\Net\SSH2('www.domain.tld');
  *    if (!$ssh->login('username', 'password')) {
  *        exit('Login Failed');
  *    }
@@ -24,9 +24,9 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $key = \phpseclib\Crypt\PublicKeyLoader::load('...', '(optional) password');
+ *    $key = \phpseclib3\Crypt\PublicKeyLoader::load('...', '(optional) password');
  *
- *    $ssh = new \phpseclib\Net\SSH2('www.domain.tld');
+ *    $ssh = new \phpseclib3\Net\SSH2('www.domain.tld');
  *    if (!$ssh->login('username', $key)) {
  *        exit('Login Failed');
  *    }
@@ -45,31 +45,31 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-namespace phpseclib\Net;
+namespace phpseclib3\Net;
 
-use phpseclib\Crypt\Blowfish;
-use phpseclib\Crypt\Hash;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\RC4;
-use phpseclib\Crypt\Rijndael;
-use phpseclib\Crypt\Common\PrivateKey;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\EC;
-use phpseclib\Crypt\DH;
-use phpseclib\Crypt\TripleDES;
-use phpseclib\Crypt\Twofish;
-use phpseclib\Crypt\ChaCha20;
-use phpseclib\Math\BigInteger; // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
-use phpseclib\System\SSH\Agent;
-use phpseclib\System\SSH\Agent\Identity as AgentIdentity;
-use phpseclib\Exception\NoSupportedAlgorithmsException;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\Exception\UnsupportedCurveException;
-use phpseclib\Exception\ConnectionClosedException;
-use phpseclib\Exception\UnableToConnectException;
-use phpseclib\Exception\InsufficientSetupException;
-use phpseclib\Common\Functions\Strings;
+use phpseclib3\Crypt\Blowfish;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\RC4;
+use phpseclib3\Crypt\Rijndael;
+use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\DH;
+use phpseclib3\Crypt\TripleDES;
+use phpseclib3\Crypt\Twofish;
+use phpseclib3\Crypt\ChaCha20;
+use phpseclib3\Math\BigInteger; // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
+use phpseclib3\System\SSH\Agent;
+use phpseclib3\System\SSH\Agent\Identity as AgentIdentity;
+use phpseclib3\Exception\NoSupportedAlgorithmsException;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Exception\ConnectionClosedException;
+use phpseclib3\Exception\UnableToConnectException;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Common\Functions\Strings;
 
 /**
  * Pure-PHP implementation of SSHv2.
@@ -83,7 +83,7 @@ class SSH2
     /**#@+
      * Execution Bitmap Masks
      *
-     * @see \phpseclib\Net\SSH2::bitmap
+     * @see \phpseclib3\Net\SSH2::bitmap
      * @access private
      */
     const MASK_CONSTRUCTOR   = 0x00000001;
@@ -106,8 +106,8 @@ class SSH2
      *     open request, and 'sender channel' is the channel number allocated by
      *     the other side.
      *
-     * @see \phpseclib\Net\SSH2::send_channel_packet()
-     * @see \phpseclib\Net\SSH2::get_channel_packet()
+     * @see \phpseclib3\Net\SSH2::send_channel_packet()
+     * @see \phpseclib3\Net\SSH2::get_channel_packet()
      * @access private
     */
     const CHANNEL_EXEC          = 1; // PuTTy uses 0x100
@@ -119,7 +119,7 @@ class SSH2
 
     /**#@+
      * @access public
-     * @see \phpseclib\Net\SSH2::getLog()
+     * @see \phpseclib3\Net\SSH2::getLog()
     */
     /**
      * Returns the message numbers
@@ -145,7 +145,7 @@ class SSH2
 
     /**#@+
      * @access public
-     * @see \phpseclib\Net\SSH2::read()
+     * @see \phpseclib3\Net\SSH2::read()
     */
     /**
      * Returns when a string matching $expect exactly is found
@@ -929,7 +929,7 @@ class SSH2
     /**
      * A System_SSH_Agent for use in the SSH2 Agent Forwarding scenario
      *
-     * @var \phpseclib\System\Ssh\Agent
+     * @var \phpseclib3\System\Ssh\Agent
      * @access private
      */
     private $agent;
@@ -1369,7 +1369,7 @@ class SSH2
      * @param string|bool $kexinit_payload_server optional
      * @throws \UnexpectedValueException on receipt of unexpected packets
      * @throws \RuntimeException on other errors
-     * @throws \phpseclib\Exception\NoSupportedAlgorithmsException when none of the algorithms phpseclib has loaded are compatible
+     * @throws \phpseclib3\Exception\NoSupportedAlgorithmsException when none of the algorithms phpseclib has loaded are compatible
      * @access private
      */
     private function key_exchange($kexinit_payload_server = false)
@@ -1903,10 +1903,10 @@ class SSH2
 
     /**
      * Maps an encryption algorithm name to an instance of a subclass of
-     * \phpseclib\Crypt\Common\SymmetricKey.
+     * \phpseclib3\Crypt\Common\SymmetricKey.
      *
      * @param string $algorithm Name of the encryption algorithm
-     * @return mixed Instance of \phpseclib\Crypt\Common\SymmetricKey or null for unknown
+     * @return mixed Instance of \phpseclib3\Crypt\Common\SymmetricKey or null for unknown
      * @access private
      */
     private static function encryption_algorithm_to_crypt_instance($algorithm)
@@ -1952,10 +1952,10 @@ class SSH2
 
     /**
      * Maps an encryption algorithm name to an instance of a subclass of
-     * \phpseclib\Crypt\Hash.
+     * \phpseclib3\Crypt\Hash.
      *
      * @param string $algorithm Name of the encryption algorithm
-     * @return mixed Instance of \phpseclib\Crypt\Hash or null for unknown
+     * @return mixed Instance of \phpseclib3\Crypt\Hash or null for unknown
      * @access private
      */
     private static function mac_algorithm_to_hash_instance($algorithm)
@@ -2009,7 +2009,7 @@ class SSH2
     /**
      * Login
      *
-     * The $password parameter can be a plaintext password, a \phpseclib\Crypt\RSA object or an array
+     * The $password parameter can be a plaintext password, a \phpseclib3\Crypt\RSA object or an array
      *
      * @param string $username
      * @param $args[] param mixed $password
@@ -2143,7 +2143,7 @@ class SSH2
         }
 
         if (!is_string($password)) {
-            throw new \UnexpectedValueException('$password needs to either be an instance of \phpseclib\Crypt\Common\PrivateKey, \System\SSH\Agent, an array or a string');
+            throw new \UnexpectedValueException('$password needs to either be an instance of \phpseclib3\Crypt\Common\PrivateKey, \System\SSH\Agent, an array or a string');
         }
 
         $packet = Strings::packSSH2(
@@ -2349,7 +2349,7 @@ class SSH2
      * Login with an ssh-agent provided key
      *
      * @param string $username
-     * @param \phpseclib\System\SSH\Agent $agent
+     * @param \phpseclib3\System\SSH\Agent $agent
      * @return bool
      * @access private
      */
@@ -2370,7 +2370,7 @@ class SSH2
      * Login with an RSA private key
      *
      * @param string $username
-     * @param \phpseclib\Crypt\Common\PrivateKey $privatekey
+     * @param \phpseclib3\Crypt\Common\PrivateKey $privatekey
      * @return bool
      * @throws \RuntimeException on connection error
      * @access private
@@ -2421,7 +2421,7 @@ class SSH2
                     if (is_array($curveName)) {
                         throw new UnsupportedCurveException('Specified Curves are not supported by SSH2');
                     }
-                    throw new UnsupportedCurveException('Named Curve of ' . $curveName . ' is not supported by phpseclib\'s SSH2 implementation');
+                    throw new UnsupportedCurveException('Named Curve of ' . $curveName . ' is not supported by phpseclib3\'s SSH2 implementation');
             }
         } else if ($publickey instanceof DSA) {
             $privatekey = $privatekey->withSignatureFormat('SSH2');
@@ -2525,7 +2525,7 @@ class SSH2
     /**
      * Execute Command
      *
-     * If $callback is set to false then \phpseclib\Net\SSH2::get_channel_packet(self::CHANNEL_EXEC) will need to be called manually.
+     * If $callback is set to false then \phpseclib3\Net\SSH2::get_channel_packet(self::CHANNEL_EXEC) will need to be called manually.
      * In all likelihood, this is not a feature you want to be taking advantage of.
      *
      * @param string $command
@@ -2611,7 +2611,7 @@ class SSH2
         }
 
         // sending a pty-req SSH_MSG_CHANNEL_REQUEST message is unnecessary and, in fact, in most cases, slows things
-        // down.  the one place where it might be desirable is if you're doing something like \phpseclib\Net\SSH2::exec('ping localhost &').
+        // down.  the one place where it might be desirable is if you're doing something like \phpseclib3\Net\SSH2::exec('ping localhost &').
         // with a pty-req SSH_MSG_CHANNEL_REQUEST, exec() will return immediately and the ping process will then
         // then immediately terminate.  without such a request exec() will loop indefinitely.  the ping process won't end but
         // neither will your script.
@@ -4039,7 +4039,7 @@ class SSH2
     /**
      * Closes and flushes a channel
      *
-     * \phpseclib\Net\SSH2 doesn't properly close most channels.  For exec() channels are normally closed by the server
+     * \phpseclib3\Net\SSH2 doesn't properly close most channels.  For exec() channels are normally closed by the server
      * and for SFTP channels are presumably closed when the client disconnects.  This functions is intended
      * for SCP more than anything.
      *
@@ -4631,7 +4631,7 @@ class SSH2
      *
      * @return mixed
      * @throws \RuntimeException on badly formatted keys
-     * @throws \phpseclib\Exception\NoSupportedAlgorithmsException when the key isn't in a supported format
+     * @throws \phpseclib3\Exception\NoSupportedAlgorithmsException when the key isn't in a supported format
      * @access public
      */
     public function getServerPublicHostKey()

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -10,9 +10,9 @@
  * <?php
  *    include 'vendor/autoload.php';
  *
- *    $agent = new \phpseclib\System\SSH\Agent();
+ *    $agent = new \phpseclib3\System\SSH\Agent();
  *
- *    $ssh = new \phpseclib\Net\SSH2('www.domain.tld');
+ *    $ssh = new \phpseclib3\Net\SSH2('www.domain.tld');
  *    if (!$ssh->login('username', $agent)) {
  *        exit('Login Failed');
  *    }
@@ -31,18 +31,18 @@
  * @internal  See http://api.libssh.org/rfc/PROTOCOL.agent
  */
 
-namespace phpseclib\System\SSH;
+namespace phpseclib3\System\SSH;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Exception\BadConfigurationException;
-use phpseclib\System\SSH\Agent\Identity;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Exception\BadConfigurationException;
+use phpseclib3\System\SSH\Agent\Identity;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 /**
  * Pure-PHP ssh-agent client identity factory
  *
- * requestIdentities() method pumps out \phpseclib\System\SSH\Agent\Identity objects
+ * requestIdentities() method pumps out \phpseclib3\System\SSH\Agent\Identity objects
  *
  * @package SSH\Agent
  * @author  Jim Wigginton <terrafrost@php.net>
@@ -130,8 +130,8 @@ class Agent
     /**
      * Default Constructor
      *
-     * @return \phpseclib\System\SSH\Agent
-     * @throws \phpseclib\Exception\BadConfigurationException if SSH_AUTH_SOCK cannot be found
+     * @return \phpseclib3\System\SSH\Agent
+     * @throws \phpseclib3\Exception\BadConfigurationException if SSH_AUTH_SOCK cannot be found
      * @throws \RuntimeException on connection errors
      * @access public
      */
@@ -160,7 +160,7 @@ class Agent
      * Request Identities
      *
      * See "2.5.2 Requesting a list of protocol 2 keys"
-     * Returns an array containing zero or more \phpseclib\System\SSH\Agent\Identity objects
+     * Returns an array containing zero or more \phpseclib3\System\SSH\Agent\Identity objects
      *
      * @return array
      * @throws \RuntimeException on receipt of unexpected packets
@@ -219,7 +219,7 @@ class Agent
      * Signal that agent forwarding should
      * be requested when a channel is opened
      *
-     * @param \phpseclib\Net\SSH2 $ssh
+     * @param \phpseclib3\Net\SSH2 $ssh
      * @return bool
      * @access public
      */
@@ -233,7 +233,7 @@ class Agent
     /**
      * Request agent forwarding of remote server
      *
-     * @param \phpseclib\Net\SSH2 $ssh
+     * @param \phpseclib3\Net\SSH2 $ssh
      * @return bool
      * @access private
      */
@@ -255,7 +255,7 @@ class Agent
      * open to give the SSH Agent an opportunity
      * to take further action. i.e. request agent forwarding
      *
-     * @param \phpseclib\Net\SSH2 $ssh
+     * @param \phpseclib3\Net\SSH2 $ssh
      * @access private
      */
     public function registerChannelOpen($ssh)

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -14,22 +14,22 @@
  * @internal  See http://api.libssh.org/rfc/PROTOCOL.agent
  */
 
-namespace phpseclib\System\SSH\Agent;
+namespace phpseclib3\System\SSH\Agent;
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\ECDSA;
-use phpseclib\Exception\UnsupportedAlgorithmException;
-use phpseclib\System\SSH\Agent;
-use phpseclib\Common\Functions\Strings;
-use phpseclib\Crypt\Common\PrivateKey;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\ECDSA;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\System\SSH\Agent;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\PrivateKey;
 
 
 /**
  * Pure-PHP ssh-agent client identity object
  *
- * Instantiation should only be performed by \phpseclib\System\SSH\Agent class.
- * This could be thought of as implementing an interface that phpseclib\Crypt\RSA
+ * Instantiation should only be performed by \phpseclib3\System\SSH\Agent class.
+ * This could be thought of as implementing an interface that phpseclib3\Crypt\RSA
  * implements. ie. maybe a Net_SSH_Auth_PublicKey interface or something.
  * The methods in this interface would be getPublicKey and sign since those are the
  * methods phpseclib looks for to perform public key authentication.
@@ -54,7 +54,7 @@ class Identity implements PrivateKey
     /**
      * Key Object
      *
-     * @var \phpseclib\Crypt\RSA
+     * @var \phpseclib3\Crypt\RSA
      * @access private
      * @see self::getPublicKey()
      */
@@ -105,7 +105,7 @@ class Identity implements PrivateKey
      * Default Constructor.
      *
      * @param resource $fsock
-     * @return \phpseclib\System\SSH\Agent\Identity
+     * @return \phpseclib3\System\SSH\Agent\Identity
      * @access private
      */
     public function __construct($fsock)
@@ -116,9 +116,9 @@ class Identity implements PrivateKey
     /**
      * Set Public Key
      *
-     * Called by \phpseclib\System\SSH\Agent::requestIdentities()
+     * Called by \phpseclib3\System\SSH\Agent::requestIdentities()
      *
-     * @param \phpseclib\Crypt\Common\PublicKey $key
+     * @param \phpseclib3\Crypt\Common\PublicKey $key
      * @access private
      */
     public function withPublicKey($key)
@@ -137,7 +137,7 @@ class Identity implements PrivateKey
     /**
      * Set Public Key
      *
-     * Called by \phpseclib\System\SSH\Agent::requestIdentities(). The key blob could be extracted from $this->key
+     * Called by \phpseclib3\System\SSH\Agent::requestIdentities(). The key blob could be extracted from $this->key
      * but this saves a small amount of computation.
      *
      * @param string $key_blob
@@ -281,7 +281,7 @@ class Identity implements PrivateKey
      * @param int $padding optional
      * @return string
      * @throws \RuntimeException on connection errors
-     * @throws \phpseclib\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
+     * @throws \phpseclib3\Exception\UnsupportedAlgorithmException if the algorithm is unsupported
      * @access public
      */
     public function sign($message)

--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -6,8 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Base;
-use phpseclib\Net\SFTP;
+use phpseclib3\Crypt\Base;
+use phpseclib3\Net\SFTP;
 
 class Functional_Net_SFTPLargeFileTest extends Functional_Net_SFTPTestCase
 {

--- a/tests/Functional/Net/SFTPStreamTest.php
+++ b/tests/Functional/Net/SFTPStreamTest.php
@@ -6,7 +6,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SFTP\Stream;
+use phpseclib3\Net\SFTP\Stream;
 
 class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
 {
@@ -48,10 +48,10 @@ class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
      */
     public function testConnectionReuse()
     {
-        $originalConnectionsCount = count(\phpseclib\Net\SSH2::getConnections());
+        $originalConnectionsCount = count(\phpseclib3\Net\SSH2::getConnections());
         $session = $this->sftp;
         $dirs = scandir("sftp://$session/");
-        $this->assertCount($originalConnectionsCount, \phpseclib\Net\SSH2::getConnections());
+        $this->assertCount($originalConnectionsCount, \phpseclib3\Net\SSH2::getConnections());
         $this->assertEquals(['.', '..'], array_slice($dirs, 0, 2));
     }
 

--- a/tests/Functional/Net/SFTPTestCase.php
+++ b/tests/Functional/Net/SFTPTestCase.php
@@ -6,7 +6,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SFTP;
+use phpseclib3\Net\SFTP;
 
 /**
  * This class provides each test method with a new and empty $this->scratchDir.

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -6,7 +6,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SFTP;
+use phpseclib3\Net\SFTP;
 
 class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 {

--- a/tests/Functional/Net/SFTPWrongServerTest.php
+++ b/tests/Functional/Net/SFTPWrongServerTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use phpseclib\Net\SFTP;
-use phpseclib\Exception\UnableToConnectException;
+use phpseclib3\Net\SFTP;
+use phpseclib3\Exception\UnableToConnectException;
 use PHPUnit\Framework\TestCase;
 
 class SFTPWrongServerTest extends TestCase

--- a/tests/Functional/Net/SSH2AgentTest.php
+++ b/tests/Functional/Net/SSH2AgentTest.php
@@ -6,8 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SSH2;
-use phpseclib\System\SSH\Agent;
+use phpseclib3\Net\SSH2;
+use phpseclib3\System\SSH\Agent;
 
 class Functional_Net_SSH2AgentTest extends PhpseclibFunctionalTestCase
 {

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -6,7 +6,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SSH2;
+use phpseclib3\Net\SSH2;
 
 class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
 {

--- a/tests/PhpseclibFunctionalTestCase.php
+++ b/tests/PhpseclibFunctionalTestCase.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Hash;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Math\BigInteger;
 
 abstract class PhpseclibFunctionalTestCase extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/AES/EvalTest.php
+++ b/tests/Unit/Crypt/AES/EvalTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_EvalTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/InternalTest.php
+++ b/tests/Unit/Crypt/AES/InternalTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_InternalTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/McryptTest.php
+++ b/tests/Unit/Crypt/AES/McryptTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_McryptTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/OpenSSLTest.php
+++ b/tests/Unit/Crypt/AES/OpenSSLTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_OpenSSLTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -5,9 +5,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Common\BlockCipher;
-use phpseclib\Crypt\Rijndael;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Rijndael;
 
 abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
 {
@@ -348,7 +348,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\InconsistentSetupException
+     * @expectedException \phpseclib3\Exception\InconsistentSetupException
      */
     public function testSetKeyLengthWithLargerKey()
     {
@@ -363,7 +363,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\InconsistentSetupException
+     * @expectedException \phpseclib3\Exception\InconsistentSetupException
      */
     public function testSetKeyLengthWithSmallerKey()
     {
@@ -409,7 +409,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\InsufficientSetupException
+     * @expectedException \phpseclib3\Exception\InsufficientSetupException
      */
     public function testNoKey()
     {

--- a/tests/Unit/Crypt/BlowfishTest.php
+++ b/tests/Unit/Crypt/BlowfishTest.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Blowfish;
-use phpseclib\Crypt\Random;
+use phpseclib3\Crypt\Blowfish;
+use phpseclib3\Crypt\Random;
 
 class Unit_Crypt_BlowfishTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/ChaCha20.php
+++ b/tests/Unit/Crypt/ChaCha20.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\ChaCha20;
+use phpseclib3\Crypt\ChaCha20;
 
 class Unit_Crypt_ChaCha20Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/DHTest.php
+++ b/tests/Unit/Crypt/DHTest.php
@@ -5,13 +5,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\DH;
-use phpseclib\Crypt\DH\PublicKey;
-use phpseclib\Crypt\DH\PrivateKey;
-use phpseclib\Crypt\DH\Parameters;
-use phpseclib\Crypt\EC;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\DH;
+use phpseclib3\Crypt\DH\PublicKey;
+use phpseclib3\Crypt\DH\PrivateKey;
+use phpseclib3\Crypt\DH\Parameters;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\AES;
 
 class Unit_Crypt_DHTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/DSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/DSA/CreateKeyTest.php
@@ -6,10 +6,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\DSA\Parameters;
-use phpseclib\Crypt\DSA\PublicKey;
-use phpseclib\Crypt\DSA\PrivateKey;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\DSA\Parameters;
+use phpseclib3\Crypt\DSA\PublicKey;
+use phpseclib3\Crypt\DSA\PrivateKey;
 
 /**
  * @requires PHP 7.0

--- a/tests/Unit/Crypt/DSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/DSA/LoadKeyTest.php
@@ -5,19 +5,19 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\PublicKeyLoader;
-use phpseclib\Crypt\DSA\PrivateKey;
-use phpseclib\Crypt\DSA\PublicKey;
-use phpseclib\Crypt\DSA\Parameters;
-use phpseclib\Crypt\DSA\Formats\Keys\PKCS1;
-use phpseclib\Crypt\DSA\Formats\Keys\PKCS8;
-use phpseclib\Crypt\DSA\Formats\Keys\PuTTY;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\DSA\PrivateKey;
+use phpseclib3\Crypt\DSA\PublicKey;
+use phpseclib3\Crypt\DSA\Parameters;
+use phpseclib3\Crypt\DSA\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\DSA\Formats\Keys\PKCS8;
+use phpseclib3\Crypt\DSA\Formats\Keys\PuTTY;
+use phpseclib3\Math\BigInteger;
 
 class Unit_Crypt_DSA_LoadKeyTest extends PhpseclibTestCase
 {
     /**
-     * @expectedException \phpseclib\Exception\NoKeyLoadedException
+     * @expectedException \phpseclib3\Exception\NoKeyLoadedException
      */
     public function testBadKey()
     {
@@ -157,7 +157,7 @@ Syea3pSvWdBpVhWzOX4A7qbxs+bhWAQWAhQiF7sFfCtZ7oOgCb2aJ9ySC9sTug==
     }
 
     /**
-     * @expectedException \phpseclib\Exception\NoKeyLoadedException
+     * @expectedException \phpseclib3\Exception\NoKeyLoadedException
      */
     public function testPuTTYBadMAC()
     {

--- a/tests/Unit/Crypt/DSA/SignatureTest.php
+++ b/tests/Unit/Crypt/DSA/SignatureTest.php
@@ -6,8 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\DSA;
-use phpseclib\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 class Unit_Crypt_DSA_SignatureTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/EC/CurveTest.php
+++ b/tests/Unit/Crypt/EC/CurveTest.php
@@ -6,15 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\EC;
-use phpseclib\File\ASN1;
-use phpseclib\Crypt\EC\Curves\Ed448;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\EC;
+use phpseclib3\File\ASN1;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 class Ed448PublicKey
 {
-    use phpseclib\Crypt\EC\Formats\Keys\Common;
+    use phpseclib3\Crypt\EC\Formats\Keys\Common;
 
     public static function load($key, $password = '')
     {
@@ -50,7 +50,7 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
             if ($testName == 'Curve25519' || $testName == 'Curve448') {
                 continue;
             }
-            $class = 'phpseclib\Crypt\EC\Curves\\' . $testName;
+            $class = 'phpseclib3\Crypt\EC\Curves\\' . $testName;
             $reflect = new \ReflectionClass($class);
             if ($reflect->isFinal()) {
                 continue;
@@ -80,7 +80,7 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
 
     public function curvesWithOIDs()
     {
-        $class = new ReflectionClass('phpseclib\Crypt\EC\Formats\Keys\PKCS8');
+        $class = new ReflectionClass('phpseclib3\Crypt\EC\Formats\Keys\PKCS8');
 
         $initialize = $class->getMethod('initialize_static_variables');
         $initialize->setAccessible(true);
@@ -105,7 +105,7 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
      */
     public function testBasePoint($name)
     {
-        $class = 'phpseclib\Crypt\EC\Curves\\' . $name;
+        $class = 'phpseclib3\Crypt\EC\Curves\\' . $name;
         $curve = new $class;
         $this->assertTrue($curve->verifyPoint($curve->getBasePoint()), "Failed to verify basepoint of curve $name");
     }
@@ -118,7 +118,7 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
      */
     public function testKeyGeneration($name)
     {
-        $class = 'phpseclib\Crypt\EC\Curves\\' . $name;
+        $class = 'phpseclib3\Crypt\EC\Curves\\' . $name;
         $curve = new $class;
         $dA = $curve->createRandomMultiplier();
         $QA = $curve->multiplyPoint($curve->getBasePoint(), $dA);

--- a/tests/Unit/Crypt/EC/KeyTest.php
+++ b/tests/Unit/Crypt/EC/KeyTest.php
@@ -5,14 +5,14 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\EC;
-use phpseclib\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib\Crypt\EC\Formats\Keys\PKCS8;
-use phpseclib\Crypt\EC\Formats\Keys\PuTTY;
-use phpseclib\Crypt\EC\Formats\Keys\OpenSSH;
-use phpseclib\Crypt\EC\Formats\Keys\XML;
-use phpseclib\Crypt\PublicKeyLoader;
-use phpseclib\Crypt\EC\PrivateKey;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS8;
+use phpseclib3\Crypt\EC\Formats\Keys\PuTTY;
+use phpseclib3\Crypt\EC\Formats\Keys\OpenSSH;
+use phpseclib3\Crypt\EC\Formats\Keys\XML;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\EC\PrivateKey;
 
 class Unit_Crypt_EC_LoadKeyTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/GCMTest.php
+++ b/tests/Unit/Crypt/GCMTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
 
 class Unit_Crypt_GCMTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Hash;
+use phpseclib3\Crypt\Hash;
 
 class Unit_Crypt_HashTest extends PhpseclibTestCase
 {
@@ -374,7 +374,7 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\UnsupportedAlgorithmException
+     * @expectedException \phpseclib3\Exception\UnsupportedAlgorithmException
      */
     public function testConstructorArgumentInvalid()
     {
@@ -382,7 +382,7 @@ class Unit_Crypt_HashTest extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\UnsupportedAlgorithmException
+     * @expectedException \phpseclib3\Exception\UnsupportedAlgorithmException
      */
     public function testSetHashInvalid()
     {

--- a/tests/Unit/Crypt/RC2Test.php
+++ b/tests/Unit/Crypt/RC2Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\RC2;
+use phpseclib3\Crypt\RC2;
 
 class Unit_Crypt_RC2Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RC4Test.php
+++ b/tests/Unit/Crypt/RC4Test.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\RC4;
-use phpseclib\Crypt\Random;
+use phpseclib3\Crypt\RC4;
+use phpseclib3\Crypt\Random;
 
 class Unit_Crypt_RC4Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/RSA/CreateKeyTest.php
@@ -6,10 +6,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\RSA\Formats\Keys\PKCS1;
-use phpseclib\Crypt\RSA\PrivateKey;
-use phpseclib\Crypt\RSA\PublicKey;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\RSA\PrivateKey;
+use phpseclib3\Crypt\RSA\PublicKey;
 
 class Unit_Crypt_RSA_CreateKeyTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -5,16 +5,16 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\PublicKeyLoader;
-use phpseclib\Crypt\RSA\PrivateKey;
-use phpseclib\Crypt\RSA\PublicKey;
-use phpseclib\Crypt\RSA\Formats\Keys\PKCS1;
-use phpseclib\Crypt\RSA\Formats\Keys\PKCS8;
-use phpseclib\Crypt\RSA\Formats\Keys\PuTTY;
-use phpseclib\Crypt\RSA\Formats\Keys\OpenSSH;
-use phpseclib\Crypt\RSA\Formats\Keys\PSS;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA\PrivateKey;
+use phpseclib3\Crypt\RSA\PublicKey;
+use phpseclib3\Crypt\RSA\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
+use phpseclib3\Crypt\RSA\Formats\Keys\PuTTY;
+use phpseclib3\Crypt\RSA\Formats\Keys\OpenSSH;
+use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Math\BigInteger;
 
 class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
 {
@@ -25,7 +25,7 @@ class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
     }
 
     /**
-     * @expectedException \phpseclib\Exception\NoKeyLoadedException
+     * @expectedException \phpseclib3\Exception\NoKeyLoadedException
      */
     public function testBadKey()
     {

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -5,10 +5,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\PublicKeyLoader;
-use phpseclib\Crypt\RSA\Formats\Keys\PKCS8;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
 
 class Unit_Crypt_RSA_ModeTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RandomTest.php
+++ b/tests/Unit/Crypt/RandomTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Random;
+use phpseclib3\Crypt\Random;
 
 class Unit_Crypt_RandomTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/Salsa20.php
+++ b/tests/Unit/Crypt/Salsa20.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Salsa20;
+use phpseclib3\Crypt\Salsa20;
 
 class Unit_Crypt_Salsa20Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/TripleDESTest.php
+++ b/tests/Unit/Crypt/TripleDESTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\TripleDES;
+use phpseclib3\Crypt\TripleDES;
 
 class Unit_Crypt_TripleDESTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/TwofishTest.php
+++ b/tests/Unit/Crypt/TwofishTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Crypt\Twofish;
+use phpseclib3\Crypt\Twofish;
 
 class Unit_Crypt_TwofishTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/ANSITest.php
+++ b/tests/Unit/File/ANSITest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\ANSI;
+use phpseclib3\File\ANSI;
 
 class Unit_File_ANSITest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -5,12 +5,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\ASN1;
+use phpseclib3\File\ASN1;
 
 class Unit_File_ASN1Test extends PhpseclibTestCase
 {
     /**
-     * on older versions of \phpseclib\File\ASN1 this would yield a PHP Warning
+     * on older versions of \phpseclib3\File\ASN1 this would yield a PHP Warning
      * @group github275
      */
     public function testAnyString()
@@ -82,7 +82,7 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
     }
 
     /**
-     * on older versions of \phpseclib\File\ASN1 this would produce a null instead of an array
+     * on older versions of \phpseclib3\File\ASN1 this would produce a null instead of an array
      * @group github275
      */
     public function testIncorrectString()
@@ -121,7 +121,7 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
                     'min' => 0,
                     'max' => -1,
                     'type' => ASN1::TYPE_SEQUENCE,
-                    'children' => ['type' => ASN1::TYPE_IA5_STRING] // should be \phpseclib\File\ASN1::TYPE_GENERAL_STRING
+                    'children' => ['type' => ASN1::TYPE_IA5_STRING] // should be \phpseclib3\File\ASN1::TYPE_GENERAL_STRING
                 ]
             ]
         ];
@@ -301,7 +301,7 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
                 continue;
             }
 
-            constant('phpseclib\\File\\ASN1\\Maps\\' . basename($file, '.php') . '::MAP');
+            constant('phpseclib3\\File\\ASN1\\Maps\\' . basename($file, '.php') . '::MAP');
         }
     }
 

--- a/tests/Unit/File/X509/CRLTest.php
+++ b/tests/Unit/File/X509/CRLTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\X509;
+use phpseclib3\File\X509;
 
 class Unit_File_X509_CRLTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/X509/CSRTest.php
+++ b/tests/Unit/File/X509/CSRTest.php
@@ -5,9 +5,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\X509;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\PublicKeyLoader;
+use phpseclib3\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 class Unit_File_X509_CSRTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/X509/SPKACTest.php
+++ b/tests/Unit/File/X509/SPKACTest.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\X509;
-use phpseclib\Crypt\RSA;
+use phpseclib3\File\X509;
+use phpseclib3\Crypt\RSA;
 
 class Unit_File_X509_SPKACTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -5,11 +5,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\File\ASN1;
-use phpseclib\File\ASN1\Element;
-use phpseclib\File\X509;
-use phpseclib\Crypt\RSA;
-use phpseclib\Crypt\PublicKeyLoader;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Element;
+use phpseclib3\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 class Unit_File_X509_X509Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Math/BigInteger/BCMathTest.php
+++ b/tests/Unit/Math/BigInteger/BCMathTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger\Engines\BCMath;
+use \phpseclib3\Math\BigInteger\Engines\BCMath;
 
 class Unit_Math_BigInteger_BCMathTest extends Unit_Math_BigInteger_TestCase
 {
@@ -24,6 +24,6 @@ class Unit_Math_BigInteger_BCMathTest extends Unit_Math_BigInteger_TestCase
 
     public static function getStaticClass()
     {
-        return 'phpseclib\Math\BigInteger\Engines\BCMath';
+        return 'phpseclib3\Math\BigInteger\Engines\BCMath';
     }
 }

--- a/tests/Unit/Math/BigInteger/DefaultTest.php
+++ b/tests/Unit/Math/BigInteger/DefaultTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger;
+use \phpseclib3\Math\BigInteger;
 
 class Unit_Math_BigInteger_DefaultTest extends Unit_Math_BigInteger_TestCase
 {
@@ -16,6 +16,6 @@ class Unit_Math_BigInteger_DefaultTest extends Unit_Math_BigInteger_TestCase
 
     public static function getStaticClass()
     {
-        return 'phpseclib\Math\BigInteger';
+        return 'phpseclib3\Math\BigInteger';
     }
 }

--- a/tests/Unit/Math/BigInteger/GMPTest.php
+++ b/tests/Unit/Math/BigInteger/GMPTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger\Engines\GMP;
+use \phpseclib3\Math\BigInteger\Engines\GMP;
 
 class Unit_Math_BigInteger_GMPTest extends Unit_Math_BigInteger_TestCase
 {
@@ -24,6 +24,6 @@ class Unit_Math_BigInteger_GMPTest extends Unit_Math_BigInteger_TestCase
 
     public static function getStaticClass()
     {
-        return 'phpseclib\Math\BigInteger\Engines\GMP';
+        return 'phpseclib3\Math\BigInteger\Engines\GMP';
     }
 }

--- a/tests/Unit/Math/BigInteger/PHP32Test.php
+++ b/tests/Unit/Math/BigInteger/PHP32Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger\Engines\PHP32;
+use \phpseclib3\Math\BigInteger\Engines\PHP32;
 
 class Unit_Math_BigInteger_PHP32Test extends Unit_Math_BigInteger_TestCase
 {
@@ -33,6 +33,6 @@ class Unit_Math_BigInteger_PHP32Test extends Unit_Math_BigInteger_TestCase
 
     public static function getStaticClass()
     {
-        return 'phpseclib\Math\BigInteger\Engines\PHP32';
+        return 'phpseclib3\Math\BigInteger\Engines\PHP32';
     }
 }

--- a/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
+++ b/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger\Engines\PHP64;
+use \phpseclib3\Math\BigInteger\Engines\PHP64;
 
 class Unit_Math_BigInteger_PHP64OpenSSLTest extends Unit_Math_BigInteger_PHP64Test
 {

--- a/tests/Unit/Math/BigInteger/PHP64Test.php
+++ b/tests/Unit/Math/BigInteger/PHP64Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib\Math\BigInteger\Engines\PHP64;
+use \phpseclib3\Math\BigInteger\Engines\PHP64;
 
 class Unit_Math_BigInteger_PHP64Test extends Unit_Math_BigInteger_TestCase
 {
@@ -32,6 +32,6 @@ class Unit_Math_BigInteger_PHP64Test extends Unit_Math_BigInteger_TestCase
 
     public static function getStaticClass()
     {
-        return 'phpseclib\Math\BigInteger\Engines\PHP64';
+        return 'phpseclib3\Math\BigInteger\Engines\PHP64';
     }
 }

--- a/tests/Unit/Math/BigIntegerTest.php
+++ b/tests/Unit/Math/BigIntegerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use phpseclib\Math\BigInteger;
-use phpseclib\Math\BigInteger\Engines\BCMath;
-use phpseclib\Math\BigInteger\Engines\GMP;
-use phpseclib\Math\BigInteger\Engines\PHP32;
-use phpseclib\Math\BigInteger\Engines\PHP64;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\GMP;
+use phpseclib3\Math\BigInteger\Engines\PHP32;
+use phpseclib3\Math\BigInteger\Engines\PHP64;
 
 class Unit_Math_BigIntegerTest extends PhpseclibTestCase
 {
@@ -15,8 +15,8 @@ class Unit_Math_BigIntegerTest extends PhpseclibTestCase
 	 */
 	private static function mockEngine($className, $isValid) {
 		eval(<<<ENGINE
-namespace phpseclib\Math\BigInteger\Engines;
-class ${className} extends \phpseclib\Math\BigInteger\Engines\Engine {
+namespace phpseclib3\Math\BigInteger\Engines;
+class ${className} extends \phpseclib3\Math\BigInteger\Engines\Engine {
 	public function __construct(){} 
 	public static function isValidEngine() { return ${isValid}; }
 	public static function setModExpEngine(\$engine){} 

--- a/tests/Unit/Net/SFTPStreamTest.php
+++ b/tests/Unit/Net/SFTPStreamTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib\Net\SFTP\Stream;
+use phpseclib3\Net\SFTP\Stream;
 
 class Unit_Net_SFTPStreamTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Net/SSH2Test.php
+++ b/tests/Unit/Net/SSH2Test.php
@@ -112,22 +112,22 @@ class Unit_Net_SSH2Test extends PhpseclibTestCase
 
     public function testGetConnectionByResourceId()
     {
-        $ssh = new \phpseclib\Net\SSH2('localhost');
-        $this->assertSame($ssh, \phpseclib\Net\SSH2::getConnectionByResourceId($ssh->getResourceId()));
+        $ssh = new \phpseclib3\Net\SSH2('localhost');
+        $this->assertSame($ssh, \phpseclib3\Net\SSH2::getConnectionByResourceId($ssh->getResourceId()));
     }
 
     public function testGetResourceId()
     {
-        $ssh = new \phpseclib\Net\SSH2('localhost');
+        $ssh = new \phpseclib3\Net\SSH2('localhost');
         $this->assertSame('{' . spl_object_hash($ssh) . '}', $ssh->getResourceId());
     }
 
     /**
-     * @return \phpseclib\Net\SSH2
+     * @return \phpseclib3\Net\SSH2
      */
     protected function createSSHMock()
     {
-        return $this->getMockBuilder('phpseclib\Net\SSH2')
+        return $this->getMockBuilder('phpseclib3\Net\SSH2')
             ->disableOriginalConstructor()
             ->setMethods(['__destruct'])
             ->getMock();


### PR DESCRIPTION
The motivation for this change is so that phpseclib 2.0 (or at least a shim of 2.0) and 3.0 can co-exist so that problems like #1427 can be avoided. In order to be an effective shim the shim has to have the namespace as phpseclib 2.0 (eg. `\phpseclib\Crypt\RSA`) which means that if the shim is going to be using phpseclib 3.0 that phpseclib 3.0 can't make use of that same namespace as phpseclib 2.0 because otherwise the PHP will think files are already loaded when they're in fact not (and if it did try to force load them you'd get a "class already exists" error)

Since phpseclib 3.0 is a huge BC breaking change, anyway, one more very minor BC breaking change isn't a huge deal imho