### PR TITLE
Remove define() from SSH2 and use class constants instead (3.0 branch)

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -73,23 +73,6 @@ use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\AsymmetricKey;
 
-/**#@+
- * @access private
- */
-/**
- * No compression
- */
-define('NET_SSH2_COMPRESSION_NONE',  1);
-/**
- * zlib compression
- */
-define('NET_SSH2_COMPRESSION_ZLIB', 2);
-/**
- * zlib@openssh.com
- */
-define('NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH', 3);
-/**#@-*/
-
 /**
  * Pure-PHP implementation of SSHv2.
  *
@@ -99,6 +82,25 @@ define('NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH', 3);
  */
 class SSH2
 {
+    /**#@+
+     * Compression Types
+     *
+     * @access private
+     */
+    /**
+     * No compression
+     */
+    const NET_SSH2_COMPRESSION_NONE = 1;
+    /**
+     * zlib compression
+     */
+    const NET_SSH2_COMPRESSION_ZLIB = 2;
+    /**
+     * zlib@openssh.com
+     */
+    const NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH = 3;
+    /**#@-*/
+
     // Execution Bitmap Masks
     const MASK_CONSTRUCTOR   = 0x00000001;
     const MASK_CONNECTED     = 0x00000002;
@@ -1055,7 +1057,7 @@ class SSH2
      * @var int
      * @access private
      */
-    private $compress = NET_SSH2_COMPRESSION_NONE;
+    private $compress = self::NET_SSH2_COMPRESSION_NONE;
 
     /**
      * Decompression method
@@ -1063,7 +1065,7 @@ class SSH2
      * @var resource|object
      * @access private
      */
-    private $decompress = NET_SSH2_COMPRESSION_NONE;
+    private $decompress = self::NET_SSH2_COMPRESSION_NONE;
 
     /**
      * Compression context
@@ -1618,9 +1620,9 @@ class SSH2
         }
 
         $compression_map = [
-            'none' => NET_SSH2_COMPRESSION_NONE,
-            'zlib' => NET_SSH2_COMPRESSION_ZLIB,
-            'zlib@openssh.com' => NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH
+            'none' => self::NET_SSH2_COMPRESSION_NONE,
+            'zlib' => self::NET_SSH2_COMPRESSION_ZLIB,
+            'zlib@openssh.com' => self::NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH
         ];
 
         $compression_algorithm_in = self::array_intersect_first($s2c_compression_algorithms, $this->compression_algorithms_server_to_client);
@@ -3474,11 +3476,11 @@ class SSH2
         }
 
         switch ($this->decompress) {
-            case NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH:
+            case self::NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH:
                 if (!$this->isAuthenticated()) {
                     break;
                 }
-            case NET_SSH2_COMPRESSION_ZLIB:
+            case self::NET_SSH2_COMPRESSION_ZLIB:
                 if ($this->regenerate_decompression_context) {
                     $this->regenerate_decompression_context = false;
 
@@ -4064,11 +4066,11 @@ class SSH2
         }
 
         switch ($this->compress) {
-            case NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH:
+            case self::NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH:
                 if (!$this->isAuthenticated()) {
                     break;
                 }
-            case NET_SSH2_COMPRESSION_ZLIB:
+            case self::NET_SSH2_COMPRESSION_ZLIB:
                 if (!$this->regenerate_compression_context) {
                     $header = '';
                 } else {
@@ -4777,9 +4779,9 @@ class SSH2
         $this->connect();
 
         $compression_map = [
-            NET_SSH2_COMPRESSION_NONE => 'none',
-            NET_SSH2_COMPRESSION_ZLIB => 'zlib',
-            NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH => 'zlib@openssh.com'
+            self::NET_SSH2_COMPRESSION_NONE => 'none',
+            self::NET_SSH2_COMPRESSION_ZLIB => 'zlib',
+            self::NET_SSH2_COMPRESSION_ZLIB_AT_OPENSSH => 'zlib@openssh.com'
         ];
 
         return [


### PR DESCRIPTION
Fixes https://github.com/phpseclib/phpseclib/issues/1721 for the 3.0 branch