### PR TITLE
X509::getChain() should always return an array of X509 objects

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -1944,14 +1944,15 @@ class X509
      */
     public function getChain()
     {
-        $chain = [$this->currentCert];
-
         if (!is_array($this->currentCert) || !isset($this->currentCert['tbsCertificate'])) {
             return false;
         }
         if (empty($this->CAs)) {
-            return $chain;
+            return [(new X509())->loadX509($this->currentCert)];
         }
+        
+        $chain = [$this->currentCert];
+        
         while (true) {
             $currentCert = $chain[count($chain) - 1];
             for ($i = 0; $i < count($this->CAs); $i++) {


### PR DESCRIPTION
`X509::getChain()` is supposed to return the chain as an array of `X509` objects (see `X509.php:1977`). However, when the certificate has no CAs loaded, the function returns early (`X509.php:1953`) without converting the `currentCert` into X509.

As a result, the caller would always have to check like this:

```php
foreach ($cert->getChain() as $part) {
    if (is_array($part)) {
       $part = (new X509())->loadX509($part);
    }
    // Do something with $part
}
```

This PR fixes this bug, ensuring the returned array always consists of X509 objects.

