### PR TITLE
Handle SSH servers that send success response out of spec order

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -4028,6 +4028,7 @@ class SSH2
                     }
                     // fall-through
                 case MessageType::CHANNEL_EOF:
+                case MessageType::CHANNEL_SUCCESS:
                     break;
                 default:
                     $this->disconnect_helper(DisconnectReason::BY_APPLICATION);


### PR DESCRIPTION
There are some Juniper switches that have a (maybe incorrect?) implementation of the SSH spec which send back a SUCCESS response at a time this lib does not expect it. This causes the lib to bail out immediately. This patch ensures that when this unexpected SSH response comes back, we just continue operations as usual.

Here's the last bit of the SSH debug output when this behavior was happening:

```
SSH Error: Error reading channel data (99)

-> NET_SSH2_MSG_REQUEST_FAILURE (since last: 0.0001, network: 0.0001s)
                                                 

<- NET_SSH2_MSG_CHANNEL_OPEN_CONFIRMATION (since last: 0.2641, network: 0s)
00000000  00:00:00:02:00:00:00:00:00:00:00:00:00:00:80:00  ................

-> NET_SSH2_MSG_CHANNEL_REQUEST (since last: 0.0001, network: 0s)
00000000  00:00:00:00:00:00:00:07:70:74:79:2d:72:65:71:01  ........pty-req.
00000010  00:00:00:05:76:74:31:30:30:00:00:03:e8:00:00:00  ....vt100.......
00000020  18:00:00:00:00:00:00:00:00:00:00:00:01:00        ..............

<- NET_SSH2_MSG_CHANNEL_SUCCESS (since last: 0.2727, network: 0s)
00000000  00:00:00:02                                      ....

-> NET_SSH2_MSG_CHANNEL_REQUEST (since last: 0.0001, network: 0s)
00000000  00:00:00:00:00:00:00:05:73:68:65:6c:6c:01        ........shell.

<- NET_SSH2_MSG_CHANNEL_WINDOW_ADJUST (since last: 0.2672, network: 0s)
00000000  00:00:00:02:00:20:00:00                          ..... ..

-> NET_SSH2_MSG_CHANNEL_DATA (since last: 0.0001, network: 0s)
00000000  00:00:00:00:00:00:00:09:0a:0a:0a:0a:0a:0a:0a:0a  ................
00000010  0a                                               .

<- NET_SSH2_MSG_CHANNEL_SUCCESS (since last: 0.0001, network: 0s)
00000000  00:00:00:02                                      ....

-> NET_SSH2_MSG_DISCONNECT (since last: 0, network: 0s)
00000000  00:00:00:0b:00:00:00:00:00:00:00:00              ............


#0 /var/www/html/vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php(3138): phpseclib3\Net\SSH2->get_channel_packet(2)
```