### PR TITLE
Remove some psr12 phpcs rule exclusions

### DIFF
--- a/build/phpcs_ruleset.xml
+++ b/build/phpcs_ruleset.xml
@@ -15,8 +15,5 @@
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment"/>
-        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
-        <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
     </rule>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -71,5 +71,10 @@
         "psr-4": {
             "phpseclib3\\": "phpseclib/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "phpseclib3\\Tests\\": "tests/"
+        }
     }
 }

--- a/phpseclib/Crypt/DH.php
+++ b/phpseclib/Crypt/DH.php
@@ -279,6 +279,7 @@ abstract class DH extends AsymmetricKey
                     return $public->publicKey->powMod($private->privateKey, $private->prime)->toBytes(true);
                 case is_string($public):
                     $public = new BigInteger($public, -256);
+                    // fall-through
                 case $public instanceof BigInteger:
                     return $public->powMod($private->privateKey, $private->prime)->toBytes(true);
                 default:
@@ -290,6 +291,7 @@ abstract class DH extends AsymmetricKey
             switch (true) {
                 case $public instanceof EC\PublicKey:
                     $public = $public->getEncodedCoordinates();
+                    // fall-through
                 case is_string($public):
                     $point = $private->multiply($public);
                     switch ($private->getCurve()) {

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -340,6 +340,7 @@ class Hash
                 break;
             case 'keccak256':
                 $this->paddingType = self::PADDING_KECCAK;
+                // fall-through
             case 'sha256':
             case 'sha512/256':
             case 'sha3-256':

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -143,6 +143,7 @@ abstract class MSBLOB
         switch ($magic) {
             case self::RSA2:
                 $components['isPublicKey'] = false;
+                // fall-through
             case self::RSA1:
                 break;
             default:

--- a/phpseclib/Crypt/TripleDES.php
+++ b/phpseclib/Crypt/TripleDES.php
@@ -164,6 +164,7 @@ class TripleDES extends DES
                 break;
             case 'cbc3':
                 $mode = 'cbc';
+                // fall-through
             // If not 3CBC, we init as usual
             default:
                 parent::__construct($mode);

--- a/phpseclib/File/ANSI.php
+++ b/phpseclib/File/ANSI.php
@@ -268,6 +268,7 @@ class ANSI
                             array_shift($this->history);
                             array_shift($this->history_attrs);
                         }
+                        // fall-through
                     case "\x1B[K": // Clear screen from cursor right
                         $this->screen[$this->y] = substr($this->screen[$this->y], 0, $this->x);
 

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -787,6 +787,7 @@ abstract class ASN1
                     }
                     return $values;
                 }
+                // fall-through
             case self::TYPE_OCTET_STRING:
                 return $decoded['content'];
             case self::TYPE_NULL:
@@ -1065,6 +1066,7 @@ abstract class ASN1
 
                     break;
                 }
+                // fall-through
             case self::TYPE_OCTET_STRING:
                 /* The initial octet shall encode, as an unsigned binary integer with bit 1 as the least significant bit,
                    the number of unused bits in the final subsequent octet. The number shall be in the range zero to seven.
@@ -1385,8 +1387,10 @@ abstract class ASN1
                 case $insize == 4:
                     $c = ($c << 8) | ord($in[$i++]);
                     $c = ($c << 8) | ord($in[$i++]);
+                    // fall-through
                 case $insize == 2:
                     $c = ($c << 8) | ord($in[$i++]);
+                    // fall-through
                 case $insize == 1:
                     break;
                 case ($c & 0x80) == 0x00:
@@ -1415,9 +1419,11 @@ abstract class ASN1
                     $c >>= 8;
                     $v .= chr($c & 0xFF);
                     $c >>= 8;
+                    // fall-through
                 case $outsize == 2:
                     $v .= chr($c & 0xFF);
                     $c >>= 8;
+                    // fall-through
                 case $outsize == 1:
                     $v .= chr($c & 0xFF);
                     $c >>= 8;
@@ -1430,18 +1436,23 @@ abstract class ASN1
                 case $c >= 0x04000000:
                     $v .= chr(0x80 | ($c & 0x3F));
                     $c = ($c >> 6) | 0x04000000;
+                    // fall-through
                 case $c >= 0x00200000:
                     $v .= chr(0x80 | ($c & 0x3F));
                     $c = ($c >> 6) | 0x00200000;
+                    // fall-through
                 case $c >= 0x00010000:
                     $v .= chr(0x80 | ($c & 0x3F));
                     $c = ($c >> 6) | 0x00010000;
+                    // fall-through
                 case $c >= 0x00000800:
                     $v .= chr(0x80 | ($c & 0x3F));
                     $c = ($c >> 6) | 0x00000800;
+                    // fall-through
                 case $c >= 0x00000080:
                     $v .= chr(0x80 | ($c & 0x3F));
                     $c = ($c >> 6) | 0x000000C0;
+                    // fall-through
                 default:
                     $v .= chr($c);
                     break;

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3629,6 +3629,7 @@ class X509
         switch ($disposition) {
             case self::ATTR_REPLACE:
                 $disposition = self::ATTR_APPEND;
+                // fall-through
             case self::ATTR_ALL:
                 $this->removeAttribute($id);
                 break;

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -718,6 +718,7 @@ class SFTP extends SSH2
             switch ($dir) {
                 case '..':
                     array_pop($new);
+                    // fall-through
                 case '.':
                     break;
                 default:
@@ -1042,6 +1043,7 @@ class SFTP extends SSH2
                 case 'mode':
                     $a[$sort] &= 07777;
                     $b[$sort] &= 07777;
+                    // fall-through
                 default:
                     if ($a[$sort] === $b[$sort]) {
                         break;

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1829,6 +1829,7 @@ class SSH2
                     $nonce = $kexHash->hash($keyBytes . $this->exchange_hash . 'A' . $this->session_id);
                     $this->encryptFixedPart = substr($nonce, 0, 4);
                     $this->encryptInvocationCounter = substr($nonce, 4, 8);
+                    // fall-through
                 case 'chacha20-poly1305@openssh.com':
                     break;
                 default:
@@ -1874,6 +1875,7 @@ class SSH2
                     $nonce = $kexHash->hash($keyBytes . $this->exchange_hash . 'B' . $this->session_id);
                     $this->decryptFixedPart = substr($nonce, 0, 4);
                     $this->decryptInvocationCounter = substr($nonce, 4, 8);
+                    // fall-through
                 case 'chacha20-poly1305@openssh.com':
                     break;
                 default:
@@ -2203,6 +2205,7 @@ class SSH2
                                     }
                                 }
                             }
+                            // fall-through
                         case 'password':
                             foreach ($args as $key => $arg) {
                                 $newargs[] = $arg;
@@ -2310,6 +2313,7 @@ class SSH2
                 case MessageType::USERAUTH_FAILURE:
                     list($auth_methods) = Strings::unpackSSH2('L', $response);
                     $this->auth_methods_to_continue = $auth_methods;
+                    // fall-through
                 default:
                     return false;
             }
@@ -3463,6 +3467,7 @@ class SSH2
                 if (!$this->isAuthenticated()) {
                     break;
                 }
+                // fall-through
             case self::NET_SSH2_COMPRESSION_ZLIB:
                 if ($this->regenerate_decompression_context) {
                     $this->regenerate_decompression_context = false;
@@ -4022,6 +4027,7 @@ class SSH2
                     if ($client_channel == $channel) {
                         return true;
                     }
+                    // fall-through
                 case MessageType::CHANNEL_EOF:
                     break;
                 default:
@@ -4058,6 +4064,7 @@ class SSH2
                 if (!$this->isAuthenticated()) {
                     break;
                 }
+                // fall-through
             case self::NET_SSH2_COMPRESSION_ZLIB:
                 if (!$this->regenerate_compression_context) {
                     $header = '';

--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Net\SFTP;
 
-class Functional_Net_SFTPLargeFileTest extends Functional_Net_SFTPTestCase
+class SFTPLargeFileTest extends SFTPTestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Functional/Net/SFTPStreamTest.php
+++ b/tests/Functional/Net/SFTPStreamTest.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Net\SFTP\Stream;
 
-class Functional_Net_SFTPStreamTest extends Functional_Net_SFTPTestCase
+class SFTPStreamTest extends SFTPTestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Functional/Net/SFTPTestCase.php
+++ b/tests/Functional/Net/SFTPTestCase.php
@@ -6,12 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Net\SFTP;
+use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
 /**
  * This class provides each test method with a new and empty $this->scratchDir.
  */
-abstract class Functional_Net_SFTPTestCase extends PhpseclibFunctionalTestCase
+abstract class SFTPTestCase extends PhpseclibFunctionalTestCase
 {
     /**
      * @var SFTP

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Net\SFTP;
 use phpseclib3\Net\SFTP\FileType;
+use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
-class Functional_Net_SFTPUserStoryTest extends PhpseclibFunctionalTestCase
+class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 {
     protected static $scratchDir;
     protected static $exampleData;

--- a/tests/Functional/Net/SFTPWrongServerTest.php
+++ b/tests/Functional/Net/SFTPWrongServerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Exception\UnableToConnectException;
 use phpseclib3\Net\SFTP;
 use PHPUnit\Framework\TestCase;

--- a/tests/Functional/Net/SSH2AgentTest.php
+++ b/tests/Functional/Net/SSH2AgentTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Functional\Net;
+
 use phpseclib3\Net\SSH2;
 use phpseclib3\System\SSH\Agent;
+use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
-class Functional_Net_SSH2AgentTest extends PhpseclibFunctionalTestCase
+class SSH2AgentTest extends PhpseclibFunctionalTestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Net\SSH2;
+namespace phpseclib3\Tests\Functional\Net;
 
-class Functional_Net_SSH2Test extends PhpseclibFunctionalTestCase
+use phpseclib3\Net\SSH2;
+use phpseclib3\Tests\PhpseclibFunctionalTestCase;
+
+class SSH2Test extends PhpseclibFunctionalTestCase
 {
     public function testConstructor()
     {

--- a/tests/PhpseclibFunctionalTestCase.php
+++ b/tests/PhpseclibFunctionalTestCase.php
@@ -6,6 +6,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests;
 
 abstract class PhpseclibFunctionalTestCase extends PhpseclibTestCase
 {

--- a/tests/PhpseclibTestCase.php
+++ b/tests/PhpseclibTestCase.php
@@ -6,7 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-abstract class PhpseclibTestCase extends PHPUnit\Framework\TestCase
+namespace phpseclib3\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class PhpseclibTestCase extends TestCase
 {
     protected $tempFilesToUnlinkOnTearDown = [];
 
@@ -105,7 +109,7 @@ abstract class PhpseclibTestCase extends PHPUnit\Framework\TestCase
 
     protected static function getVar($obj, $var)
     {
-        $reflection = new ReflectionClass(get_class($obj));
+        $reflection = new \ReflectionClass(get_class($obj));
         $prop = $reflection->getProperty($var);
         $prop->setAccessible(true);
         return $prop->getValue($obj);
@@ -113,7 +117,7 @@ abstract class PhpseclibTestCase extends PHPUnit\Framework\TestCase
 
     public static function callFunc($obj, $func, $params = [])
     {
-        $reflection = new ReflectionClass(get_class($obj));
+        $reflection = new \ReflectionClass(get_class($obj));
         $method = $reflection->getMethod($func);
         $method->setAccessible(true);
         return $method->invokeArgs($obj, $params);

--- a/tests/Unit/Crypt/AES/EvalTest.php
+++ b/tests/Unit/Crypt/AES/EvalTest.php
@@ -6,8 +6,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\AES;
 
-class Unit_Crypt_AES_EvalTest extends Unit_Crypt_AES_TestCase
+class EvalTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Unit/Crypt/AES/McryptTest.php
+++ b/tests/Unit/Crypt/AES/McryptTest.php
@@ -6,8 +6,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\AES;
 
-class Unit_Crypt_AES_McryptTest extends Unit_Crypt_AES_TestCase
+class McryptTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Unit/Crypt/AES/OpenSSLTest.php
+++ b/tests/Unit/Crypt/AES/OpenSSLTest.php
@@ -6,8 +6,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\AES;
 
-class Unit_Crypt_AES_OpenSSLTest extends Unit_Crypt_AES_TestCase
+class OpenSSLTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Unit/Crypt/AES/PurePHPTest.php
+++ b/tests/Unit/Crypt/AES/PurePHPTest.php
@@ -6,8 +6,9 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\AES;
 
-class Unit_Crypt_AES_PurePHPTest extends Unit_Crypt_AES_TestCase
+class PurePHPTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Unit/Crypt/AES/TestCase.php
+++ b/tests/Unit/Crypt/AES/TestCase.php
@@ -6,12 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\AES;
+
 use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\Rijndael;
 use phpseclib3\Exception\InconsistentSetupException;
 use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-abstract class Unit_Crypt_AES_TestCase extends PhpseclibTestCase
+abstract class TestCase extends PhpseclibTestCase
 {
     protected $engine;
 

--- a/tests/Unit/Crypt/BlowfishTest.php
+++ b/tests/Unit/Crypt/BlowfishTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt;
+
 use phpseclib3\Crypt\Blowfish;
 use phpseclib3\Crypt\Random;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_BlowfishTest extends PhpseclibTestCase
+class BlowfishTest extends PhpseclibTestCase
 {
     public function engineVectors()
     {

--- a/tests/Unit/Crypt/ChaCha20Test.php
+++ b/tests/Unit/Crypt/ChaCha20Test.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\ChaCha20;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_ChaCha20Test extends PhpseclibTestCase
+use phpseclib3\Crypt\ChaCha20;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class ChaCha20Test extends PhpseclibTestCase
 {
     // see https://tools.ietf.org/html/rfc8439#section-2.3.2
     public function test232()

--- a/tests/Unit/Crypt/DHTest.php
+++ b/tests/Unit/Crypt/DHTest.php
@@ -6,6 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt;
+
 use phpseclib3\Crypt\AES;
 use phpseclib3\Crypt\DH;
 use phpseclib3\Crypt\DH\Parameters;
@@ -13,8 +15,9 @@ use phpseclib3\Crypt\DH\PrivateKey;
 use phpseclib3\Crypt\DH\PublicKey;
 use phpseclib3\Crypt\EC;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_DHTest extends PhpseclibTestCase
+class DHTest extends PhpseclibTestCase
 {
     public function testParametersWithString()
     {

--- a/tests/Unit/Crypt/DSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/DSA/CreateKeyTest.php
@@ -6,15 +6,18 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\DSA;
+
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\DSA\Parameters;
 use phpseclib3\Crypt\DSA\PrivateKey;
 use phpseclib3\Crypt\DSA\PublicKey;
+use phpseclib3\Tests\PhpseclibTestCase;
 
 /**
  * @requires PHP 7.0
  */
-class Unit_Crypt_DSA_CreateKeyTestDSA extends PhpseclibTestCase
+class CreateKeyTest extends PhpseclibTestCase
 {
     public function testCreateParameters()
     {
@@ -24,8 +27,8 @@ class Unit_Crypt_DSA_CreateKeyTestDSA extends PhpseclibTestCase
 
         try {
             $dsa = DSA::createParameters(100, 100);
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(\Exception::class, $e);
         }
 
         $dsa = DSA::createParameters(512, 160);

--- a/tests/Unit/Crypt/DSA/LoadDSAKeyTest.php
+++ b/tests/Unit/Crypt/DSA/LoadDSAKeyTest.php
@@ -6,13 +6,16 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\DSA;
+
 use phpseclib3\Crypt\DSA\Parameters;
 use phpseclib3\Crypt\DSA\PrivateKey;
 use phpseclib3\Crypt\DSA\PublicKey;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Exception\NoKeyLoadedException;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_DSA_LoadDSAKeyTest extends PhpseclibTestCase
+class LoadDSAKeyTest extends PhpseclibTestCase
 {
     public function testBadKey()
     {

--- a/tests/Unit/Crypt/DSA/SignatureTest.php
+++ b/tests/Unit/Crypt/DSA/SignatureTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\DSA;
+
 use phpseclib3\Crypt\DSA;
 use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_DSA_SignatureTest extends PhpseclibTestCase
+class SignatureTest extends PhpseclibTestCase
 {
     public function testPKCSSignature()
     {

--- a/tests/Unit/Crypt/EC/CurveTest.php
+++ b/tests/Unit/Crypt/EC/CurveTest.php
@@ -6,46 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Common\Functions\Strings;
+namespace phpseclib3\Tests\Unit\Crypt\EC;
+
 use phpseclib3\Crypt\EC;
 use phpseclib3\Crypt\EC\Curves\Ed448;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\File\ASN1;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Ed448PublicKey
-{
-    use phpseclib3\Crypt\EC\Formats\Keys\Common;
-
-    public static function load($key, $password = '')
-    {
-        if (!Strings::is_stringable($key)) {
-            throw new \UnexpectedValueException('Key should be a string - not a ' . gettype($key));
-        }
-
-        $components = ['curve' => new Ed448()];
-        $components['QA'] = self::extractPoint($key, $components['curve']);
-
-        return $components;
-    }
-}
-
-class Ed448PrivateKey
-{
-    public static function load($key, $password = '')
-    {
-        if (!Strings::is_stringable($key)) {
-            throw new \UnexpectedValueException('Key should be a string - not a ' . gettype($key));
-        }
-
-        $components = ['curve' => new Ed448()];
-        $components['dA'] = $components['curve']->extractSecret($key);
-        $components['QA'] = $components['curve']->multiplyPoint($components['curve']->getBasePoint(), $components['dA']);
-
-        return $components;
-    }
-}
-
-class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
+class CurveTest extends PhpseclibTestCase
 {
     public function curves()
     {
@@ -88,7 +57,7 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
 
     public function curvesWithOIDs()
     {
-        $class = new ReflectionClass('phpseclib3\Crypt\EC\Formats\Keys\PKCS8');
+        $class = new \ReflectionClass('phpseclib3\Crypt\EC\Formats\Keys\PKCS8');
 
         $initialize = $class->getMethod('initialize_static_variables');
         $initialize->setAccessible(true);
@@ -231,8 +200,8 @@ class Unit_Crypt_EC_CurveTest extends PhpseclibTestCase
      */
     public function testEd448TestVectors()
     {
-        EC::addFileFormat('Ed448PublicKey');
-        EC::addFileFormat('Ed448PrivateKey');
+        EC::addFileFormat(Ed448PublicKey::class);
+        EC::addFileFormat(Ed448PrivateKey::class);
 
         $private = pack('H*', '6c82a562cb808d10d632be89c8513ebf6c929f34ddfa8c9f63c9960ef6e348a3528c8a3fcc2f044e39a3fc5b94492f8f032e7549a20098f95b');
         $public = pack('H*', '5fd7449b59b461fd2ce787ec616ad46a1da1342485a70e1f8a0ea75d80e96778edf124769b46c7061bd6783df1e50f6cd1fa1abeafe8256180');

--- a/tests/Unit/Crypt/EC/Ed448PrivateKey.php
+++ b/tests/Unit/Crypt/EC/Ed448PrivateKey.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace phpseclib3\Tests\Unit\Crypt\EC;
+
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+
+class Ed448PrivateKey
+{
+    public static function load($key, $password = '')
+    {
+        if (!Strings::is_stringable($key)) {
+            throw new \UnexpectedValueException('Key should be a string - not a ' . gettype($key));
+        }
+
+        $components = ['curve' => new Ed448()];
+        $components['dA'] = $components['curve']->extractSecret($key);
+        $components['QA'] = $components['curve']->multiplyPoint($components['curve']->getBasePoint(), $components['dA']);
+
+        return $components;
+    }
+}

--- a/tests/Unit/Crypt/EC/Ed448PublicKey.php
+++ b/tests/Unit/Crypt/EC/Ed448PublicKey.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace phpseclib3\Tests\Unit\Crypt\EC;
+
+use phpseclib3\Common\Functions\Strings;
+use phpseclib3\Crypt\EC\Curves\Ed448;
+use phpseclib3\Crypt\EC\Formats\Keys\Common;
+
+class Ed448PublicKey
+{
+    use Common;
+
+    public static function load($key, $password = '')
+    {
+        if (!Strings::is_stringable($key)) {
+            throw new \UnexpectedValueException('Key should be a string - not a ' . gettype($key));
+        }
+
+        $components = ['curve' => new Ed448()];
+        $components['QA'] = self::extractPoint($key, $components['curve']);
+
+        return $components;
+    }
+}

--- a/tests/Unit/Crypt/EC/KeyTest.php
+++ b/tests/Unit/Crypt/EC/KeyTest.php
@@ -6,6 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\EC;
+
 use phpseclib3\Crypt\EC;
 use phpseclib3\Crypt\EC\Formats\Keys\OpenSSH;
 use phpseclib3\Crypt\EC\Formats\Keys\PKCS1;
@@ -14,8 +16,9 @@ use phpseclib3\Crypt\EC\Formats\Keys\PuTTY;
 use phpseclib3\Crypt\EC\Formats\Keys\XML;
 use phpseclib3\Crypt\EC\PrivateKey;
 use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_EC_KeyTest extends PhpseclibTestCase
+class KeyTest extends PhpseclibTestCase
 {
     public function testBinaryPKCS1PrivateParameters()
     {
@@ -458,7 +461,7 @@ pomV7r6gmoMYteGVABfgAAAAD3ZhZ3JhbnRAdmFncmFudAECAwQFBg==
 
         XML::enableRFC4050Syntax();
 
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = false;
         $dom->loadXML($orig);
         $expected = $dom->C14N();

--- a/tests/Unit/Crypt/GCMTest.php
+++ b/tests/Unit/Crypt/GCMTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\AES;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_GCMTest extends PhpseclibTestCase
+use phpseclib3\Crypt\AES;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class GCMTest extends PhpseclibTestCase
 {
     /**
      * Produces all combinations of test values.

--- a/tests/Unit/Crypt/HashTest.php
+++ b/tests/Unit/Crypt/HashTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt;
+
 use phpseclib3\Crypt\Hash;
 use phpseclib3\Exception\UnsupportedAlgorithmException;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_HashTest extends PhpseclibTestCase
+class HashTest extends PhpseclibTestCase
 {
     protected function assertHashesTo($hash, $message, $expected)
     {

--- a/tests/Unit/Crypt/RC2Test.php
+++ b/tests/Unit/Crypt/RC2Test.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\RC2;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_RC2Test extends PhpseclibTestCase
+use phpseclib3\Crypt\RC2;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class RC2Test extends PhpseclibTestCase
 {
     public $engines = [
         'PHP',

--- a/tests/Unit/Crypt/RC4Test.php
+++ b/tests/Unit/Crypt/RC4Test.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt;
+
 use phpseclib3\Crypt\Random;
 use phpseclib3\Crypt\RC4;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_RC4Test extends PhpseclibTestCase
+class RC4Test extends PhpseclibTestCase
 {
     public function engineVectors()
     {

--- a/tests/Unit/Crypt/RSA/CreateKeyTest.php
+++ b/tests/Unit/Crypt/RSA/CreateKeyTest.php
@@ -6,13 +6,16 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\RSA;
+
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS1;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
 use phpseclib3\Crypt\RSA\PrivateKey;
 use phpseclib3\Crypt\RSA\PublicKey;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_RSA_CreateKeyTestRSA extends PhpseclibTestCase
+class CreateKeyTestRSA extends PhpseclibTestCase
 {
     public function testCreateKey()
     {

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -6,6 +6,8 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\RSA;
+
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\OpenSSH;
@@ -18,8 +20,9 @@ use phpseclib3\Crypt\RSA\PublicKey;
 use phpseclib3\Exception\NoKeyLoadedException;
 use phpseclib3\Exception\UnsupportedFormatException;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_RSA_LoadKeyTest extends PhpseclibTestCase
+class LoadKeyTest extends PhpseclibTestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -6,12 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Crypt\RSA;
+
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\Formats\Keys\PKCS8;
 use phpseclib3\Math\BigInteger;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Crypt_RSA_ModeTest extends PhpseclibTestCase
+class ModeTest extends PhpseclibTestCase
 {
     public function testEncryptionModeNone()
     {

--- a/tests/Unit/Crypt/RandomTest.php
+++ b/tests/Unit/Crypt/RandomTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Random;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_RandomTest extends PhpseclibTestCase
+use phpseclib3\Crypt\Random;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class RandomTest extends PhpseclibTestCase
 {
     public function stringLengthData()
     {

--- a/tests/Unit/Crypt/Salsa20Test.php
+++ b/tests/Unit/Crypt/Salsa20Test.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Salsa20;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_Salsa20Test extends PhpseclibTestCase
+use phpseclib3\Crypt\Salsa20;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class Salsa20Test extends PhpseclibTestCase
 {
     public function engineVectors()
     {

--- a/tests/Unit/Crypt/TripleDESTest.php
+++ b/tests/Unit/Crypt/TripleDESTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\TripleDES;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_TripleDESTest extends PhpseclibTestCase
+use phpseclib3\Crypt\TripleDES;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class TripleDESTest extends PhpseclibTestCase
 {
     public $engines = [
         'PHP',

--- a/tests/Unit/Crypt/TwofishTest.php
+++ b/tests/Unit/Crypt/TwofishTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Crypt\Twofish;
+namespace phpseclib3\Tests\Unit\Crypt;
 
-class Unit_Crypt_TwofishTest extends PhpseclibTestCase
+use phpseclib3\Crypt\Twofish;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class TwofishTest extends PhpseclibTestCase
 {
     public function testVectors()
     {

--- a/tests/Unit/File/ANSITest.php
+++ b/tests/Unit/File/ANSITest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\File\ANSI;
+namespace phpseclib3\Tests\Unit\File;
 
-class Unit_File_ANSITest extends PhpseclibTestCase
+use phpseclib3\File\ANSI;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class ANSITest extends PhpseclibTestCase
 {
     public function testCase1()
     {

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\File\ASN1;
+namespace phpseclib3\Tests\Unit\File;
 
-class Unit_File_ASN1Test extends PhpseclibTestCase
+use phpseclib3\File\ASN1;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class ASN1Test extends PhpseclibTestCase
 {
     /**
      * on older versions of \phpseclib3\File\ASN1 this would yield a PHP Warning

--- a/tests/Unit/File/X509/CRLTest.php
+++ b/tests/Unit/File/X509/CRLTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\File\X509;
+namespace phpseclib3\Tests\Unit\File\X509;
 
-class Unit_File_X509_CRLTest extends PhpseclibTestCase
+use phpseclib3\File\X509;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class CRLTest extends PhpseclibTestCase
 {
     public function testLoadCRL()
     {

--- a/tests/Unit/File/X509/CSRTest.php
+++ b/tests/Unit/File/X509/CSRTest.php
@@ -6,11 +6,14 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\File\X509;
+
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\File\X509;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_File_X509_CSRTest extends PhpseclibTestCase
+class CSRTest extends PhpseclibTestCase
 {
     public function testLoadCSR()
     {

--- a/tests/Unit/File/X509/SPKACTest.php
+++ b/tests/Unit/File/X509/SPKACTest.php
@@ -6,10 +6,13 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\File\X509;
+
 use phpseclib3\Crypt\RSA;
 use phpseclib3\File\X509;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_File_X509_SPKACTest extends PhpseclibTestCase
+class SPKACTest extends PhpseclibTestCase
 {
     public function testLoadSPKAC()
     {

--- a/tests/Unit/File/X509/X509ExtensionTest.php
+++ b/tests/Unit/File/X509/X509ExtensionTest.php
@@ -6,12 +6,15 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\File\X509;
+
 use phpseclib3\Crypt\EC;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\X509;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_File_X509_X509ExtensionTest extends PhpseclibTestCase
+class X509ExtensionTest extends PhpseclibTestCase
 {
     public function testCustomExtension()
     {

--- a/tests/Unit/File/X509/X509Test.php
+++ b/tests/Unit/File/X509/X509Test.php
@@ -6,13 +6,16 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\File\X509;
+
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\File\ASN1;
 use phpseclib3\File\ASN1\Element;
 use phpseclib3\File\X509;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_File_X509_X509Test extends PhpseclibTestCase
+class X509Test extends PhpseclibTestCase
 {
     public function testExtensionMapping()
     {

--- a/tests/Unit/Math/BigInteger/BCMathTest.php
+++ b/tests/Unit/Math/BigInteger/BCMathTest.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
 use phpseclib3\Math\BigInteger\Engines\BCMath;
 
-class Unit_Math_BigInteger_BCMathTest extends Unit_Math_BigInteger_TestCase
+class BCMathTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Math/BigInteger/DefaultTest.php
+++ b/tests/Unit/Math/BigInteger/DefaultTest.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
 use phpseclib3\Math\BigInteger;
 
-class Unit_Math_BigInteger_DefaultTest extends Unit_Math_BigInteger_TestCase
+class DefaultTest extends TestCase
 {
     public function getInstance($x = 0, $base = 10)
     {

--- a/tests/Unit/Math/BigInteger/GMPTest.php
+++ b/tests/Unit/Math/BigInteger/GMPTest.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
 use phpseclib3\Math\BigInteger\Engines\GMP;
 
-class Unit_Math_BigInteger_GMPTest extends Unit_Math_BigInteger_TestCase
+class GMPTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Math/BigInteger/PHP32Test.php
+++ b/tests/Unit/Math/BigInteger/PHP32Test.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
 use phpseclib3\Math\BigInteger\Engines\PHP32;
 
-class Unit_Math_BigInteger_PHP32Test extends Unit_Math_BigInteger_TestCase
+class PHP32Test extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
+++ b/tests/Unit/Math/BigInteger/PHP64OpenSSLTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
+use phpseclib3\Exception\BadConfigurationException;
 use phpseclib3\Math\BigInteger\Engines\PHP64;
 
-class Unit_Math_BigInteger_PHP64OpenSSLTest extends Unit_Math_BigInteger_TestCase
+class PHP64OpenSSLTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Math/BigInteger/PHP64Test.php
+++ b/tests/Unit/Math/BigInteger/PHP64Test.php
@@ -6,9 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
 use phpseclib3\Math\BigInteger\Engines\PHP64;
 
-class Unit_Math_BigInteger_PHP64Test extends Unit_Math_BigInteger_TestCase
+class PHP64Test extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -6,7 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-abstract class Unit_Math_BigInteger_TestCase extends PhpseclibTestCase
+namespace phpseclib3\Tests\Unit\Math\BigInteger;
+
+use phpseclib3\Tests\PhpseclibTestCase;
+
+abstract class TestCase extends PhpseclibTestCase
 {
     public function testConstructorBase2()
     {

--- a/tests/Unit/Math/BigIntegerTest.php
+++ b/tests/Unit/Math/BigIntegerTest.php
@@ -1,12 +1,15 @@
 <?php
 
+namespace phpseclib3\Tests\Unit\Math;
+
 use phpseclib3\Math\BigInteger;
 use phpseclib3\Math\BigInteger\Engines\BCMath;
 use phpseclib3\Math\BigInteger\Engines\GMP;
 use phpseclib3\Math\BigInteger\Engines\PHP32;
 use phpseclib3\Math\BigInteger\Engines\PHP64;
+use phpseclib3\Tests\PhpseclibTestCase;
 
-class Unit_Math_BigIntegerTest extends PhpseclibTestCase
+class BigIntegerTest extends PhpseclibTestCase
 {
     /**
      * @param string $className

--- a/tests/Unit/Net/SFTPStreamUnitTest.php
+++ b/tests/Unit/Net/SFTPStreamUnitTest.php
@@ -6,9 +6,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-use phpseclib3\Net\SFTP\Stream;
+namespace phpseclib3\Tests\Unit\Net;
 
-class Unit_Net_SFTPStreamUnitTest extends PhpseclibTestCase
+use phpseclib3\Net\SFTP\Stream;
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class SFTPStreamUnitTest extends PhpseclibTestCase
 {
     public function testRegisterWithoutArgument()
     {

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -6,7 +6,11 @@
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
-class Unit_Net_SSH2UnitTest extends PhpseclibTestCase
+namespace phpseclib3\Tests\Unit\Net;
+
+use phpseclib3\Tests\PhpseclibTestCase;
+
+class SSH2UnitTest extends PhpseclibTestCase
 {
     public function formatLogDataProvider()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,11 +10,13 @@ date_default_timezone_set('UTC');
 
 $loader_path = __DIR__ . '/../vendor/autoload.php';
 if (!file_exists($loader_path)) {
-    echo "Dependencies must be installed using composer:\n\n";
-    echo "php composer.phar install\n\n";
-    echo "See http://getcomposer.org for help with installing composer\n";
-    exit(1);
+    exit(<<<EOF
+Dependencies must be installed using composer:
+    php composer.phar install
+See https://getcomposer.org for help with installing composer.
+
+EOF
+    );
 }
 
-$loader = include $loader_path;
-$loader->add('', __DIR__);
+require $loader_path;


### PR DESCRIPTION
PSR4 for tests, single file per class, and fall-through comments in switches