### PR TITLE
Add PHP 8 support for PublicKeyLoader::load()

### DIFF
--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
@@ -61,7 +61,7 @@ abstract class PKCS1 extends Progenitor
     {
         self::initialize_static_variables();
 
-        if (strpos($key, 'BEGIN EC PARAMETERS') && strpos($key, 'BEGIN EC PRIVATE KEY')) {
+        if (is_string($key) && strpos($key, 'BEGIN EC PARAMETERS') && strpos($key, 'BEGIN EC PRIVATE KEY')) {
             $components = [];
 
             preg_match('#-*BEGIN EC PRIVATE KEY-*[^-]*-*END EC PRIVATE KEY-*#s', $key, $matches);

--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -33,7 +33,7 @@ abstract class PublicKeyLoader
      *
      * @return AsymmetricKey
      * @access public
-     * @param string $key
+     * @param string|array $key
      * @param string $password optional
      */
     public static function load($key, $password = false)

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -34,6 +34,17 @@ class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
         PublicKeyLoader::load($key);
     }
 
+    public function testLoadModulusAndExponent()
+    {
+        $rsa = PublicKeyLoader::load([
+            'e' => new BigInteger('123', 16),
+            'n' => new BigInteger('123', 16)
+        ]);
+
+        $this->assertInstanceOf(PublicKey::class, $rsa);
+        $this->assertIsString("$rsa");
+    }
+
     public function testPKCS1Key()
     {
         $key = '-----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
The following example taken from documentation
https://phpseclib.com/docs/rsa#raw-rsa-public-keys

Pass in PHP 7.4
But not in the stable current version of PHP 8.0
```
There was 1 error:

1) Unit_Crypt_RSA_LoadKeyTest::testLoadModulusAndExponent
TypeError: strpos(): Argument #1 ($haystack) must be of type string, array given

C:\Users\kylek\PhpstormProjects\phpseclib\phpseclib\Crypt\EC\Formats\Keys\PKCS1.php:64
C:\Users\kylek\PhpstormProjects\phpseclib\phpseclib\Crypt\Common\AsymmetricKey.php:162
C:\Users\kylek\PhpstormProjects\phpseclib\phpseclib\Crypt\PublicKeyLoader.php:42
C:\Users\kylek\PhpstormProjects\phpseclib\tests\Unit\Crypt\RSA\LoadKeyTest.php:44
```
https://travis-ci.com/github/phpseclib/phpseclib/jobs/464235441#L3282