### PR TITLE
get_sftp_packet: Do not bail on receiving spurious (empty) packets.

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3095,7 +3095,7 @@ class SFTP extends SSH2
                 }
                 $this->packet_type = false;
                 $this->packet_buffer = '';
-                return false;
+                return ($this->channel_close ? false : $this->get_sftp_packet($request_id));
             }
             $this->packet_buffer .= $temp;
         }
@@ -3117,9 +3117,12 @@ class SFTP extends SSH2
         while ($tempLength > 0) {
             $temp = $this->get_channel_packet(self::CHANNEL, true);
             if (is_bool($temp)) {
+                if ($this->channel_status[self::CHANNEL] === NET_SSH2_MSG_CHANNEL_CLOSE) {
+                    $this->channel_close = true;
+                }
                 $this->packet_type = false;
                 $this->packet_buffer = '';
-                return false;
+                return ($this->channel_close ? false : $this->get_sftp_packet($request_id));
             }
             $this->packet_buffer .= $temp;
             $tempLength -= strlen($temp);


### PR DESCRIPTION
Previously the function would return `false' on such a case, causing
the caller to abort on an UnexpectedValueException; but then the pre-
viously unreceived packet would arrive at further get_sftp_packet calls
which of course do not expect it, aborting again on a UnexpectedValue-
Exception and so on (basically the remaining of the session would be
broken).

The typical error messages in such a broken session look like this:
 1  Error:Expected NET_SFTP_HANDLE or NET_SFTP_STATUS. Got packet type:
 2  Error:Expected NET_SFTP_DATA or NET_SFTP_STATUS. Got packet type: 102
(etc.)