### PR TITLE
fix "Creating default object from empty value" error

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -519,7 +519,7 @@ class SFTP extends SSH2
             if (!$this->canonicalize_paths) {
                 throw $e;
             }
-            $this->$this->canonicalize_paths = false;
+            $this->canonicalize_paths = false;
             $this->reset_connection(DisconnectReason::CONNECTION_LOST);
         }
 


### PR DESCRIPTION
This seems like a typo that causes a "Creating default object from empty value" warning on my side, please let me know if anything is wrong