### PR TITLE
SFTP: fix chgrp() for version < 4

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1635,7 +1635,7 @@ class SFTP extends SSH2
     public function chgrp($filename, $gid, $recursive = false)
     {
         $attr = $this->version < 4 ?
-            pack('N3', NET_SFTP_ATTR_UIDGID, $gid, -1) :
+            pack('N3', NET_SFTP_ATTR_UIDGID, -1, $gid) :
             Strings::packSSH2('Nss', NET_SFTP_ATTR_OWNERGROUP, '', $gid);
 
         return $this->setstat($filename, $attr, $recursive);

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -765,5 +765,22 @@ class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         $list_cache_disabled = $sftp->rawlist('.', true);
 
         $this->assertEquals($list_cache_enabled, $list_cache_disabled, 'The files should be the same regardless of stat cache', 0.0, 10, true);
+
+        return $sftp;
+    }
+
+    /**
+     * @depends testRawlistDisabledStatCache
+     */
+    public function testChownChgrp($sftp)
+    {
+        $stat = $sftp->stat(self::$scratchDir);
+        $this->assertTrue($sftp->chown(self::$scratchDir, $stat['uid']));
+        $this->assertTrue($sftp->chgrp(self::$scratchDir, $stat['gid']));
+
+        $sftp->clearStatCache();
+        $stat2 = $sftp->stat(self::$scratchDir);
+        $this->assertSame($stat['uid'], $stat2['uid']);
+        $this->assertSame($stat['gid'], $stat2['gid']);
     }
 }


### PR DESCRIPTION
$uid and $gid were flipped with [dbfc7622571](https://github.com/phpseclib/phpseclib/commit/dbfc76225714d28d41f832cf424ff6696d14e344#diff-2c14c913d58f0f70ffc8a953c7608e51ac68d69aa85a664375d1a84b7f62d98fR1696)

The test does not test this bug. I don't know how to do it for any ssh on PHPSECLIB_SSH_HOSTNAME which may or may not have some users/groups or permission to change them. If you give me some idea on how to do it, I will be happy to implement it, or remove the test if you see it as unnecessary.
Also seems like all tests are in chain with `@depends` which is strange but I followed it.