### PR TITLE
Set up php cs fixer and psalm ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-/vendor
-/composer.phar
 /.idea/
+/build/vendor/
+/build/php-cs-fixer.cache
+/build/composer.lock
+/composer.lock
+/composer.phar
+/vendor/
 .gitignore
-composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ install:
 script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.5' ]; then vendor/bin/phing -f build/build.xml sniff; fi"
   - sh -c "if [ -d build/vendor ]; then build/vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --dry-run; fi"
+  - sh -c "if [ -d build/vendor ]; then build/vendor/bin/psalm --config="build/psalm.xml" --no-cache --long-progress --report-show-info=false --output-format=text; fi"
   - travis/run-phpunit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,5 @@ install:
 
 script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.5' ]; then vendor/bin/phing -f build/build.xml sniff; fi"
+  - sh -c "if [ -d build/vendor ]; then build/vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --dry-run; fi"
   - travis/run-phpunit.sh

--- a/README.md
+++ b/README.md
@@ -79,22 +79,21 @@ Special Thanks to our Patreon sponsors!:
 2. Ensure you have Composer installed (see [Composer Download Instructions](https://getcomposer.org/download/))
 
 3. Install Development Dependencies
-
-    ``` sh
+    ```sh
     composer install
     ```
 
 4. Create a Feature Branch
 
-5. (Recommended) Run the Test Suite
-
-    ``` sh
-    vendor/bin/phpunit
-    ```
-6. (Recommended) Check whether your code conforms to our Coding Standards by running
-
-    ``` sh
-    vendor/bin/phing -f build/build.xml sniff
-    ```
-
-7. Send us a Pull Request
+5. Run continuous integration checks:
+   ```sh
+   vendor/bin/phpunit
+   vendor/bin/phing -f build/build.xml sniff
+   
+   # The following tools are from the build specific composer.json:
+   composer install --no-interaction --working-dir=build
+   build/vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --dry-run
+   build/vendor/bin/psalm --config=build/psalm.xml --no-cache --long-progress --report-show-info=false --output-format=text
+   ```
+   
+6. Send us a Pull Request

--- a/build/composer.json
+++ b/build/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "phpseclib/tools",
+    "description": "",
+    "minimum-stability": "stable",
+    "license": "proprietary",
+    "authors": [{"name": "Jack Worman", "email": "jworman@healthcall.com"}],
+    "require": {
+        "php": "^8.1.0",
+        "friendsofphp/php-cs-fixer": "^3.5"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/build/composer.json
+++ b/build/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "phpseclib/tools",
-    "description": "",
+    "name": "phpseclib/build",
+    "description": "A separate composer.json file to house build related dependencies.",
     "minimum-stability": "stable",
-    "license": "proprietary",
-    "authors": [{"name": "Jack Worman", "email": "jworman@healthcall.com"}],
+    "license": "MIT",
     "require": {
         "php": "^8.1.0",
-        "friendsofphp/php-cs-fixer": "^3.5"
+        "friendsofphp/php-cs-fixer": "^3.5",
+        "vimeo/psalm": "^4.19"
     },
     "config": {
         "sort-packages": true

--- a/build/php-cs-fixer.php
+++ b/build/php-cs-fixer.php
@@ -1,0 +1,23 @@
+<?php
+
+return (new PhpCsFixer\Config())
+    ->setFinder(PhpCsFixer\Finder::create()->in(__DIR__ . '/..'))
+    ->setCacheFile(__DIR__ . '/php-cs-fixer.cache')
+    ->setRiskyAllowed(true)
+    // https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/index.rst
+    ->setRules(
+        [
+            // Array
+            'array_syntax' => ['syntax' => 'short'],
+            // Function Notation
+            'native_function_invocation' => ['exclude' => [], 'include' => [], 'scope' => 'all', 'strict' => true],
+            // Import
+            'fully_qualified_strict_types' => true,
+            'global_namespace_import' => ['import_constants' => false, 'import_functions' => false, 'import_classes' => false],
+            'no_leading_import_slash' => true,
+            'no_unused_imports' => true,
+            'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['class', 'const', 'function']],
+            'single_import_per_statement' => true,
+            'single_line_after_imports' => true,
+        ]
+    );

--- a/build/psalm.xml
+++ b/build/psalm.xml
@@ -9,20 +9,17 @@
     sealAllMethods="true"
 >
     <projectFiles>
-        <directory name="phpseclib/Net"/>
+        <directory name="../phpseclib/Net"/>
     </projectFiles>
-    <fileExtensions>
-        <extension name=".php"/>
-    </fileExtensions>
     <issueHandlers>
         <Trace>
             <errorLevel type="error">
-                <directory name="."/>
+                <directory name=".."/>
             </errorLevel>
         </Trace>
         <UndefinedConstant>
             <errorLevel type="suppress">
-                <directory name="phpseclib/Net"/>
+                <directory name="../phpseclib/Net"/>
             </errorLevel>
         </UndefinedConstant>
     </issueHandlers>

--- a/phpseclib/Crypt/ChaCha20.php
+++ b/phpseclib/Crypt/ChaCha20.php
@@ -15,8 +15,8 @@
 
 namespace phpseclib3\Crypt;
 
-use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Exception\BadDecryptionException;
+use phpseclib3\Exception\InsufficientSetupException;
 
 /**
  * Pure-PHP implementation of ChaCha20.

--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -15,13 +15,12 @@
 
 namespace phpseclib3\Crypt\Common;
 
-use phpseclib3\Exception\UnsupportedFormatException;
-use phpseclib3\Exception\NoKeyLoadedException;
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Crypt\RSA;
-use phpseclib3\Crypt\DSA;
-use phpseclib3\Crypt\ECDSA;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Base Class for all asymmetric cipher classes

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
@@ -17,13 +17,13 @@ namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
-use phpseclib3\Crypt\Random;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\DES;
+use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\TripleDES;
-use phpseclib3\File\ASN1;
-use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\File\ASN1;
 
 /**
  * PKCS1 Formatted Key Handler

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
@@ -28,17 +28,16 @@
 namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\DES;
+use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\RC2;
 use phpseclib3\Crypt\RC4;
-use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\TripleDES;
-use phpseclib3\Crypt\Random;
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**
  * PKCS#8 Formatted Key Handler

--- a/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
@@ -17,10 +17,10 @@ namespace phpseclib3\Crypt\Common\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Crypt\Random;
-use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
 
 /**

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -213,6 +213,9 @@ abstract class SymmetricKey
         self::ENGINE_OPENSSL_GCM => 'OpenSSL (GCM)'
     ];
 
+    /** @var string|false */
+    public $fixed;
+
     /**
      * The Encryption Mode
      *

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -36,16 +36,16 @@
 
 namespace phpseclib3\Crypt\Common;
 
-use phpseclib3\Crypt\Hash;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Math\BinaryField;
-use phpseclib3\Math\PrimeField;
+use phpseclib3\Crypt\Hash;
 use phpseclib3\Exception\BadDecryptionException;
 use phpseclib3\Exception\BadModeException;
 use phpseclib3\Exception\InconsistentSetupException;
 use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BinaryField;
+use phpseclib3\Math\PrimeField;
 
 /**
  * Base Class for all \phpseclib3\Crypt\* cipher classes

--- a/phpseclib/Crypt/DH.php
+++ b/phpseclib/Crypt/DH.php
@@ -26,12 +26,12 @@
 
 namespace phpseclib3\Crypt;
 
-use phpseclib3\Exception\NoKeyLoadedException;
-use phpseclib3\Exception\UnsupportedOperationException;
 use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\DH\Parameters;
 use phpseclib3\Crypt\DH\PrivateKey;
 use phpseclib3\Crypt\DH\PublicKey;
-use phpseclib3\Crypt\DH\Parameters;
+use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedOperationException;
 use phpseclib3\Math\BigInteger;
 
 /**

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
@@ -23,10 +23,10 @@
 
 namespace phpseclib3\Crypt\DH\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
 
 /**
  * "PKCS1" Formatted DH Key Handler

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
@@ -21,11 +21,11 @@
 
 namespace phpseclib3\Crypt\DH\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted DH Key Handler

--- a/phpseclib/Crypt/DH/PrivateKey.php
+++ b/phpseclib/Crypt/DH/PrivateKey.php
@@ -13,8 +13,8 @@
 
 namespace phpseclib3\Crypt\DH;
 
-use phpseclib3\Crypt\DH;
 use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\DH;
 
 /**
  * DH Private Key

--- a/phpseclib/Crypt/DH/PublicKey.php
+++ b/phpseclib/Crypt/DH/PublicKey.php
@@ -13,8 +13,8 @@
 
 namespace phpseclib3\Crypt\DH;
 
-use phpseclib3\Crypt\DH;
 use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\DH;
 
 /**
  * DH Public Key

--- a/phpseclib/Crypt/DSA.php
+++ b/phpseclib/Crypt/DSA.php
@@ -32,11 +32,11 @@
 namespace phpseclib3\Crypt;
 
 use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\DSA\Parameters;
 use phpseclib3\Crypt\DSA\PrivateKey;
 use phpseclib3\Crypt\DSA\PublicKey;
-use phpseclib3\Crypt\DSA\Parameters;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Pure-PHP FIPS 186-4 compliant implementation of DSA.

--- a/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
@@ -17,10 +17,9 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
+use phpseclib3\Math\BigInteger;
 
 /**
  * OpenSSH Formatted DSA Key Handler

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
@@ -29,11 +29,11 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use ParagonIE\ConstantTime\Base64;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use ParagonIE\ConstantTime\Base64;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#1 Formatted DSA Key Handler

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
@@ -25,11 +25,11 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted DSA Key Handler

--- a/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
@@ -20,9 +20,9 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PuTTY Formatted DSA Key Handler

--- a/phpseclib/Crypt/DSA/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/XML.php
@@ -22,8 +22,8 @@
 namespace phpseclib3\Crypt\DSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * XML Formatted DSA Key Handler

--- a/phpseclib/Crypt/DSA/Formats/Signature/ASN1.php
+++ b/phpseclib/Crypt/DSA/Formats/Signature/ASN1.php
@@ -18,9 +18,9 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Signature;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\File\ASN1 as Encoder;
 use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
 
 /**
  * ASN1 Signature Handler

--- a/phpseclib/Crypt/DSA/Formats/Signature/SSH2.php
+++ b/phpseclib/Crypt/DSA/Formats/Signature/SSH2.php
@@ -17,8 +17,8 @@
 
 namespace phpseclib3\Crypt\DSA\Formats\Signature;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * SSH2 Signature Handler

--- a/phpseclib/Crypt/DSA/PrivateKey.php
+++ b/phpseclib/Crypt/DSA/PrivateKey.php
@@ -13,10 +13,10 @@
 
 namespace phpseclib3\Crypt\DSA;
 
+use phpseclib3\Crypt\Common;
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
 use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\Common;
 
 /**
  * DSA Private Key

--- a/phpseclib/Crypt/DSA/PublicKey.php
+++ b/phpseclib/Crypt/DSA/PublicKey.php
@@ -13,9 +13,9 @@
 
 namespace phpseclib3\Crypt\DSA;
 
+use phpseclib3\Crypt\Common;
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\DSA\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib3\Crypt\Common;
 
 /**
  * DSA Public Key

--- a/phpseclib/Crypt/EC.php
+++ b/phpseclib/Crypt/EC.php
@@ -32,21 +32,21 @@
 namespace phpseclib3\Crypt;
 
 use phpseclib3\Crypt\Common\AsymmetricKey;
-use phpseclib3\Crypt\EC\PrivateKey;
-use phpseclib3\Crypt\EC\PublicKey;
-use phpseclib3\Crypt\EC\Parameters;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\Curves\Curve25519;
 use phpseclib3\Crypt\EC\Curves\Ed25519;
 use phpseclib3\Crypt\EC\Curves\Ed448;
 use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib3\File\ASN1\Maps\ECParameters;
-use phpseclib3\File\ASN1;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Crypt\EC\Parameters;
+use phpseclib3\Crypt\EC\PrivateKey;
+use phpseclib3\Crypt\EC\PublicKey;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\UnsupportedCurveException;
 use phpseclib3\Exception\UnsupportedOperationException;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps\ECParameters;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Pure-PHP implementation of EC.

--- a/phpseclib/Crypt/EC/BaseCurves/Binary.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Binary.php
@@ -23,9 +23,8 @@
 
 namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\BinaryField;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BinaryField;
 use phpseclib3\Math\BinaryField\Integer as BinaryInteger;
 
 /**

--- a/phpseclib/Crypt/EC/BaseCurves/KoblitzPrime.php
+++ b/phpseclib/Crypt/EC/BaseCurves/KoblitzPrime.php
@@ -30,10 +30,8 @@
 
 namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\BigInteger;
-use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
+use phpseclib3\Math\PrimeField;
 
 /**
  * Curves over y^2 = x^3 + b

--- a/phpseclib/Crypt/EC/BaseCurves/Montgomery.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Montgomery.php
@@ -26,10 +26,9 @@
 
 namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\PrimeField;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**

--- a/phpseclib/Crypt/EC/BaseCurves/Prime.php
+++ b/phpseclib/Crypt/EC/BaseCurves/Prime.php
@@ -23,10 +23,10 @@
 
 namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib3\Math\Common\FiniteField\Integer;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer;
+use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**

--- a/phpseclib/Crypt/EC/BaseCurves/TwistedEdwards.php
+++ b/phpseclib/Crypt/EC/BaseCurves/TwistedEdwards.php
@@ -28,8 +28,8 @@
 
 namespace phpseclib3\Crypt\EC\BaseCurves;
 
-use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\PrimeField;
 use phpseclib3\Math\PrimeField\Integer as PrimeInteger;
 
 /**

--- a/phpseclib/Crypt/EC/Curves/Ed25519.php
+++ b/phpseclib/Crypt/EC/Curves/Ed25519.php
@@ -15,9 +15,9 @@
 namespace phpseclib3\Crypt\EC\Curves;
 
 use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Crypt\Random;
+use phpseclib3\Math\BigInteger;
 
 class Ed25519 extends TwistedEdwards
 {

--- a/phpseclib/Crypt/EC/Curves/Ed448.php
+++ b/phpseclib/Crypt/EC/Curves/Ed448.php
@@ -15,9 +15,9 @@
 namespace phpseclib3\Crypt\EC\Curves;
 
 use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Crypt\Random;
+use phpseclib3\Math\BigInteger;
 
 class Ed448 extends TwistedEdwards
 {

--- a/phpseclib/Crypt/EC/Formats/Keys/Common.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/Common.php
@@ -16,16 +16,15 @@
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib3\Crypt\EC\BaseCurves\Prime as PrimeCurve;
-use phpseclib3\Crypt\EC\BaseCurves\Binary as BinaryCurve;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Math\PrimeField;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Binary as BinaryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Prime as PrimeCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Exception\UnsupportedCurveException;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Generic EC Key Parsing Helper functions

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
@@ -22,11 +22,11 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
 use phpseclib3\Crypt\EC\Curves\Curve25519;
 use phpseclib3\Crypt\EC\Curves\Curve448;
-use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Montgomery Curve Private Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
@@ -15,10 +15,9 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
 use phpseclib3\Crypt\EC\Curves\Curve25519;
 use phpseclib3\Crypt\EC\Curves\Curve448;
-use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib3\Math\Common\FiniteField\Integer;
 use phpseclib3\Math\BigInteger;
 
 /**

--- a/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
@@ -17,13 +17,12 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
 use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib3\Exception\UnsupportedCurveException;
 use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * OpenSSH Formatted EC Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
@@ -27,16 +27,16 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
+use ParagonIE\ConstantTime\Base64;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
+use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Exception\UnsupportedCurveException;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
 use phpseclib3\Math\BigInteger;
-use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib3\Exception\UnsupportedCurveException;
-use phpseclib3\Common\Functions\Strings;
 
 /**
  * "PKCS1" (RFC5915) Formatted EC Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
@@ -25,17 +25,17 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
-use phpseclib3\File\ASN1;
-use phpseclib3\File\ASN1\Maps;
 use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\Curves\Ed25519;
 use phpseclib3\Crypt\EC\Curves\Ed448;
 use phpseclib3\Exception\UnsupportedCurveException;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted EC Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
@@ -16,11 +16,11 @@
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
 use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
 use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PuTTY Formatted EC Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/XML.php
@@ -21,13 +21,13 @@
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\EC\BaseCurves\Base as BaseCurve;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
 use phpseclib3\Crypt\EC\BaseCurves\Prime as PrimeCurve;
 use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\UnsupportedCurveException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * XML Formatted EC Key Handler

--- a/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
@@ -20,8 +20,8 @@
 namespace phpseclib3\Crypt\EC\Formats\Keys;
 
 use phpseclib3\Crypt\EC\Curves\Ed25519;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * libsodium Key Handler

--- a/phpseclib/Crypt/EC/Formats/Signature/ASN1.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/ASN1.php
@@ -18,9 +18,9 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Signature;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\File\ASN1 as Encoder;
 use phpseclib3\File\ASN1\Maps\EcdsaSigValue;
+use phpseclib3\Math\BigInteger;
 
 /**
  * ASN1 Signature Handler

--- a/phpseclib/Crypt/EC/Formats/Signature/SSH2.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/SSH2.php
@@ -17,8 +17,8 @@
 
 namespace phpseclib3\Crypt\EC\Formats\Signature;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * SSH2 Signature Handler

--- a/phpseclib/Crypt/EC/PrivateKey.php
+++ b/phpseclib/Crypt/EC/PrivateKey.php
@@ -13,18 +13,18 @@
 
 namespace phpseclib3\Crypt\EC;
 
-use phpseclib3\Crypt\EC;
-use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
-use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
-use phpseclib3\Crypt\Hash;
-use phpseclib3\Crypt\EC\Curves\Ed25519;
-use phpseclib3\Crypt\EC\Curves\Curve25519;
-use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib3\Crypt\Common;
-use phpseclib3\Exception\UnsupportedOperationException;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
+use phpseclib3\Crypt\EC\Curves\Curve25519;
+use phpseclib3\Crypt\EC\Curves\Ed25519;
+use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
+use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Exception\UnsupportedOperationException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * EC Private Key

--- a/phpseclib/Crypt/EC/PublicKey.php
+++ b/phpseclib/Crypt/EC/PublicKey.php
@@ -13,17 +13,17 @@
 
 namespace phpseclib3\Crypt\EC;
 
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common;
 use phpseclib3\Crypt\EC;
-use phpseclib3\Crypt\Hash;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
-use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\BaseCurves\Montgomery as MontgomeryCurve;
+use phpseclib3\Crypt\EC\BaseCurves\TwistedEdwards as TwistedEdwardsCurve;
 use phpseclib3\Crypt\EC\Curves\Ed25519;
 use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
-use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\EC\Formats\Signature\ASN1 as ASN1Signature;
+use phpseclib3\Crypt\Hash;
 use phpseclib3\Exception\UnsupportedOperationException;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * EC Public Key

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -33,11 +33,10 @@
 
 namespace phpseclib3\Crypt;
 
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Exception\UnsupportedAlgorithmException;
-use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\AES;
+use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Math\BigInteger;
 use phpseclib3\Math\PrimeField;
 
 /**

--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -16,8 +16,8 @@
 namespace phpseclib3\Crypt;
 
 use phpseclib3\Crypt\Common\AsymmetricKey;
-use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Exception\NoKeyLoadedException;
 use phpseclib3\File\X509;
 

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -56,12 +56,12 @@
 namespace phpseclib3\Crypt;
 
 use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
 use phpseclib3\Crypt\RSA\PrivateKey;
 use phpseclib3\Crypt\RSA\PublicKey;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Exception\UnsupportedAlgorithmException;
 use phpseclib3\Exception\InconsistentSetupException;
-use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Pure-PHP PKCS#1 compliant implementation of RSA.

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -20,9 +20,9 @@
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Microsoft BLOB Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
@@ -17,10 +17,9 @@
 
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH as Progenitor;
+use phpseclib3\Math\BigInteger;
 
 /**
  * OpenSSH Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
@@ -24,11 +24,11 @@
 
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS1 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#1 Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
@@ -27,10 +27,10 @@
 
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
 use phpseclib3\File\ASN1;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
@@ -25,11 +25,11 @@
 
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PKCS8 as Progenitor;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Maps;
-use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PKCS#8 Formatted RSA-PSS Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
@@ -15,9 +15,9 @@
 
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\Formats\Keys\PuTTY as Progenitor;
+use phpseclib3\Math\BigInteger;
 
 /**
  * PuTTY Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/XML.php
@@ -23,9 +23,9 @@
 namespace phpseclib3\Crypt\RSA\Formats\Keys;
 
 use ParagonIE\ConstantTime\Base64;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * XML Formatted RSA Key Handler

--- a/phpseclib/Crypt/RSA/PrivateKey.php
+++ b/phpseclib/Crypt/RSA/PrivateKey.php
@@ -13,16 +13,12 @@
 
 namespace phpseclib3\Crypt\RSA;
 
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\File\ASN1;
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\Hash;
-use phpseclib3\Exceptions\NoKeyLoadedException;
-use phpseclib3\Exception\UnsupportedFormatException;
-use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\Common;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Raw RSA Key Handler

--- a/phpseclib/Crypt/RSA/PublicKey.php
+++ b/phpseclib/Crypt/RSA/PublicKey.php
@@ -13,18 +13,17 @@
 
 namespace phpseclib3\Crypt\RSA;
 
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\File\ASN1;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\Hash;
-use phpseclib3\Exception\NoKeyLoadedException;
-use phpseclib3\Exception\UnsupportedFormatException;
-use phpseclib3\Exception\UnsupportedAlgorithmException;
-use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\Common;
-use phpseclib3\File\ASN1\Maps\DigestInfo;
+use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\File\ASN1;
+use phpseclib3\File\ASN1\Maps\DigestInfo;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Raw RSA Key Handler

--- a/phpseclib/Crypt/Rijndael.php
+++ b/phpseclib/Crypt/Rijndael.php
@@ -54,13 +54,13 @@
 
 namespace phpseclib3\Crypt;
 
-use phpseclib3\Crypt\Common\BlockCipher;
-
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Exception\BadModeException;
-use phpseclib3\Exception\InsufficientSetupException;
-use phpseclib3\Exception\InconsistentSetupException;
+
+use phpseclib3\Crypt\Common\BlockCipher;
 use phpseclib3\Exception\BadDecryptionException;
+use phpseclib3\Exception\BadModeException;
+use phpseclib3\Exception\InconsistentSetupException;
+use phpseclib3\Exception\InsufficientSetupException;
 
 /**
  * Pure-PHP implementation of Rijndael.

--- a/phpseclib/Crypt/Salsa20.php
+++ b/phpseclib/Crypt/Salsa20.php
@@ -15,10 +15,10 @@
 
 namespace phpseclib3\Crypt;
 
-use phpseclib3\Crypt\Common\StreamCipher;
-use phpseclib3\Exception\InsufficientSetupException;
-use phpseclib3\Exception\BadDecryptionException;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Common\StreamCipher;
+use phpseclib3\Exception\BadDecryptionException;
+use phpseclib3\Exception\InsufficientSetupException;
 
 /**
  * Pure-PHP implementation of Salsa20.

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -23,12 +23,11 @@
 
 namespace phpseclib3\File;
 
+use DateTime;
 use ParagonIE\ConstantTime\Base64;
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\File\ASN1\Element;
 use phpseclib3\Math\BigInteger;
-use phpseclib3\Common\Functions\Strings;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Pure-PHP ASN.1 Parser
@@ -1030,9 +1029,9 @@ abstract class ASN1
                 $format = $mapping['type'] == self::TYPE_UTC_TIME ? 'y' : 'Y';
                 $format.= 'mdHis';
                 // if $source does _not_ include timezone information within it then assume that the timezone is GMT
-                $date = new DateTime($source, new DateTimeZone('GMT'));
+                $date = new \DateTime($source, new \DateTimeZone('GMT'));
                 // if $source _does_ include timezone information within it then convert the time to GMT
-                $date->setTimezone(new DateTimeZone('GMT'));
+                $date->setTimezone(new \DateTimeZone('GMT'));
                 $value = $date->format($format) . 'Z';
                 break;
             case self::TYPE_BIT_STRING:
@@ -1308,7 +1307,7 @@ abstract class ASN1
 
         // error supression isn't necessary as of PHP 7.0:
         // http://php.net/manual/en/migration70.other-changes.php
-        return @DateTime::createFromFormat($format, $content);
+        return @\DateTime::createFromFormat($format, $content);
     }
 
     /**

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -26,9 +26,6 @@
 
 namespace phpseclib3\File;
 
-use DateTimeImmutable;
-use DateTimeInterface;
-use DateTimeZone;
 use ParagonIE\ConstantTime\Base64;
 use ParagonIE\ConstantTime\Hex;
 use phpseclib3\Crypt\Common\PrivateKey;
@@ -36,6 +33,7 @@ use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\EC;
 use phpseclib3\Crypt\Hash;
+use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
@@ -43,7 +41,6 @@ use phpseclib3\Exception\UnsupportedAlgorithmException;
 use phpseclib3\File\ASN1\Element;
 use phpseclib3\File\ASN1\Maps;
 use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\PublicKeyLoader;
 
 /**
  * Pure-PHP X.509 Parser
@@ -1124,7 +1121,7 @@ class X509
      *
      * If $date isn't defined it is assumed to be the current date.
      *
-     * @param DateTimeInterface|string $date optional
+     * @param \DateTimeInterface|string $date optional
      * @access public
      * @return boolean
      */
@@ -1135,7 +1132,7 @@ class X509
         }
 
         if (!isset($date)) {
-            $date = new DateTimeImmutable(null, new DateTimeZone(@date_default_timezone_get()));
+            $date = new \DateTimeImmutable(null, new \DateTimeZone(@date_default_timezone_get()));
         }
 
         $notBefore = $this->currentCert['tbsCertificate']['validity']['notBefore'];
@@ -1145,11 +1142,11 @@ class X509
         $notAfter = isset($notAfter['generalTime']) ? $notAfter['generalTime'] : $notAfter['utcTime'];
 
         if (is_string($date)) {
-            $date = new DateTimeImmutable($date, new DateTimeZone(@date_default_timezone_get()));
+            $date = new \DateTimeImmutable($date, new \DateTimeZone(@date_default_timezone_get()));
         }
 
-        $notBefore = new DateTimeImmutable($notBefore, new DateTimeZone(@date_default_timezone_get()));
-        $notAfter = new DateTimeImmutable($notAfter, new DateTimeZone(@date_default_timezone_get()));
+        $notBefore = new \DateTimeImmutable($notBefore, new \DateTimeZone(@date_default_timezone_get()));
+        $notAfter = new \DateTimeImmutable($notAfter, new \DateTimeZone(@date_default_timezone_get()));
 
         return $date >= $notBefore && $date<= $notAfter;
     }
@@ -2580,7 +2577,7 @@ class X509
         if ($date instanceof Element) {
             return $date;
         }
-        $dateObj = new DateTimeImmutable($date, new DateTimeZone('GMT'));
+        $dateObj = new \DateTimeImmutable($date, new \DateTimeZone('GMT'));
         $year = $dateObj->format('Y'); // the same way ASN1.php parses this
         if ($year < 2050) {
             return ['utcTime' => $date];
@@ -2656,10 +2653,10 @@ class X509
                 return false;
             }
 
-            $startDate = new DateTimeImmutable('now', new DateTimeZone(@date_default_timezone_get()));
+            $startDate = new \DateTimeImmutable('now', new \DateTimeZone(@date_default_timezone_get()));
             $startDate = !empty($this->startDate) ? $this->startDate : $startDate->format('D, d M Y H:i:s O');
 
-            $endDate = new DateTimeImmutable('+1 year', new DateTimeZone(@date_default_timezone_get()));
+            $endDate = new \DateTimeImmutable('+1 year', new \DateTimeZone(@date_default_timezone_get()));
             $endDate = !empty($this->endDate) ? $this->endDate : $endDate->format('D, d M Y H:i:s O');
 
             /* "The serial number MUST be a positive integer"
@@ -2924,7 +2921,7 @@ class X509
         $signatureSubject = isset($this->signatureSubject) ? $this->signatureSubject : null;
         $signatureAlgorithm = self::identifySignatureAlgorithm($issuer->privateKey);
 
-        $thisUpdate = new DateTimeImmutable('now', new DateTimeZone(@date_default_timezone_get()));
+        $thisUpdate = new \DateTimeImmutable('now', new \DateTimeZone(@date_default_timezone_get()));
         $thisUpdate = !empty($this->startDate) ? $this->startDate : $thisUpdate->format('D, d M Y H:i:s O');
 
         if (isset($crl->currentCert) && is_array($crl->currentCert) && isset($crl->currentCert['tbsCertList'])) {
@@ -3098,13 +3095,13 @@ class X509
     /**
      * Set certificate start date
      *
-     * @param DateTimeInterface|string $date
+     * @param \DateTimeInterface|string $date
      * @access public
      */
     public function setStartDate($date)
     {
-        if (!is_object($date) || !($date instanceof DateTimeInterface)) {
-            $date = new DateTimeImmutable($date, new DateTimeZone(@date_default_timezone_get()));
+        if (!is_object($date) || !($date instanceof \DateTimeInterface)) {
+            $date = new \DateTimeImmutable($date, new \DateTimeZone(@date_default_timezone_get()));
         }
 
         $this->startDate = $date->format('D, d M Y H:i:s O');
@@ -3113,7 +3110,7 @@ class X509
     /**
      * Set certificate end date
      *
-     * @param DateTimeInterface|string $date
+     * @param \DateTimeInterface|string $date
      * @access public
      */
     public function setEndDate($date)
@@ -3130,8 +3127,8 @@ class X509
             $temp = chr(ASN1::TYPE_GENERALIZED_TIME) . ASN1::encodeLength(strlen($temp)) . $temp;
             $this->endDate = new Element($temp);
         } else {
-            if (!is_object($date) || !($date instanceof DateTimeInterface)) {
-                $date = new DateTimeImmutable($date, new DateTimeZone(@date_default_timezone_get()));
+            if (!is_object($date) || !($date instanceof \DateTimeInterface)) {
+                $date = new \DateTimeImmutable($date, new \DateTimeZone(@date_default_timezone_get()));
             }
 
             $this->endDate = $date->format('D, d M Y H:i:s O');
@@ -3867,7 +3864,7 @@ class X509
         }
 
         $i = count($rclist);
-        $revocationDate = new DateTimeImmutable('now', new DateTimeZone(@date_default_timezone_get()));
+        $revocationDate = new \DateTimeImmutable('now', new \DateTimeZone(@date_default_timezone_get()));
         $rclist[] = ['userCertificate' => $serial,
                           'revocationDate'  => $this->timeField($revocationDate->format('D, d M Y H:i:s O'))];
         return $i;

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
@@ -15,8 +15,8 @@
 
 namespace phpseclib3\Math\BigInteger\Engines\BCMath\Reductions;
 
-use phpseclib3\Math\BigInteger\Engines\BCMath\Base;
 use phpseclib3\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\BCMath\Base;
 
 /**
  * PHP Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -16,10 +16,10 @@
 namespace phpseclib3\Math\BigInteger\Engines;
 
 use ParagonIE\ConstantTime\Hex;
-use phpseclib3\Exception\BadConfigurationException;
-use phpseclib3\Crypt\Random;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\Random;
+use phpseclib3\Exception\BadConfigurationException;
+use phpseclib3\Math\BigInteger;
 
 /**
  * Base Engine.

--- a/phpseclib/Math/BigInteger/Engines/GMP.php
+++ b/phpseclib/Math/BigInteger/Engines/GMP.php
@@ -15,7 +15,6 @@
 
 namespace phpseclib3\Math\BigInteger\Engines;
 
-use ParagonIE\ConstantTime\Hex;
 use phpseclib3\Exception\BadConfigurationException;
 
 /**

--- a/phpseclib/Math/BigInteger/Engines/OpenSSL.php
+++ b/phpseclib/Math/BigInteger/Engines/OpenSSL.php
@@ -15,7 +15,6 @@
 
 namespace phpseclib3\Math\BigInteger\Engines;
 
-use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
 use phpseclib3\Math\BigInteger;
 

--- a/phpseclib/Math/BigInteger/Engines/PHP/Montgomery.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Montgomery.php
@@ -15,10 +15,9 @@
 
 namespace phpseclib3\Math\BigInteger\Engines\PHP;
 
-use phpseclib3\Math\BigInteger\Engines\PHP\Reductions\PowerOfTwo;
-use phpseclib3\Math\BigInteger\Engines\PHP;
-use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 use phpseclib3\Math\BigInteger\Engines\Engine;
+use phpseclib3\Math\BigInteger\Engines\PHP;
+use phpseclib3\Math\BigInteger\Engines\PHP\Reductions\PowerOfTwo;
 
 /**
  * PHP Montgomery Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
@@ -15,8 +15,8 @@
 
 namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 use phpseclib3\Math\BigInteger\Engines\PHP;
+use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Dynamic Barrett Modular Exponentiation Engine

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/MontgomeryMult.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/MontgomeryMult.php
@@ -15,7 +15,6 @@
 
 namespace phpseclib3\Math\BigInteger\Engines\PHP\Reductions;
 
-use phpseclib3\Math\BigInteger\Engines\PHP\Base;
 
 /**
  * PHP Montgomery Modular Exponentiation Engine with interleaved multiplication

--- a/phpseclib/Math/BigInteger/Engines/PHP32.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP32.php
@@ -15,7 +15,6 @@
 
 namespace phpseclib3\Math\BigInteger\Engines;
 
-use ParagonIE\ConstantTime\Hex;
 
 /**
  * Pure-PHP 32-bit Engine.

--- a/phpseclib/Math/BigInteger/Engines/PHP64.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP64.php
@@ -15,7 +15,6 @@
 
 namespace phpseclib3\Math\BigInteger\Engines;
 
-use ParagonIE\ConstantTime\Hex;
 
 /**
  * Pure-PHP 64-bit Engine.

--- a/phpseclib/Math/BinaryField.php
+++ b/phpseclib/Math/BinaryField.php
@@ -16,10 +16,9 @@
 
 namespace phpseclib3\Math;
 
-use ParagonIE\ConstantTime\Hex;
-use phpseclib3\Math\Common\FiniteField;
-use phpseclib3\Math\BinaryField\Integer;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Math\BinaryField\Integer;
+use phpseclib3\Math\Common\FiniteField;
 
 /**
  * Binary Finite Fields

--- a/phpseclib/Math/BinaryField/Integer.php
+++ b/phpseclib/Math/BinaryField/Integer.php
@@ -22,10 +22,10 @@
 
 namespace phpseclib3\Math\BinaryField;
 
-use phpseclib3\Math\Common\FiniteField\Integer as Base;
+use ParagonIE\ConstantTime\Hex;
 use phpseclib3\Math\BigInteger;
 use phpseclib3\Math\BinaryField;
-use ParagonIE\ConstantTime\Hex;
+use phpseclib3\Math\Common\FiniteField\Integer as Base;
 
 /**
  * Binary Finite Fields

--- a/phpseclib/Math/PrimeField/Integer.php
+++ b/phpseclib/Math/PrimeField/Integer.php
@@ -14,9 +14,9 @@
 
 namespace phpseclib3\Math\PrimeField;
 
-use phpseclib3\Math\Common\FiniteField\Integer as Base;
-use phpseclib3\Math\BigInteger;
 use ParagonIE\ConstantTime\Hex;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\Math\Common\FiniteField\Integer as Base;
 
 /**
  * Prime Finite Fields

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -35,10 +35,8 @@
 
 namespace phpseclib3\Net;
 
-use phpseclib3\Exception\FileNotFoundException;
 use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\Common\AsymmetricKey;
-use phpseclib3\System\SSH\Agent;
+use phpseclib3\Exception\FileNotFoundException;
 
 /**
  * Pure-PHP implementations of SFTP.

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -404,7 +404,7 @@ class SSH2
      * Server to Client Encryption Object
      *
      * @see self::_get_binary_packet()
-     * @var object
+     * @var SymmetricKey|false
      * @access private
      */
     private $decrypt = false;
@@ -440,7 +440,7 @@ class SSH2
      * Client to Server Encryption Object
      *
      * @see self::_send_binary_packet()
-     * @var object
+     * @var SymmetricKey|false
      * @access private
      */
     private $encrypt = false;
@@ -3457,6 +3457,11 @@ class SSH2
                     $remaining_length = 0;
                     break;
                 case 'chacha20-poly1305@openssh.com':
+                    // This should be impossible, but we are checking anyway to narrow the type for Psalm.
+                    if (!($this->decrypt instanceof ChaCha20)) {
+                        throw new \LogicException('$this->decrypt is not a ' . ChaCha20::class);
+                    }
+
                     $nonce = pack('N2', 0, $this->get_seq_no);
 
                     $this->lengthDecrypt->setNonce($nonce);
@@ -4204,6 +4209,11 @@ class SSH2
                     $packet = $temp . $this->encrypt->encrypt(substr($packet, 4));
                     break;
                 case 'chacha20-poly1305@openssh.com':
+                    // This should be impossible, but we are checking anyway to narrow the type for Psalm.
+                    if (!($this->encrypt instanceof ChaCha20)) {
+                        throw new \LogicException('$this->encrypt is not a ' . ChaCha20::class);
+                    }
+
                     $nonce = pack('N2', 0, $this->send_seq_no);
 
                     $this->encrypt->setNonce($nonce);
@@ -5154,6 +5164,7 @@ class SSH2
      * @return string
      * @access public
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return $this->getResourceId();

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -47,32 +47,31 @@
 
 namespace phpseclib3\Net;
 
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Blowfish;
+use phpseclib3\Crypt\ChaCha20;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\Common\SymmetricKey;
+use phpseclib3\Crypt\DH;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\EC;
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\RC4;
 use phpseclib3\Crypt\Rijndael;
-use phpseclib3\Crypt\Common\PublicKey;
-use phpseclib3\Crypt\Common\PrivateKey;
 use phpseclib3\Crypt\RSA;
-use phpseclib3\Crypt\DSA;
-use phpseclib3\Crypt\EC;
-use phpseclib3\Crypt\DH;
-use phpseclib3\Crypt\TripleDES;
+use phpseclib3\Crypt\TripleDES; // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
 use phpseclib3\Crypt\Twofish;
-use phpseclib3\Crypt\ChaCha20;
-use phpseclib3\Math\BigInteger; // Used to do Diffie-Hellman key exchange and DSA/RSA signature verification.
-use phpseclib3\System\SSH\Agent;
-use phpseclib3\System\SSH\Agent\Identity as AgentIdentity;
+use phpseclib3\Exception\ConnectionClosedException;
+use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Exception\NoSupportedAlgorithmsException;
+use phpseclib3\Exception\UnableToConnectException;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
 use phpseclib3\Exception\UnsupportedCurveException;
-use phpseclib3\Exception\ConnectionClosedException;
-use phpseclib3\Exception\UnableToConnectException;
-use phpseclib3\Exception\InsufficientSetupException;
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Math\BigInteger;
+use phpseclib3\System\SSH\Agent;
 
 /**
  * Pure-PHP implementation of SSHv2.

--- a/phpseclib/System/SSH/Agent.php
+++ b/phpseclib/System/SSH/Agent.php
@@ -34,11 +34,11 @@
 
 namespace phpseclib3\System\SSH;
 
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Exception\BadConfigurationException;
 use phpseclib3\System\SSH\Agent\Identity;
-use phpseclib3\Common\Functions\Strings;
-use phpseclib3\Crypt\PublicKeyLoader;
 
 /**
  * Pure-PHP ssh-agent client identity factory

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -17,13 +17,13 @@
 
 namespace phpseclib3\System\SSH\Agent;
 
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Crypt\DSA;
-use phpseclib3\Crypt\EC;
-use phpseclib3\Exception\UnsupportedAlgorithmException;
-use phpseclib3\System\SSH\Agent;
 use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Crypt\DSA;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\System\SSH\Agent;
 
 /**
  * Pure-PHP ssh-agent client identity object

--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -6,7 +6,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Base;
 use phpseclib3\Net\SFTP;
 
 class Functional_Net_SFTPLargeFileTest extends Functional_Net_SFTPTestCase

--- a/tests/Functional/Net/SFTPWrongServerTest.php
+++ b/tests/Functional/Net/SFTPWrongServerTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use phpseclib3\Net\SFTP;
 use phpseclib3\Exception\UnableToConnectException;
+use phpseclib3\Net\SFTP;
 use PHPUnit\Framework\TestCase;
 
 class SFTPWrongServerTest extends TestCase

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -109,7 +109,7 @@ class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
     public function testExecWithMethodCallback($ssh)
     {
         $callbackObject = $this->getMockBuilder('stdClass')
-            ->setMethods(array('callbackMethod'))
+            ->setMethods(['callbackMethod'])
             ->getMock();
         $callbackObject
             ->expects($this->atLeastOnce())

--- a/tests/PhpseclibFunctionalTestCase.php
+++ b/tests/PhpseclibFunctionalTestCase.php
@@ -5,8 +5,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Hash;
-use phpseclib3\Math\BigInteger;
 
 abstract class PhpseclibFunctionalTestCase extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/AES/EvalTest.php
+++ b/tests/Unit/Crypt/AES/EvalTest.php
@@ -5,7 +5,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_EvalTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/McryptTest.php
+++ b/tests/Unit/Crypt/AES/McryptTest.php
@@ -5,7 +5,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_McryptTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/OpenSSLTest.php
+++ b/tests/Unit/Crypt/AES/OpenSSLTest.php
@@ -5,7 +5,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_OpenSSLTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/PurePHPTest.php
+++ b/tests/Unit/Crypt/AES/PurePHPTest.php
@@ -5,7 +5,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Common\BlockCipher;
 
 class Unit_Crypt_AES_PurePHPTest extends Unit_Crypt_AES_TestCase
 {

--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -6,7 +6,6 @@
  */
 
 use phpseclib3\Crypt\AES;
-use phpseclib3\Crypt\Common\BlockCipher;
 use phpseclib3\Crypt\Rijndael;
 use phpseclib3\Exception\InconsistentSetupException;
 use phpseclib3\Exception\InsufficientSetupException;

--- a/tests/Unit/Crypt/DHTest.php
+++ b/tests/Unit/Crypt/DHTest.php
@@ -5,13 +5,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\DH;
-use phpseclib3\Crypt\DH\PublicKey;
-use phpseclib3\Crypt\DH\PrivateKey;
 use phpseclib3\Crypt\DH\Parameters;
+use phpseclib3\Crypt\DH\PrivateKey;
+use phpseclib3\Crypt\DH\PublicKey;
 use phpseclib3\Crypt\EC;
 use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\AES;
 
 class Unit_Crypt_DHTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/DSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/DSA/CreateKeyTest.php
@@ -8,8 +8,8 @@
 
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\DSA\Parameters;
-use phpseclib3\Crypt\DSA\PublicKey;
 use phpseclib3\Crypt\DSA\PrivateKey;
+use phpseclib3\Crypt\DSA\PublicKey;
 
 /**
  * @requires PHP 7.0

--- a/tests/Unit/Crypt/DSA/LoadDSAKeyTest.php
+++ b/tests/Unit/Crypt/DSA/LoadDSAKeyTest.php
@@ -5,14 +5,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\DSA\Parameters;
 use phpseclib3\Crypt\DSA\PrivateKey;
 use phpseclib3\Crypt\DSA\PublicKey;
-use phpseclib3\Crypt\DSA\Parameters;
-use phpseclib3\Crypt\DSA\Formats\Keys\PKCS1;
-use phpseclib3\Crypt\DSA\Formats\Keys\PKCS8;
-use phpseclib3\Crypt\DSA\Formats\Keys\PuTTY;
-use phpseclib3\Math\BigInteger;
+use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Exception\NoKeyLoadedException;
 
 class Unit_Crypt_DSA_LoadDSAKeyTest extends PhpseclibTestCase

--- a/tests/Unit/Crypt/EC/CurveTest.php
+++ b/tests/Unit/Crypt/EC/CurveTest.php
@@ -6,12 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\EC;
-use phpseclib3\File\ASN1;
-use phpseclib3\Crypt\EC\Curves\Ed448;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\File\ASN1;
 
 class Ed448PublicKey
 {

--- a/tests/Unit/Crypt/EC/KeyTest.php
+++ b/tests/Unit/Crypt/EC/KeyTest.php
@@ -6,13 +6,13 @@
  */
 
 use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\Formats\Keys\OpenSSH;
 use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
 use phpseclib3\Crypt\EC\Formats\Keys\PKCS8;
 use phpseclib3\Crypt\EC\Formats\Keys\PuTTY;
-use phpseclib3\Crypt\EC\Formats\Keys\OpenSSH;
 use phpseclib3\Crypt\EC\Formats\Keys\XML;
-use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\EC\PrivateKey;
+use phpseclib3\Crypt\PublicKeyLoader;
 
 class Unit_Crypt_EC_KeyTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RC4Test.php
+++ b/tests/Unit/Crypt/RC4Test.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\RC4;
 use phpseclib3\Crypt\Random;
+use phpseclib3\Crypt\RC4;
 
 class Unit_Crypt_RC4Test extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -5,18 +5,18 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\PublicKeyLoader;
-use phpseclib3\Crypt\RSA\PrivateKey;
-use phpseclib3\Crypt\RSA\PublicKey;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\Formats\Keys\OpenSSH;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS1;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
-use phpseclib3\Crypt\RSA\Formats\Keys\PuTTY;
-use phpseclib3\Crypt\RSA\Formats\Keys\OpenSSH;
 use phpseclib3\Crypt\RSA\Formats\Keys\PSS;
-use phpseclib3\Math\BigInteger;
-use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Crypt\RSA\Formats\Keys\PuTTY;
+use phpseclib3\Crypt\RSA\PrivateKey;
+use phpseclib3\Crypt\RSA\PublicKey;
 use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Exception\UnsupportedFormatException;
+use phpseclib3\Math\BigInteger;
 
 class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
 {

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -5,10 +5,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Math\BigInteger;
 use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
+use phpseclib3\Math\BigInteger;
 
 class Unit_Crypt_RSA_ModeTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -307,12 +307,12 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
 
     public function testApplicationTag()
     {
-        $map = array(
+        $map = [
             'type'     => ASN1::TYPE_SEQUENCE,
-            'children' => array(
+            'children' => [
                 // technically, default implies optional, but we'll define it as being optional, none-the-less, just to
                 // reenforce that fact
-                'version'             => array(
+                'version'             => [
                     // if class isn't present it's assumed to be ASN1::CLASS_UNIVERSAL or
                     // (if constant is present) ASN1::CLASS_CONTEXT_SPECIFIC
                     'class'    => ASN1::CLASS_APPLICATION,
@@ -321,12 +321,12 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
                     'explicit' => true,
                     'default'  => 'v1',
                     'type'     => ASN1::TYPE_INTEGER,
-                    'mapping' => array('v1', 'v2', 'v3')
-                )
-            )
-        );
+                    'mapping' => ['v1', 'v2', 'v3']
+                ]
+            ]
+        ];
 
-        $data = array('version' => 'v3');
+        $data = ['version' => 'v3'];
 
         $str = ASN1::encodeDER($data, $map);
 
@@ -370,21 +370,21 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
      */
     public function testExplicitImplicitDate()
     {
-        $map = array(
+        $map = [
             'type'     => ASN1::TYPE_SEQUENCE,
-            'children' => array(
-                'notBefore' => array(
+            'children' => [
+                'notBefore' => [
                                              'constant' => 0,
                                              'optional' => true,
                                              'implicit' => true,
-                                             'type' => ASN1::TYPE_GENERALIZED_TIME),
-                'notAfter'  => array(
+                                             'type' => ASN1::TYPE_GENERALIZED_TIME],
+                'notAfter'  => [
                                              'constant' => 1,
                                              'optional' => true,
                                              'implicit' => true,
-                                             'type' => ASN1::TYPE_GENERALIZED_TIME)
-            )
-        );
+                                             'type' => ASN1::TYPE_GENERALIZED_TIME]
+            ]
+        ];
 
         $a = pack('H*', '3026a011180f32303137303432313039303535305aa111180f32303138303432313230353935395a');
         $a = ASN1::decodeBER($a);

--- a/tests/Unit/File/X509/CSRTest.php
+++ b/tests/Unit/File/X509/CSRTest.php
@@ -5,9 +5,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\File\X509;
-use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 
 class Unit_File_X509_CSRTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/X509/SPKACTest.php
+++ b/tests/Unit/File/X509/SPKACTest.php
@@ -5,8 +5,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\File\X509;
 use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 
 class Unit_File_X509_SPKACTest extends PhpseclibTestCase
 {

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -5,11 +5,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Element;
 use phpseclib3\File\X509;
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Crypt\PublicKeyLoader;
 
 class Unit_File_X509_X509Test extends PhpseclibTestCase
 {
@@ -1045,7 +1045,7 @@ ut3+b2Xvzq8yzmHMFtLIJ6Afu1jJpqD82BUAFcvi5vhnP8M7b974R18WCOpgNQvXDI+2/8ZINeU=
 -----END CERTIFICATE-----');
         $r = $x509->saveX509($r);
         $r = $x509->loadX509($r);
-        $this->assertSame($r['tbsCertificate']['extensions'][5]['extnValue']['excludedSubtrees'][1]['base']['iPAddress'], array('0.0.0.0', '0.0.0.0'));
+        $this->assertSame($r['tbsCertificate']['extensions'][5]['extnValue']['excludedSubtrees'][1]['base']['iPAddress'], ['0.0.0.0', '0.0.0.0']);
     }
 
     /**

--- a/tests/Unit/Math/BigInteger/BCMathTest.php
+++ b/tests/Unit/Math/BigInteger/BCMathTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger\Engines\BCMath;
+use phpseclib3\Math\BigInteger\Engines\BCMath;
 
 class Unit_Math_BigInteger_BCMathTest extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/DefaultTest.php
+++ b/tests/Unit/Math/BigInteger/DefaultTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger;
+use phpseclib3\Math\BigInteger;
 
 class Unit_Math_BigInteger_DefaultTest extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/GMPTest.php
+++ b/tests/Unit/Math/BigInteger/GMPTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger\Engines\GMP;
+use phpseclib3\Math\BigInteger\Engines\GMP;
 
 class Unit_Math_BigInteger_GMPTest extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/PHP32Test.php
+++ b/tests/Unit/Math/BigInteger/PHP32Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger\Engines\PHP32;
+use phpseclib3\Math\BigInteger\Engines\PHP32;
 
 class Unit_Math_BigInteger_PHP32Test extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
+++ b/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger\Engines\PHP64;
+use phpseclib3\Math\BigInteger\Engines\PHP64;
 
 class Unit_Math_BigInteger_PHP64OpenSSLTest extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/PHP64Test.php
+++ b/tests/Unit/Math/BigInteger/PHP64Test.php
@@ -5,7 +5,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use \phpseclib3\Math\BigInteger\Engines\PHP64;
+use phpseclib3\Math\BigInteger\Engines\PHP64;
 
 class Unit_Math_BigInteger_PHP64Test extends Unit_Math_BigInteger_TestCase
 {

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -488,10 +488,10 @@ abstract class Unit_Math_BigInteger_TestCase extends PhpseclibTestCase
 
     public function testNegativePrecision()
     {
-        $vals = array(
+        $vals = [
             '-9223372036854775808', // eg. 8000 0000 0000 0000
             '-1'
-        );
+        ];
         foreach ($vals as $val) {
             $x = $this->getInstance($val);
             $x->setPrecision(64); // ie. 8 bytes

--- a/travis/setup-composer.sh
+++ b/travis/setup-composer.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 composer self-update --no-interaction
 composer install --no-interaction
+if [ "$TRAVIS_PHP_VERSION" = '8.1.0' ]; then
+    composer install --no-interaction --working-dir=build
+fi


### PR DESCRIPTION
I used a separate composer.json to hold the ci tools, so we only need to worry about running it on the latest php version.

php-cs-fixer:
Most changes are just sorting the imports and removing unused imports. Please review the rules and decide if you agree with them. There are many others I would like to use, but left that for a later PR.

psalm:
The newer version of psalm found a couple more errors. More dynamic properties found!
Also, I needed to create a \ReturnTypeWillChange polyfill (the symfony polyfill requires php 7.1...)