### PR TITLE
mbstring.func_overload is deprecated in php 7.2 and removed in php 8.0

### DIFF
--- a/phpseclib/bootstrap.php
+++ b/phpseclib/bootstrap.php
@@ -11,7 +11,8 @@
  */
 if (extension_loaded('mbstring')) {
     // 2 - MB_OVERLOAD_STRING
-    if (ini_get('mbstring.func_overload') & 2) {
+    // mbstring.func_overload is deprecated in php 7.2 and removed in php 8.0.
+    if ((PHP_VERSION_ID < 80000) && (ini_get('mbstring.func_overload') & 2)) {
         throw new UnexpectedValueException(
             'Overloading of string functions using mbstring.func_overload ' .
             'is not supported by phpseclib.'


### PR DESCRIPTION
According to the official PHP manual  https://www.php.net/manual/en/migration72.deprecated.php and https://www.php.net/manual/en/migration80.incompatible.php, mbstring.func_overload is deprecated in php 7.2 and removed in php 8.0, So I think we should add PHP version judgment here.