### PR TITLE
read larger chunks from sftp in stream wrapper

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -17,6 +17,7 @@
 
 namespace phpseclib3\Net\SFTP;
 
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Net\SFTP;
 use phpseclib3\Net\SSH2;
@@ -339,8 +340,7 @@ class Stream
             $this->buffer .= $chunk;
         }
 
-        $result = substr($this->buffer, 0, $count);
-        $this->buffer = substr($this->buffer, $count);
+        $result = Strings::shift($this->buffer, $count);
 
         if (empty($result)) { // ie. false or empty string
             $this->eof = true;
@@ -360,6 +360,9 @@ class Stream
      */
     private function _stream_write($data)
     {
+        // invalidate any readahead buffer on write
+        $this->buffer = '';
+
         switch ($this->mode) {
             case 'r':
                 return false;
@@ -425,6 +428,9 @@ class Stream
      */
     private function _stream_seek($offset, $whence)
     {
+        // invalidate any readahead buffer on seek
+        $this->buffer = '';
+
         switch ($whence) {
             case SEEK_SET:
                 if ($offset >= $this->size || $offset < 0) {
@@ -738,6 +744,9 @@ class Stream
      */
     private function _stream_truncate($new_size)
     {
+        // invalidate any readahead buffer on truncate
+        $this->buffer = '';
+
         if (!$this->sftp->truncate($this->path, $new_size)) {
             return false;
         }

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -114,6 +114,8 @@ class Stream
      */
     private $notification;
 
+    private $readAheadLength = 81920;
+
     /**
      * Buffer of data being read
      *
@@ -215,6 +217,9 @@ class Stream
             }
             if (isset($context[$scheme]['privkey']) && $context[$scheme]['privkey'] instanceof RSA) {
                 $pass = $context[$scheme]['privkey'];
+            }
+            if (isset($context[$scheme]['readahead_length'])) {
+                $this->readAheadLength = $context[$scheme]['readahead_length'];
             }
 
             if (!isset($user) || !isset($pass)) {
@@ -325,9 +330,9 @@ class Stream
         //}
 
         if (strlen($this->buffer) < $count) {
-            // read 80k chunks from sftp even though php will only request 8k chunk
+            // read 80k chunks (configurable by the readahead_length context option) from sftp even though php will only request 8k chunk
             // this allows us to minimize the overhead of making sftp requests
-            $chunk = $this->sftp->get($this->path, false, $this->pos, 81920);
+            $chunk = $this->sftp->get($this->path, false, $this->pos, $this->readAheadLength);
             if (isset($this->notification) && is_callable($this->notification)) {
                 if ($chunk === false) {
                     call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $this->sftp->getLastSFTPError(), NET_SFTP_OPEN, 0, 0);


### PR DESCRIPTION
This speeds up reading from the stream wrapper about 5x in my local testing, increasing the chunk size further doesn't seem to make a difference