### PR TITLE
Fixing 'Undefined array key' E_WARNING

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -4331,7 +4331,7 @@ class SSH2
     function _send_channel_packet($client_channel, $data)
     {
         while (strlen($data)) {
-            if (!$this->window_size_client_to_server[$client_channel]) {
+            if (!isset($this->window_size_client_to_server[$client_channel])) {
                 $this->bitmap^= self::MASK_WINDOW_ADJUST;
                 // using an invalid channel will let the buffers be built up for the valid channels
                 $this->_get_channel_packet(-1);


### PR DESCRIPTION
Also fixing E_WARNING when try to access undefined array key in Version 2.0