### PR TITLE
Creation of dynamic property is deprecated

### DIFF
--- a/phpseclib/Crypt/Common/BlockCipher.php
+++ b/phpseclib/Crypt/Common/BlockCipher.php
@@ -23,4 +23,5 @@ namespace phpseclib3\Crypt\Common;
  */
 abstract class BlockCipher extends SymmetricKey
 {
+    public $mcrypt_polyfill_init;
 }


### PR DESCRIPTION
Without this change, with PHP 8.2 I have: `Deprecated functionality: Creation of dynamic property phpseclib3\Crypt\Blowfish::$mcrypt_polyfill_init is deprecated  in .../mcryptcompat/mcrypt.php on line 680` (with latest [mcryptcompat](https://github.com/phpseclib/mcrypt_compat) and OpenMage)