### PR TITLE
Prevent static call to non-static method error

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3714,7 +3714,7 @@ class X509
      * @param string $domain
      * @return array
      */
-    private function dnsName($domain)
+    private static function dnsName($domain)
     {
         return ['dNSName' => $domain];
     }


### PR DESCRIPTION
Starting from PHP 8.0 the following line will result in an error:
```
$altName = array_map(['\phpseclib3\File\X509', 'dnsName'], $subject->domains); 
```
The dnsName method is not static but called as a static one. This results in an error starting from PHP 8.0 (see https://www.php.net/manual/en/migration80.incompatible.php)

See issue #1805