### PR TITLE
Fix logic error reading random bytes from /dev/urandom

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -98,7 +98,7 @@ class Random
             }
             if ($fp !== true && $fp !== false) { // surprisingly faster than !is_bool() or is_resource()
                 $temp = fread($fp, $length);
-                if (strlen($temp) != $length) {
+                if (strlen($temp) == $length) {
                     return $temp;
                 }
             }


### PR DESCRIPTION
Fixes a bug introduced in c2be7e648

Previously, this would return those bytes if the number of bytes read
was **less than** the number of bytes this was trying to read.

In practice, I believe this would mean bytes from /dev/urandom would never
get used.  (Noticed when upgrading phpseclib)

Also, I think that `if (!\is_bool($fp))` might be even faster than `if ($fp !== true && $fp !== false) {` or `if (!is_bool($fp))` - PHP Opcache can convert the is_bool call to an efficient ZEND_TYPE_CHECK opcode instead of a function call, but only if opcache is enabled and the call is fully qualified (e.g. with `\`).

This looks like it only impacts php 5 applications without openssl support