### PR TITLE
Allow to pass end date as DateTime

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3061,7 +3061,7 @@ class X509
 
           -- http://tools.ietf.org/html/rfc5280#section-4.1.2.5
         */
-        if (strtolower($date) == 'lifetime') {
+        if (is_string($date) && strtolower($date) === 'lifetime') {
             $temp = '99991231235959Z';
             $temp = chr(ASN1::TYPE_GENERALIZED_TIME) . ASN1::encodeLength(strlen($temp)) . $temp;
             $this->endDate = new Element($temp);


### PR DESCRIPTION
While the method intents to support date objects, it's actually made impossible due to `strtolower()` throwing an error. This preliminary check will actually allow to enter into the `else` without triggering the `if (!is_object($date) || !($date instanceof DateTimeInterface))` e.g. support `DateTimeInterface` as parameter.