### PR TITLE
Fixed risky tests

### DIFF
--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -200,9 +200,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
         $aes->setKey($key);
         $aes->setIV($iv);
 
-        if (!$this->_checkEngine($aes)) {
-            return;
-        }
+        $this->_checkEngine($aes);
 
         foreach ($test as $len) {
             $temp = str_repeat('d', $len);
@@ -223,7 +221,7 @@ abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
     public function testNonContinuousBufferBattery($op, $mode, $test)
     {
         if (count($test) == 1) {
-            return;
+            self::markTestSkipped('test is 1');
         }
 
         $iv = str_repeat('x', 16);

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -571,7 +571,10 @@ AAIBAAIBAAIBAAIBAA==
             ->withMGFHash('md5')
             ->withPadding(RSA::SIGNATURE_PKCS1);
 
-        $rsa->sign('zzzz');
+        self::assertSame(
+            'oW0X9GlHa1qyC3Xj2gyzf5VwzLksmIB60icLdrneWA1kTW9RvkfskB4XLs8IVxYy+O8Tm/fJTIPpdNtRB7sfeQ==',
+            base64_encode($rsa->sign('zzzz'))
+        );
     }
 
     public function pkcs8tester($key, $pass)

--- a/tests/Unit/Crypt/TripleDESTest.php
+++ b/tests/Unit/Crypt/TripleDESTest.php
@@ -190,14 +190,47 @@ class Unit_Crypt_TripleDESTest extends PhpseclibTestCase
         }
     }
 
-    // test special case lambda function error
-    public function testCorrectSelfUseInLambda()
+    /**
+     * @dataProvider provideForCorrectSelfUseInLambda
+     * @param string $key
+     * @param string $expectedCiphertext
+     * @return void
+     */
+    public function testCorrectSelfUseInLambda($key, $expectedCiphertext)
     {
         $td = new TripleDES('ecb');
         $td->setPreferredEngine('Eval');
-        for ($i = 0; $i < 20; $i++) {
-            $td->setKey(str_repeat('a', 20) . pack('V', mt_rand()));
-            $td->encrypt(str_repeat('a', 32));
-        }
+        $td->setKey(base64_decode($key));
+        $ciphertext = $td->encrypt(str_repeat('a', 32));
+        self::assertSame($expectedCiphertext, base64_encode($ciphertext));
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public function provideForCorrectSelfUseInLambda()
+    {
+        return [
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWG9l9gm', 'fDSmC5bbLdx8NKYLltst3Hw0pguW2y3cfDSmC5bbLdxmhqEOIeS2ig=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWFhiyIR', 'pRE2q3y7s6ylETarfLuzrKURNqt8u7OspRE2q3y7s6wn4E6gffbNJw=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWFKOPlL', 'lnarcjmMu+OWdqtyOYy745Z2q3I5jLvjlnarcjmMu+NYSjvKzL2Osw=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWEfGesQ', 'VxvHOxYoHAJXG8c7FigcAlcbxzsWKBwCVxvHOxYoHAKu2gQBvhV4Qw=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGeCuBh', 'dQZuvUeEemp1Bm69R4R6anUGbr1HhHpqdQZuvUeEempfXEWLEcWTYQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWHrg28q', 'vWcEQuwfYZC9ZwRC7B9hkL1nBELsH2GQvWcEQuwfYZChcIWy7Jx4AQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWE7VTFW', '5HfiS1TkD4Lkd+JLVOQPguR34ktU5A+C5HfiS1TkD4J7OjziCG84YA=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWHu6jQV', '0XOLOVBh3HXRc4s5UGHcddFzizlQYdx10XOLOVBh3HWAfZzoan7UNA=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWHBQqVh', '5sXLCUFzKCTmxcsJQXMoJObFywlBcygk5sXLCUFzKCQx78hr/rq4ww=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWElZYAM', 'i7hwXD3f/ziLuHBcPd//OIu4cFw93/84i7hwXD3f/zjYM/eL8sCkVQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGiFRwF', '2ybIPpjRyufbJsg+mNHK59smyD6Y0crn2ybIPpjRyueUX5HLPHATqQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWFHDjMw', 'uhLr0mWFI4i6EuvSZYUjiLoS69JlhSOIuhLr0mWFI4hrCZ9vaOlmbg=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGqlkgm', '9gjxyj6xL6z2CPHKPrEvrPYI8co+sS+s9gjxyj6xL6z1Swr5acgeOw=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGFxv4E', 'wr+yhvXSmo7Cv7KG9dKajsK/sob10pqOwr+yhvXSmo5fTYtM7AM0Tg=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWHIuKFR', 'Ug35w2rztYhSDfnDavO1iFIN+cNq87WIUg35w2rztYgU5XzjwaRlbw=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWEvbSIB', '7lo0S11Kp6PuWjRLXUqno+5aNEtdSqej7lo0S11Kp6OX1cTbb6FyyA=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWEgD5wO', 'QF1VxM0jlm5AXVXEzSOWbkBdVcTNI5ZuQF1VxM0jlm6qoYnfJo67NQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGBNnsp', 'ZFtpJzprc+9kW2knOmtz72RbaSc6a3PvZFtpJzprc++DKOgJXprsFQ=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWGbz7Zy', '6m3d0xNg5t/qbd3TE2Dm3+pt3dMTYObf6m3d0xNg5t+ddL6I8jfWYA=='],
+            ['YWFhYWFhYWFhYWFhYWFhYWFhYWEijusc', 'R8guMW5IH1pHyC4xbkgfWkfILjFuSB9aR8guMW5IH1pDXTJwKiDKbA=='],
+        ];
     }
 }

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -290,18 +290,21 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
     public function testInfiniteLoop()
     {
         $data = base64_decode('MD6gJQYKKwYBBAGCNxQCA6AXDBVvZmZpY2VAY2VydGRpZ2l0YWwucm+BFW9mZmljZUBjZXJ0ZGlnaXRhbC5ybw==');
-        ASN1::decodeBER($data);
+        self::assertSame(
+            'a:1:{i:0;a:5:{s:5:"start";i:0;s:12:"headerlength";i:2;s:4:"type";i:16;s:7:"content";a:2:{i:0;a:6:{s:4:"type";i:2;s:8:"constant";i:0;s:7:"content";a:2:{i:0;a:5:{s:5:"start";i:4;s:12:"headerlength";i:2;s:4:"type";i:6;s:7:"content";s:22:"1.3.6.1.4.1.311.20.2.3";s:6:"length";i:12;}i:1;a:6:{s:4:"type";i:2;s:8:"constant";i:0;s:7:"content";a:1:{i:0;a:5:{s:5:"start";i:18;s:12:"headerlength";i:2;s:4:"type";i:12;s:7:"content";s:21:"office@certdigital.ro";s:6:"length";i:23;}}s:6:"length";i:25;s:5:"start";i:16;s:12:"headerlength";i:2;}}s:6:"length";i:39;s:5:"start";i:2;s:12:"headerlength";i:2;}i:1;a:6:{s:4:"type";i:2;s:8:"constant";i:1;s:7:"content";s:21:"office@certdigital.ro";s:6:"length";i:23;s:5:"start";i:41;s:12:"headerlength";i:2;}}s:6:"length";i:64;}}',
+            serialize(ASN1::decodeBER($data))
+        );
     }
 
     public function testMaps()
     {
         $files = scandir('phpseclib/File/ASN1/Maps');
+        self::assertNotEmpty($files);
         foreach ($files as $file) {
             if ($file == '.' || $file == '..') {
                 continue;
             }
-
-            constant('phpseclib3\\File\\ASN1\\Maps\\' . basename($file, '.php') . '::MAP');
+            self::assertTrue(defined('phpseclib3\\File\\ASN1\\Maps\\' . basename($file, '.php') . '::MAP'));
         }
     }
 
@@ -342,7 +345,10 @@ class Unit_File_ASN1Test extends PhpseclibTestCase
     public function testInvalidCertificate()
     {
         $data = 'a' . base64_decode('MD6gJQYKKwYBBAGCNxQCA6AXDBVvZmZpY2VAY2VydGRpZ2l0YWwucm+BFW9mZmljZUBjZXJ0ZGlnaXRhbC5ybw==');
-        ASN1::decodeBER($data);
+        self::assertSame(
+            'a:1:{i:0;a:6:{s:4:"type";i:1;s:8:"constant";i:1;s:7:"content";a:0:{}s:6:"length";i:2;s:5:"start";i:0;s:12:"headerlength";i:2;}}',
+            serialize(ASN1::decodeBER($data))
+        );
     }
 
     /**

--- a/tests/Unit/File/X509/CSRTest.php
+++ b/tests/Unit/File/X509/CSRTest.php
@@ -119,6 +119,10 @@ U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
         $x509->setPrivateKey($rsa);
         $x509->setDN(['cn' => 'website.com']);
         $x509->saveCSR($x509->signCSR(), X509::FORMAT_DER);
+        self::assertSame(
+            'MIIBUTCBvQIBADAWMRQwEgYDVQQDDAt3ZWJzaXRlLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAqhirpDtQ3u84WY+vh9KrY05FccEwqbynuHgmdBT6q4tHG9iWX1yfw4GEher1KcJiRvMFUGSo3hnIwzi+VJbLrrBZ3As1gUO0SjVEnrJkETEhpFW9f94/rJGelLVvubtPZRzbI+rUOdbNUj6wgZHnWzX9E6dBmzCQ8keHvU9OGWcCAwEAATALBgkqhkiG9w0BAQUDgYEAMsFgm5Y7/DY+a4NFK/2VHEyEf5C9+Oe+qaZQie0djZ5wPadabV4lOEYX4RcGMtrnfgYuUt8pMIubq4JQtpnw2rpaEZPQIr0ed/GvuiQD2oyaBd7tmPDoiJzN/+DjdniF/wq3POUz/UzZ+g1IgSYaGXtmtn7XgafiE+K+PQFRvrQ=',
+            base64_encode($x509->saveCSR($x509->signCSR(), X509::FORMAT_DER))
+        );
     }
 
     /**

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -375,6 +375,7 @@ Mj93S
 
         $x509 = new X509();
         $x509->sign($issuer, $subject);
+        self::assertTrue(true);
     }
 
     public function testUtcTimeWithoutSeconds()

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -410,7 +410,7 @@ abstract class Unit_Math_BigInteger_TestCase extends PhpseclibTestCase
         $e = $this->getInstance(str_repeat('1', 1794), 2);
         $x = $this->getInstance(1);
         $n = $this->getInstance(2);
-        $x->powMod($e, $n);
+        self::assertSame('1', $x->powMod($e, $n)->toString());
     }
 
     public function testRoot()


### PR DESCRIPTION
Tests are marked as risky when no assertions are made.
Mostly just added a snapshot-like test; for one of them I just added an `self::assertTrue(true)`.