### PR TITLE
PublicKeyLoader: make all methods static

### DIFF
--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -72,7 +72,7 @@ abstract class PublicKeyLoader
      * @param string|array $key
      * @param string $password optional
      */
-    public function loadPrivateKey($key, $password = false)
+    public static function loadPrivateKey($key, $password = false)
     {
         $key = self::load($key, $password);
         if (!$key instanceof PrivateKey) {
@@ -88,7 +88,7 @@ abstract class PublicKeyLoader
      * @access public
      * @param string|array $key
      */
-    public function loadPublicKey($key)
+    public static function loadPublicKey($key)
     {
         $key = self::load($key);
         if (!$key instanceof PublicKey) {
@@ -104,7 +104,7 @@ abstract class PublicKeyLoader
      * @access public
      * @param string|array $key
      */
-    public function loadParameters($key)
+    public static function loadParameters($key)
     {
         $key = self::load($key);
         if (!$key instanceof PrivateKey && !$key instanceof PublicKey) {


### PR DESCRIPTION
Those methods are intended to be used statically.

However, as they are not static, calling them statically will trigger a deprecation warning in PHP 7 and throw an error in PHP 8.
