### PR TITLE
Fix return type comment on Crypt/RSA::createKey()

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -286,7 +286,7 @@ abstract class RSA extends AsymmetricKey
      *
      * The public key can be extracted from the private key
      *
-     * @return RSA
+     * @return RSA\PrivateKey
      */
     public static function createKey(int $bits = 2048)
     {


### PR DESCRIPTION
Function returns a Crypt/RSA/PrivateKey and updating
the PHPDoc for it will help with static analysis.