### PR TITLE
fix undefined index notice in stream touch()

### DIFF
--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -447,7 +447,7 @@ class Stream extends SFTP
         //     and https://github.com/php/php-src/blob/master/main/php_streams.h#L592
         switch ($option) {
             case 1: // PHP_STREAM_META_TOUCH
-                return $this->sftp->touch($path, $var[0], $var[1]);
+                return $this->sftp->touch($path, $var[0] ?? null, $var[1] ?? null);
             case 2: // PHP_STREAM_OWNER_NAME
             case 3: // PHP_STREAM_GROUP_NAME
                 return false;

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -447,11 +447,9 @@ class Stream extends SFTP
         //     and https://github.com/php/php-src/blob/master/main/php_streams.h#L592
         switch ($option) {
             case 1: // PHP_STREAM_META_TOUCH
-            {
                 $time = isset($var[0]) ? $var[0] : null;
                 $atime = isset($var[1]) ? $var[1] : null;
                 return $this->sftp->touch($path, $time, $atime);
-            }
             case 2: // PHP_STREAM_OWNER_NAME
             case 3: // PHP_STREAM_GROUP_NAME
                 return false;

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -447,7 +447,11 @@ class Stream extends SFTP
         //     and https://github.com/php/php-src/blob/master/main/php_streams.h#L592
         switch ($option) {
             case 1: // PHP_STREAM_META_TOUCH
-                return $this->sftp->touch($path, $var[0] ?? null, $var[1] ?? null);
+            {
+                $time = isset($var[0]) ? $var[0] : null;
+                $atime = isset($var[1]) ? $var[1] : null;
+                return $this->sftp->touch($path, $time, $atime);
+            }
             case 2: // PHP_STREAM_OWNER_NAME
             case 3: // PHP_STREAM_GROUP_NAME
                 return false;


### PR DESCRIPTION
I was getting a PHP notice in Stream.php.  It would happen when using touch( ) with the stream wrapper and no atime/mtime given.            

`vendor/phpseclib/phpseclib/phpseclib/Net/SFTP/Stream.php(450): Undefined offset: 0`