### PR TITLE
[3.0] Return false when attempting to delete a non-existent directory

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2990,6 +2990,9 @@ class SFTP extends SSH2
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        /**
+         * @var int $status
+         */
         list($status) = Strings::unpackSSH2('N', $response);
         if ($status != NET_SFTP_STATUS_OK) {
             $this->logError($response, $status);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -2602,7 +2602,7 @@ class SFTP extends SSH2
 
         // Normally $entries would have at least . and .. but it might not if the directories
         // permissions didn't allow reading. If this happens then default to an empty list of files.
-        if (($entries === false) || is_int($entries)) {
+        if ($entries === false || is_int($entries)) {
             $entries = [];
         }
 

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -618,9 +618,8 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      * @depends testRmDirScratchNonexistent
      * @group github706
      */
-    public function testDeleteEmptyDir($sftp)
+    public function testDeleteEmptyDir(SFTP $sftp)
     {
-        assert($sftp instanceof SFTP);
         $this->assertTrue(
             $sftp->mkdir(self::$scratchDir),
             'Failed asserting that scratch directory could ' .

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -13,6 +13,9 @@ use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
 class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
 {
+    /**
+     * @var string
+     */
     protected static $scratchDir;
     protected static $exampleData;
     protected static $exampleDataLength;
@@ -617,6 +620,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testDeleteEmptyDir($sftp)
     {
+        assert($sftp instanceof SFTP);
         $this->assertTrue(
             $sftp->mkdir(self::$scratchDir),
             'Failed asserting that scratch directory could ' .

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -635,6 +635,11 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             $sftp->stat(self::$scratchDir),
             'Failed asserting that stat on a deleted directory returns false'
         );
+        $this->assertFalse(
+            $sftp->delete(self::$scratchDir),
+            'Failed asserting that non-existent directory could not ' .
+            'be deleted using recursive delete().'
+        );
 
         return $sftp;
     }


### PR DESCRIPTION
Backport #1848 

Note: I did not backport the commit for "Declare return type of readlst" - I don't think that will work on PHP 5.6?