### PR TITLE
ChaCha20 testsuite: tfix (missing quote)

### DIFF
--- a/tests/Unit/Crypt/ChaCha20.php
+++ b/tests/Unit/Crypt/ChaCha20.php
@@ -25,7 +25,7 @@ class Unit_Crypt_ChaCha20Test extends PhpseclibTestCase
         $expected = str_replace(' ', '', $expected);
         $expected = pack('H*', $expected);
 
-        $engines = ['PHP', OpenSSL', 'libsodium'];
+        $engines = ['PHP', 'OpenSSL', 'libsodium'];
         for ($engines as $engine) {
             $c = new ChaCha20();
             $c->setKey($key);


### PR DESCRIPTION
For some reason, this test doesn’t seem to be used by the CI.