### PR TITLE
Don't use phpinfo() if it is disabled

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -515,7 +515,7 @@ class Crypt_RSA
                 case !function_exists('openssl_pkey_get_details'):
                     define('CRYPT_RSA_MODE', CRYPT_RSA_MODE_INTERNAL);
                     break;
-                case extension_loaded('openssl') && version_compare(PHP_VERSION, '4.2.0', '>=') && file_exists($this->configFile):
+                case function_exists('phpinfo') && extension_loaded('openssl') && version_compare(PHP_VERSION, '4.2.0', '>=') && file_exists($this->configFile):
                     // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
                     ob_start();
                     @phpinfo();

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -257,7 +257,7 @@ class Math_BigInteger
             }
         }
 
-        if (extension_loaded('openssl') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
+        if (function_exists('phpinfo') && extension_loaded('openssl') && !defined('MATH_BIGINTEGER_OPENSSL_DISABLE') && !defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
             // some versions of XAMPP have mismatched versions of OpenSSL which causes it not to work
             ob_start();
             @phpinfo();


### PR DESCRIPTION
I've come across two users whose web hosting disables the function `phpinfo()` (see: https://wordpress.org/support/topic/php-fatal-error-on-connection-attempt/). This is used in phpseclib 1.0 (which we still have to use, because as a backup plugin, we want to support users who are backing up their antique WordPress sites before they test upgrading them).
This PR checks that `phpinfo()` is available before using it, avoiding a resulting PHP fatal error.