### PR TITLE
Fix a Doctum 5.3.0-dev phpdoc reported error

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2705,7 +2705,7 @@ class Net_SSH2
      *
      * Sends an SSH2_MSG_IGNORE message every x seconds, if x is a positive non-zero number.
      *
-     * @param mixed $timeout
+     * @param int $interval
      * @access public
      */
     function setKeepAlive($interval)


### PR DESCRIPTION
Hi,

I am testing my latest version on different code-bases and I found one error:
```
 ------ ----------------------------------------------------------------------------------------------------------- 
  Line   /mnt/Dev/@code-lts/@doctum-fork/api-docs/phpseclib/phpseclib/Net/SSH2.php                                  
 ------ ----------------------------------------------------------------------------------------------------------- 
  2711   The "interval" parameter of the method "setKeepAlive" is missing a @param tag on "Net_SSH2::setKeepAlive"  
 ------ ----------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 1 error                                                                                                  

```

Affects: 1.x, 2.x, 3.x