### PR TITLE
add option to allow arbitrary length packets

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -270,6 +270,21 @@ class SFTP extends SSH2
     var $preserveTime = false;
 
     /**
+     * Arbitrary Length Packets Flag
+     *
+     * Determines whether or not packets of any length should be allowed,
+     * in cases where the server chooses the packet length (such as
+     * directory listings). By default, packets are only allowed to be
+     * 256 * 1024 bytes (SFTP_MAX_MSG_LENGTH from OpenSSH's sftp-common.h)
+     *
+     * @see self::enableArbitraryLengthPackets()
+     * @see self::_get_sftp_packet()
+     * @var bool
+     * @access private
+     */
+    var $allow_arbitrary_length_packets = false;
+
+    /**
      * Was the last packet due to the channels being closed or not?
      *
      * @see self::get()
@@ -642,6 +657,16 @@ class SFTP extends SSH2
     function enablePathCanonicalization()
     {
         $this->canonicalize_paths = true;
+    }
+
+    /**
+     * Enable arbitrary length packets
+     *
+     * @access public
+     */
+    function enableArbitraryLengthPackets()
+    {
+        $this->allow_arbitrary_length_packets = true;
     }
 
     /**
@@ -3126,7 +3151,7 @@ class SFTP extends SSH2
 
 
         // 256 * 1024 is what SFTP_MAX_MSG_LENGTH is set to in OpenSSH's sftp-common.h
-        if (!$this->use_request_id && $tempLength > 256 * 1024) {
+        if (!$this->allow_arbitrary_length_packets &&!$this->use_request_id && $tempLength > 256 * 1024) {
             user_error('Invalid SFTP packet size');
             return false;
         }


### PR DESCRIPTION
The company OpenText has their own SFTP server, and when navigating a directory with a large number of files, the entire directory listing is in one packet. As such, the packet can get arbitrarily long. Add a flag to allow any length packets. This probably should still default to being off, as this could maybe be a security issue where the server could claim to send any length packet. For our needs, we trust the server enough to allow them to send any length, and the directory could have any number of files, so putting any "reasonable" limit on it might not work, thus the request is to allow arbitrarily long packets.