### PR TITLE
Avoid Implicit conversion error when float type cast to int. in PHP8.1.

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1347,8 +1347,8 @@ class SSH2
                     $read = [$this->fsock];
                     $write = $except = null;
                     $start = microtime(true);
-                    $sec = floor($this->curTimeout);
-                    $usec = 1000000 * ($this->curTimeout - $sec);
+                    $sec = (int)floor($this->curTimeout);
+                    $usec = (int)(1000000 * ($this->curTimeout - $sec));
                     if (@stream_select($read, $write, $except, $sec, $usec) === false) {
                         throw new \RuntimeException('Connection timed out whilst receiving server identification string');
                     }
@@ -3330,8 +3330,8 @@ class SSH2
                     $this->curTimeout-= $elapsed;
                 }
 
-                $sec = floor($this->curTimeout);
-                $usec = 1000000 * ($this->curTimeout - $sec);
+                $sec = (int)floor($this->curTimeout);
+                $usec = (int)(1000000 * ($this->curTimeout - $sec));
 
                 // this can return a "stream_select(): unable to select [4]: Interrupted system call" error
                 if (!@stream_select($read, $write, $except, $sec, $usec)) {


### PR DESCRIPTION
Hi.

## probrem

I got some error when using phpseclib with League\Flysystem and PHP 8.1.

```
Implicit conversion from float 992216.1102294922 to int loses precision
```

## reason

`stream_select()` need $second and $microseconds as int. but some params are float in phpseclib.

```
stream_select(
    ?array &$read,
    ?array &$write,
    ?array &$except,
    ?int $seconds,
    ?int $microseconds = null
): int|false
```

https://www.php.net/manual/en/function.stream-select.php

```
// ex: phpseclib/phpseclib/phpseclib/Net/SSH2.php(1299)
                    $sec = floor($this->curTimeout);
                    $usec = 1000000 * ($this->curTimeout - $sec); 
```

## my error pattern part 1

```
#0 [internal function]: {closure}()
#1 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(1299): stream_select()
#2 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(2249): phpseclib\Net\SSH2->_connect()
#3 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(2228): phpseclib\Net\SSH2->_login()
#4 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(235): phpseclib\Net\SSH2->login()
#5 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(207): League\Flysystem\Sftp\SftpAdapter->login()
#6 /some/path/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php(650): League\Flysystem\Sftp\SftpAdapter->connect()
#7 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(453): League\Flysystem\Adapter\AbstractFtpAdapter->getConnection()
#8 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(436): League\Flysystem\Sftp\SftpAdapter->upload()
#9 /some/path/myApp.php(32): League\Flysystem\Sftp\SftpAdapter->writeStream()
```

## my error pattern  part 2

```
#0 [internal function]: {closure}()
#1 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(3504): stream_select()
#2 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(3922): phpseclib\Net\SSH2->_get_binary_packet()
#3 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php(537): phpseclib\Net\SSH2->_get_channel_packet()
#4 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php(638): phpseclib\Net\SFTP->_partial_init_sftp_connection()
#5 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php(505): phpseclib\Net\SFTP->_init_sftp_connection()
#6 /some/path/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php(937): phpseclib\Net\SFTP->_precheck()
#7 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(278): phpseclib\Net\SFTP->chdir()
#8 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(208): League\Flysystem\Sftp\SftpAdapter->setConnectionRoot()
#9 /some/path/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php(650): League\Flysystem\Sftp\SftpAdapter->connect()
#10 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(453): League\Flysystem\Adapter\AbstractFtpAdapter->getConnection()
#11 /some/path/vendor/league/flysystem-sftp/src/SftpAdapter.php(436): League\Flysystem\Sftp\SftpAdapter->upload()
#12 /some/path/myApp.php(32): League\Flysystem\Sftp\SftpAdapter->writeStream()
```

## solution.(this pull request)

Explicit typecasting.

```
                    $sec = floor($this->curTimeout);
                    $usec = 1000000 * ($this->curTimeout - $sec);

to

                    $sec = (int)floor($this->curTimeout);
                    $usec = (int)(1000000 * ($this->curTimeout - $sec));
```

regards.