### PR TITLE
Don't filter basicConstraints on unique values

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -2751,7 +2751,7 @@ class X509
 
             $this->setExtension(
                 'id-ce-basicConstraints',
-                array_unique(array_merge(['cA' => true], $basicConstraints)),
+                array_merge(['cA' => true], $basicConstraints),
                 true
             );
 


### PR DESCRIPTION
array_unique check values which is not relevant for basicConstraints where `true == "foo"` so prevent to specify any other constraint (like pathlen)