### PR TITLE
SSH2: Adding getter for timeout

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2375,6 +2375,16 @@ class SSH2
     }
 
     /**
+     * Return the currently configured timeout
+     *
+     * @return int
+     */
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    /**
      * Set Timeout
      *
      * $ssh->exec('ping 127.0.0.1'); on a Linux host will never return and will run indefinitely.  setTimeout() makes it so it'll timeout.

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -143,6 +143,16 @@ class SSH2UnitTest extends PhpseclibTestCase
         $this->assertSame('{' . spl_object_hash($ssh) . '}', $ssh->getResourceId());
     }
 
+    public function testGetTimeout(): void
+    {
+        $ssh = new SSH2('localhost');
+        $this->assertEquals(10, $ssh->getTimeout());
+        $ssh->setTimeout(0);
+        $this->assertEquals(0, $ssh->getTimeout());
+        $ssh->setTimeout(20);
+        $this->assertEquals(20, $ssh->getTimeout());
+    }
+
     /**
      */
     protected function createSSHMock(): SSH2


### PR DESCRIPTION
Just an added nicety for callers configuring timeouts, and allowing callers to respect default client timeout configuration without themselves hard-coding to the 10-second value presently applied on __construct().