### PR TITLE
Resource not closed

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2084,14 +2084,16 @@ class SFTP extends SSH2
             return false;
         }
 
-        if ($mode & self::SOURCE_LOCAL_FILE) {
-            if ($this->preserveTime) {
-                $stat = fstat($fp);
-                $this->touch($remote_file, $stat['mtime'], $stat['atime']);
-            }
-
-            fclose($fp);
-        }
+		if ($mode & self::SOURCE_LOCAL_FILE) {
+			if ($this->preserveTime) {
+				$stat = fstat($fp);
+				$this->touch($remote_file, $stat['mtime'], $stat['atime']);
+			}
+		}
+		
+        if(is_resource($fp)) {
+        	fclose($fp);
+		}
 
         return $this->_close_handle($handle);
     }

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2091,7 +2091,7 @@ class SFTP extends SSH2
 	    }
 	}
 		
-        if(is_resource($fp)) {
+        if(isset($fp) && is_resource($fp)) {
 	     fclose($fp);
 	}
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2084,16 +2084,16 @@ class SFTP extends SSH2
             return false;
         }
 
-		if ($mode & self::SOURCE_LOCAL_FILE) {
-			if ($this->preserveTime) {
-				$stat = fstat($fp);
-				$this->touch($remote_file, $stat['mtime'], $stat['atime']);
-			}
-		}
+	if ($mode & self::SOURCE_LOCAL_FILE) {
+	    if ($this->preserveTime) {
+		$stat = fstat($fp);
+		$this->touch($remote_file, $stat['mtime'], $stat['atime']);
+	    }
+	}
 		
         if(is_resource($fp)) {
-        	fclose($fp);
-		}
+	     fclose($fp);
+	}
 
         return $this->_close_handle($handle);
     }


### PR DESCRIPTION
Hey there,

We might have been identified a problem with the SFTP (2.x) version only. This file has been used by League Flysystem SFTP adapter itensively. We found this in the League package itself as well, however the problem could be solved by changing just a few lines of code - see my pull request.

Since we're having a strong dependency on the adapter pattern - provided by the League package - we cannot get rid of it. This has led us to change these lines.

About the problem: We faced with an issue, when transferring files from a local <-> SFTP destination (and vice-versa) and some of the read streams are just being stuck / not closed