### PR TITLE
(3.0 branch) update exception message

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -4266,7 +4266,8 @@ class SSH2
 
         if (strlen($packet) != $sent) {
             $this->bitmap = 0;
-            throw new \RuntimeException("Only $sent of " . strlen($packet) . " bytes were sent");
+            $message = $sent === false ? ('Unable to write ' . strlen($packet) . ' bytes') : ("Only $sent of " . strlen($packet) . " bytes were sent");
+            throw new \RuntimeException($message);
         }
     }
 


### PR DESCRIPTION
`fputs()` can return `int|false`.  if it fails and `$sent` is `false`, then our exception message looks a little confusing:

> Only   of XXX bytes were sent

This change updates the message to be more descriptive if the `fputs()` fails.

> Unable to write XXX bytes
