### PR TITLE
ProgressCallback should report the actual downloaded amount of data and not the requested packets.

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2248,9 +2248,6 @@ class SFTP extends SSH2
                 }
                 $packet = null;
                 $read+= $packet_size;
-                if (is_callable($progressCallback)) {
-                    call_user_func($progressCallback, $read);
-                }
                 $i++;
             }
 
@@ -2279,6 +2276,9 @@ class SFTP extends SSH2
                             $content.= $temp;
                         } else {
                             fputs($fp, $temp);
+                        }
+                        if (is_callable($progressCallback)) {
+                            call_user_func($progressCallback, $offset);
                         }
                         $temp = null;
                         break;


### PR DESCRIPTION
$progressCallback should be called after a specific amount of data has been received and not, if its just requested, as the requested packets might be more as the available and received data.

This does not only solve the problem for $length = -1, because it requests 32 "slots" of max_packet_size packets nevertheless if the requested file is that big or not, it also solves the issue that requesting the data is not having the data delivered. Placing the call to $progressCallback later in the script, it reports the actual received amount of data.