### PR TITLE
Infinite loop error when logging in

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2204,7 +2204,13 @@ class SSH2
                                     break;
                                 }
                             }
-                            $args = [];
+                            if (
+                                count($this->auth_methods_to_continue) === 1 &&
+                                $this->auth_methods_to_continue[0] === 'publickey' &&
+                                count($newargs) === 0
+                            ) {
+                                return false;
+                            }
                             break;
                         case 'keyboard-interactive':
                             $hasArray = $hasString = false;

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2204,6 +2204,7 @@ class SSH2
                                     break;
                                 }
                             }
+                            $args = [];
                             break;
                         case 'keyboard-interactive':
                             $hasArray = $hasString = false;


### PR DESCRIPTION

<img width="1314" alt="Screen Shot 2022-01-24 at 8 54 41" src="https://user-images.githubusercontent.com/9611224/150703376-fb361117-cbd9-444c-bd00-c51c206f6f66.png">


Report Bug:

- The server only allows login with private key.
- When I login with a password, for example:

```php
$ssh = new SSH2($ip, $port);
$ssh->login($username, 'my_password');
```

`Line 2191`: Now the value of `$args` is `array('my_password')`
The code will run down to 2200 line (server refuses to login with a password, Public Key requirements)
`Line 2201`: The value `$arg` is `'my_password'`, not the instance of PrivateKey or Agent
So break in line 2207, up to now, `count($args)` is still 1 and the loop continues to be infinite
