### PR TITLE
Create tbsCertificate/extensions if missing

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -670,7 +670,7 @@ class X509
      */
     private function mapOutExtensions(&$root, $path)
     {
-        $extensions = &$this->subArray($root, $path);
+        $extensions = &$this->subArray($root, $path, true);
 
         foreach ($this->extensionValues as $id => $data) {
             extract($data);


### PR DESCRIPTION
Fix #1642
Create tbsCertificate/extensions if missing when extensions values are proceeded