### PR TITLE
SFTP: add stream to get method

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2217,7 +2217,7 @@ class SFTP extends SSH2
             $res_offset = $stat['size'];
         } else {
             $res_offset = 0;
-            if ($local_file !== false) {
+            if ($local_file !== false && !is_callable($local_file) ) {
                 $fp = fopen($local_file, 'wb');
                 if (!$fp) {
                     return false;
@@ -2227,7 +2227,7 @@ class SFTP extends SSH2
             }
         }
 
-        $fclose_check = $local_file !== false && !is_resource($local_file);
+        $fclose_check = $local_file !== false && !is_callable($local_file) && !is_resource($local_file);
 
         $start = $offset;
         $read = 0;
@@ -2274,6 +2274,8 @@ class SFTP extends SSH2
                         $offset+= strlen($temp);
                         if ($local_file === false) {
                             $content.= $temp;
+                        } elseif (is_callable($local_file)) {
+													$local_file($temp);
                         } else {
                             fputs($fp, $temp);
                         }


### PR DESCRIPTION
Hello Guys,

I have a proposal of the streaming feature for `->get()` method of `SFTP` class. 
It is very easy to implement and gives you nice flexibility of what you can do with the streamed file content.  
For example, parsing CSV and saving into DB in the fly, etc.

```
$sftp = new SFTP('www.domain.tld');
if (!$sftp->login('username', 'password')) {
	exit('Login Failed');
}

//returns outputs the contents of filename.remote to callback function
$sftp->get('filename.remote',function($output){
	//parse csv
	//DB save
});

```
Thanks