### PR TITLE
fix exception thrown because of undefined constant with php7.4

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2940,7 +2940,7 @@ class SFTP extends SSH2
         while (strlen($this->packet_buffer) < 4) {
             $temp = $this->get_channel_packet(self::CHANNEL, true);
             if ($temp === true) {
-                if ($this->channel_status[NET_SFTP_CHANNEL] === NET_SSH2_MSG_CHANNEL_CLOSE) {
+                if ($this->channel_status[self::CHANNEL] === NET_SSH2_MSG_CHANNEL_CLOSE) {
                     $this->channel_close = true;
                 }
                 $this->packet_type = false;


### PR DESCRIPTION
Hello,

When using php7.4 and symfony an exception is thrown while using SFTP class :
`WARNING   [php] Warning: Use of undefined constant NET_SFTP_CHANNEL - assumed 'NET_SFTP_CHANNEL' (this will throw an Error in a future version of PHP)`

This is because of this line : 
`if ($this->channel_status[NET_SFTP_CHANNEL] === NET_SSH2_MSG_CHANNEL_CLOSE) {`
NET_SFTP_CHANNEL is not defined as a constant.