### PR TITLE
add SFTP v4/5/6 support to phpseclib v1

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -206,6 +206,15 @@ class Net_SFTP extends Net_SSH2
     var $defaultVersion;
 
     /**
+     * Preferred SFTP version
+     *
+     * @var int
+     * @see self::_initChannel()
+     * @access private
+     */
+    var $preferredVersion = 3;
+
+    /**
      * Current working directory
      *
      * @var string

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -330,14 +330,6 @@ class Net_SFTP extends Net_SSH2
     var $partial_init = false;
 
     /**
-     * Has the SFTP channel been fully negotiated?
-     *
-     * @var bool
-     * @access private
-     */
-    var $full_init = false;
-
-    /**
      * Default Constructor.
      *
      * Connects to an SFTP server
@@ -515,7 +507,7 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
-        if (!$this->full_init) {
+        if ($this->pwd === false) {
             return $this->_init_sftp_connection();
         }
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -792,6 +792,10 @@ class Net_SFTP extends Net_SSH2
      */
     function pwd()
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
         return $this->pwd;
     }
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -829,6 +829,10 @@ class Net_SFTP extends Net_SSH2
      */
     function realpath($path)
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
         return $this->_realpath($path);
     }
 
@@ -1293,10 +1297,6 @@ class Net_SFTP extends Net_SSH2
      */
     function size($filename)
     {
-        if (!$this->_precheck()) {
-            return false;
-        }
-
         $result = $this->stat($filename);
         if ($result === false) {
             return false;
@@ -2693,6 +2693,10 @@ SFTP v6 changes (from v5)
     function file_exists($path)
     {
         if ($this->use_stat_cache) {
+            if (!$this->_precheck()) {
+                return false;
+            }
+
             $path = $this->_realpath($path);
 
             $result = $this->_query_stat_cache($path);
@@ -2763,6 +2767,10 @@ SFTP v6 changes (from v5)
      */
     function is_readable($path)
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
         $path = $this->_realpath($path);
 
         $packet = pack('Na*N2', strlen($path), $path, NET_SFTP_OPEN_READ, 0);
@@ -2791,6 +2799,10 @@ SFTP v6 changes (from v5)
      */
     function is_writable($path)
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
         $path = $this->_realpath($path);
 
         $packet = pack('Na*N2', strlen($path), $path, NET_SFTP_OPEN_WRITE, 0);
@@ -2971,6 +2983,10 @@ SFTP v6 changes (from v5)
      */
     function _get_xstat_cache_prop($path, $prop, $type)
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
         if ($this->use_stat_cache) {
             $path = $this->_realpath($path);
 
@@ -3000,6 +3016,10 @@ SFTP v6 changes (from v5)
      */
     function rename($oldname, $newname)
     {
+        if (!$this->_precheck()) {
+            return false;
+        }
+
 // in SFTP v5+
 // Add support for better control of the rename operation.
 // so we'll just need to add \0\0\0\0 after

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -674,7 +674,7 @@ class Net_SFTP extends Net_SSH2
         */
         if (isset($this->extensions['versions']) && (!$this->preferredVersion || $this->preferredVersion != $this->version)) {
             $versions = explode(',', $this->extensions['versions']);
-            $supported = [6, 5, 4];
+            $supported = array(6, 5, 4);
             if ($this->preferredVersion) {
                 $supported = array_diff($supported, [$this->preferredVersion]);
                 array_unshift($supported, $this->preferredVersion);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1981,7 +1981,7 @@ class Net_SFTP extends Net_SSH2
                    uint32      id
                    string      targetpath
                    string      linkpath */
-            $packet = substr($this->server_identifier, 0, 13) == 'SSH-2.0-OpenSSH' ?
+            $packet = substr($this->server_identifier, 0, 15) == 'SSH-2.0-OpenSSH' ?
                 pack('Na*Na*', strlen($target), $target, strlen($link), $link) :
                 pack('Na*Na*', strlen($link), $link, strlen($target), $target);
         }

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3079,7 +3079,6 @@ SFTP v6 changes (from v5)
         foreach ($this->attributes as $key => $value) {
             switch ($flags & $key) {
                 case NET_SFTP_ATTR_SIZE:             // 0x00000001
-echo "size\n";
                     // The size attribute is defined as an unsigned 64-bit integer.
                     // The following will use floats on 32-bit platforms, if necessary.
                     // As can be seen in the BigInteger class, floats are generally
@@ -3089,7 +3088,6 @@ echo "size\n";
                     $attr['size'] = hexdec(bin2hex($this->_string_shift($response, 8)));
                     break;
                 case NET_SFTP_ATTR_UIDGID:           // 0x00000002 (SFTPv3 or earlier)
-echo "uidgid\n";
                     if (strlen($response) < 8) {
                         user_error('Malformed file attributes');
                         return $attr;
@@ -3097,7 +3095,6 @@ echo "uidgid\n";
                     $attr+= unpack('Nuid/Ngid', $this->_string_shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_PERMISSIONS:      // 0x00000004
-echo "perms\n";
                     if (strlen($response) < 4) {
                         user_error('Malformed file attributes');
                         return $attr;
@@ -3112,7 +3109,6 @@ echo "perms\n";
                     }
                     break;
                 case NET_SFTP_ATTR_ACCESSTIME:       // 0x00000008
-echo "accesstime\n";
                     if ($this->version >= 4) {
                         $attr+= $this->_parseTime('atime', $flags, $response);
                         break;
@@ -3124,15 +3120,12 @@ echo "accesstime\n";
                     $attr+= unpack('Natime/Nmtime', $this->_string_shift($response, 8));
                     break;
                 case NET_SFTP_ATTR_CREATETIME:       // 0x00000010 (SFTPv4+)
-echo "createtime\n";
                     $attr+= $this->_parseTime('createtime', $flags, $response);
                     break;
                 case NET_SFTP_ATTR_MODIFYTIME:       // 0x00000020
-echo "modifytime\n";
                     $attr+= $this->_parseTime('mtime', $flags, $response);
                     break;
                 case NET_SFTP_ATTR_ACL:              // 0x00000040
-echo "acl\n";
                     // see https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-04#section-5.7
                     // currently unsupported
                     if (strlen($response) < 4) {
@@ -3154,7 +3147,6 @@ echo "acl\n";
                     }
                     break;
                 case NET_SFTP_ATTR_OWNERGROUP:       // 0x00000080
-echo "ownergroup\n";
                     if (strlen($response) < 4) {
                         user_error('Malformed file attributes');
                         return $attr;
@@ -3180,6 +3172,14 @@ echo "ownergroup\n";
                 case NET_SFTP_ATTR_SUBSECOND_TIMES:  // 0x00000100
                     break;
                 case NET_SFTP_ATTR_BITS:             // 0x00000200 (SFTPv5+)
+                    // see https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-05#section-5.8
+                    // currently unsupported
+                    if (strlen($response) < 4) {
+                        user_error('Malformed file attributes');
+                        return $attr;
+                    }
+                    extract(unpack('Nbits', $this->_string_shift($response, 4)));
+                    break;
                 case NET_SFTP_ATTR_ALLOCATION_SIZE:  // 0x00000400 (SFTPv6+)
                 case NET_SFTP_ATTR_TEXT_HINT:        // 0x00000800
                 case NET_SFTP_ATTR_MIME_TYPE:        // 0x00001000

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1635,11 +1635,13 @@ class Net_SFTP extends Net_SSH2
             $atime = $time;
         }
 
+        $attr = pack('N3', NET_SFTP_ATTR_ACCESSTIME, $time, $atime);
+
         $packet = pack('Na*', strlen($filename), $filename);
         $packet.= $this->version >= 5 ?
             pack('N2', 0, NET_SFTP_OPEN_OPEN_EXISTING) :
             pack('N', NET_SFTP_OPEN_WRITE | NET_SFTP_OPEN_CREATE | NET_SFTP_OPEN_EXCL);
-        $packet.= pack('N3', NET_SFTP_ATTR_ACCESSTIME, $time, $atime);
+        $packet.= $attr;
 
         if (!$this->_send_sftp_packet(NET_SFTP_OPEN, $packet)) {
             return false;

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -4,9 +4,7 @@
  *
  * PHP versions 4 and 5
  *
- * Currently only supports SFTPv2 and v3, which, according to wikipedia.org, "is the most widely used version,
- * implemented by the popular OpenSSH SFTP server".  If you want SFTPv4/5/6 support, provide me with access
- * to an SFTPv4/5/6 server.
+ * Supports SFTPv2/3/4/5/6. Defaults to v3.
  *
  * The API for this library is modeled after the API from PHP's {@link http://php.net/book.ftp FTP extension}.
  *

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1,6 +1,4 @@
 <?php
-// attributes will require a lot of work
-
 /**
  * Pure-PHP implementation of SFTP.
  *

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1661,7 +1661,7 @@ class Net_SFTP extends Net_SSH2
          will just use whatever value the user provided
        */
 
-        $attr = $this->version >= 4 ?
+        $attr = $this->version < 4 ?
             // quoting <http://www.kernel.org/doc/man-pages/online/pages/man2/chown.2.html>,
             // "if the owner or group is specified as -1, then that ID is not changed"
             pack('N3', NET_SFTP_ATTR_UIDGID, $uid, -1) :
@@ -1692,7 +1692,7 @@ class Net_SFTP extends Net_SSH2
      */
     function chgrp($filename, $gid, $recursive = false)
     {
-        $attr = $this->version >= 4 ?
+        $attr = $this->version < 4 ?
             pack('N3', NET_SFTP_ATTR_UIDGID, $gid, -1) :
             pack('NNa*Na*', NET_SFTP_ATTR_OWNERGROUP, 0, '', strlen($gid), $gid);
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -515,7 +515,7 @@ class Net_SFTP extends Net_SSH2
     }
 
     /**
-     * Partiailly initialize an SFTP connection
+     * Partially initialize an SFTP connection
      *
      * @return bool
      * @access public

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3106,10 +3106,6 @@ class Net_SFTP extends Net_SSH2
             return false;
         }
 
-        if (!$this->_precheck()) {
-            return false;
-        }
-
         $oldname = $this->_realpath($oldname);
         $newname = $this->_realpath($newname);
         if ($oldname === false || $newname === false) {


### PR DESCRIPTION
Most of the changes are transparent to the end user. The only differences are that two new functions have been added:

- `setPreferredVersion()`
- `getNegotiatedVersion()`

By default phpseclib will still use SFTPv3 but if it's unavailable it'll use v4/5/6. It'll also use different versions if you tell it to do so via `setPreferredVersion()`.

Maybe I'll change this at some point but right now the SFTPv3 code is battle tested. The SFTPv4/5/6 code is not.