### PR TITLE
timeout in _get_channel_packet during  _init_sftp_connection should be a failure

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -467,6 +467,8 @@ class SFTP extends SSH2
         $response = $this->_get_channel_packet(self::CHANNEL, true);
         if ($response === false) {
             return false;
+        } else if ($response === true && $this->isTimeout()) {
+            return false;
         }
 
         $packet = pack(
@@ -513,6 +515,8 @@ class SFTP extends SSH2
             if ($response === false) {
                 return false;
             }
+        } else if ($response === true && $this->isTimeout()) {
+            return false;
         }
 
         $this->channel_status[self::CHANNEL] = NET_SSH2_MSG_CHANNEL_DATA;


### PR DESCRIPTION
If using SFTP to connect to a server that timed out during the initial connection, you'll get weird error messages, as the _init_sftp_connection will ignore the timeout and continue to try to connect, but now the underlying SSH connection is in a weird state. Instead, it should treat that as a failure.

The underlying issue can be reproduced by changing the timeout to a really small value (say 1 second) and then connecting to a server far enough away that it'll timeout during connection.