### PR TITLE
Throw an error when a packet can not be read to prevent infinite loop

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3108,6 +3108,9 @@ class SFTP extends SSH2
                 $this->packet_buffer = '';
                 return false;
             }
+            if ($temp === false) {
+                throw new \RuntimeException('Packet can not be read');
+            }
             $this->packet_buffer.= $temp;
         }
         if (strlen($this->packet_buffer) < 4) {


### PR DESCRIPTION
The method SSH2::_get_channel_packet() returns false when
the connection has been closed. This would cause an infinite loop
in SFTP::_get_sftp_packet because it keeps reading until the packet
buffer length is 4. To solve this a runtime exception is thrown when the
return value is false.