### PR TITLE
Don't Use Array Unpacking for Status Code -> Error

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -807,7 +807,7 @@ class SFTP extends SSH2
             list($status) = Strings::unpackSSH2('N', $response);
         }
 
-        list($error) = $this->status_codes[$status];
+        $error = $this->status_codes[$status];
 
         if ($this->version > 2) {
             list($message) = Strings::unpackSSH2('s', $response);


### PR DESCRIPTION
the `status_codes` property is an array with integer keys and string
values, but the `$error` value in `SFTP::logError` was trying to be unpacked
from an array.

Seems to come from cee3f3cd4a8b469b8250cde6d130e2c06faae7ed, but even at
that commit the `status_codes` data structure was still an array.

This bug is only present in 3.X, 2.X release didn't unpack here:
https://github.com/phpseclib/phpseclib/blob/a684f120653d6c0d1b1fb25f4c75c2bf57252965/phpseclib/Net/SFTP.php#L829