### PR TITLE
make SSH2::exec behave as expected

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2623,7 +2623,7 @@ class SSH2
 
         $this->channel_status[self::CHANNEL_EXEC] = MessageType::CHANNEL_DATA;
 
-        if ($callback === false || $this->in_request_pty_exec) {
+        if ($callback === null || $this->in_request_pty_exec) {
             return true;
         }
 


### PR DESCRIPTION
SSH2::exec used to behave differently when `false` was given as callback, this has been changed in the method signature to be nullable but not reflected in the code.

We got a huge chunk of PHP code using phpseclib v2 and while we ported our code to phpseclib v3 we came across a few issues which one of them needs to be fixed upstream :-)

I hope that makes sense for you, I’d appreciate to have this merged and released quite soon.