### PR TITLE
ASN1: fix timezone issue when non-utc time is given

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -1032,6 +1032,7 @@ abstract class ASN1
                 $format = $mapping['type'] == self::TYPE_UTC_TIME ? 'y' : 'Y';
                 $format.= 'mdHis';
                 $date = new DateTime($source, new DateTimeZone('GMT'));
+                $date->setTimezone(new DateTimeZone('GMT'));
                 $value = $date->format($format) . 'Z';
                 break;
             case self::TYPE_BIT_STRING:


### PR DESCRIPTION
This pull request addresses issue #1652. It provides a fix for the correct timezone in the ASN1 parser.