### PR TITLE
Allow newer versions of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     ],
     "require": {
         "paragonie/constant_time_encoding": "^1|^2",
-        "paragonie/random_compat": "^1.4|^2.0",
+        "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
         "php": ">=5.6.1"
     },
     "require-dev": {


### PR DESCRIPTION
Allows to use version of paragonie/random_compat which is NOOP for PHP 7.0 or newer.