### PR TITLE
_parseKey should return false by default

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -1624,6 +1624,8 @@ class Crypt_RSA
 
                 return $components;
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
If you try to use `setKey` with a non supported type, you handle with an exception.
Indeed the method `_parseKey` will return `null` but the check made after is `=== false`.

This fix, should be made in 2.0 too. I assume you'll merge 1.0 into 2.0.