### PR TITLE
SSH2.php define_array() fix double break

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -4314,7 +4314,7 @@ class SSH2
                 if (!defined($value)) {
                     define($value, $key);
                 } else {
-                    break 2;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
double break causes define_array() to skip further arguments if a single key already exists.