### PR TITLE
Return false when attempting to delete a non-existent directory

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2663,6 +2663,9 @@ class SFTP extends SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        /**
+         * @var int $status
+         */
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
             $this->logError($response, $status);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -898,7 +898,7 @@ class SFTP extends SSH2
      * @return array|int|false array of files, integer status (if known) or false if something else is wrong
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function readlist(string $dir, bool $raw = true)
+    private function readlist(string $dir, bool $raw = true): array|int|false
     {
         if (!$this->precheck()) {
             return false;

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2331,7 +2331,7 @@ class SFTP extends SSH2
 
         // Normally $entries would have at least . and .. but it might not if the directories
         // permissions didn't allow reading. If this happens then default to an empty list of files.
-        if (($entries === false) || is_int($entries)) {
+        if ($entries === false || is_int($entries)) {
             $entries = [];
         }
 

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -621,9 +621,8 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      * @depends testRmDirScratchNonexistent
      * @group github706
      */
-    public function testDeleteEmptyDir($sftp)
+    public function testDeleteEmptyDir(SFTP $sftp)
     {
-        assert($sftp instanceof SFTP);
         $this->assertTrue(
             $sftp->mkdir(self::$scratchDir),
             'Failed asserting that scratch directory could ' .

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -16,6 +16,9 @@ use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
 class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 {
+    /**
+     * @var string
+     */
     protected static $scratchDir;
     protected static $exampleData;
     protected static $exampleDataLength;
@@ -620,6 +623,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testDeleteEmptyDir($sftp)
     {
+        assert($sftp instanceof SFTP);
         $this->assertTrue(
             $sftp->mkdir(self::$scratchDir),
             'Failed asserting that scratch directory could ' .

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -638,6 +638,11 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             $sftp->stat(self::$scratchDir),
             'Failed asserting that stat on a deleted directory returns false'
         );
+        $this->assertFalse(
+            $sftp->delete(self::$scratchDir),
+            'Failed asserting that non-existent directory could not ' .
+            'be deleted using recursive delete().'
+        );
 
         return $sftp;
     }


### PR DESCRIPTION
1) Add test assertion that delete on a non-existent directory returns false
2) Adjust testDeleteEmptyDir so that Psalm understands what `$sftp` is
3) Adjust real code so that SFTP `readList` can return a status (if it knows one) rather than always returning `false` when something unexpected happens. Enhance `delete_recursive` so that it detects `StatusCode::NO_SUCH_FILE` and explicitly returns `false` in that case. That will put back the previous behavior - a delete call on a non-existent folder returned `false`

Fixes issue #1847 