### PR TITLE
Detect if stream metadata has wrapper_type set for SFTP put() method

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1936,7 +1936,7 @@ class SFTP extends SSH2
             case is_resource($data):
                 $mode = $mode & ~self::SOURCE_LOCAL_FILE;
                 $info = stream_get_meta_data($data);
-                if ($info['wrapper_type'] == 'PHP' && $info['stream_type'] == 'Input') {
+                if (isset($info['wrapper_type']) && $info['wrapper_type'] == 'PHP' && $info['stream_type'] == 'Input') {
                     $fp = fopen('php://memory', 'w+');
                     stream_copy_to_stream($data, $fp);
                     rewind($fp);


### PR DESCRIPTION
For some kinds of streams, `stream_get_meta_data()` result doesn't have `wrapper_type` value.
Example, ZipArchive getStream method:
```php
$zip = new ZipArchive();
$zip->open('test.zip');
$stream = $zip->getStream('test.txt');
var_dump(stream_get_meta_data($stream));
```
The output:

> [
     "timed_out" => false,
     "blocked" => true,
     "eof" => false,
     "stream_type" => "zip",
     "mode" => "rb",
     "unread_bytes" => 0,
     "seekable" => false,
     "uri" => "test.txt",
   ]