### PR TITLE
Fix docblock

### DIFF
--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -50,7 +50,6 @@ class Identity implements PrivateKey
      */
     const SSH_AGENT_RSA2_256 = 2;
     const SSH_AGENT_RSA2_512 = 4;
-    /**#@-*/
 
     /**
      * Key Object

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -41,7 +41,7 @@ class Identity implements PrivateKey
 {
     use \phpseclib3\System\SSH\Common\Traits\ReadBytes;
 
-    /**@+
+    /**
      * Signature Flags
      *
      * See https://tools.ietf.org/html/draft-miller-ssh-agent-00#section-5.3


### PR DESCRIPTION
While bundling phpseclib into a phar for a third-party app, an error was thrown because of the invalid doc block. This PR fixes the docblock and removes an unneeded (?) comment.