### PR TITLE
X509::getChain() should always return array of X509 objects

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -166,7 +166,7 @@ class X509
      *
      * @var array
      */
-    private $CAs;
+    private $CAs = [];
 
     /**
      * The currently loaded certificate
@@ -1948,9 +1948,6 @@ class X509
 
         if (!is_array($this->currentCert) || !isset($this->currentCert['tbsCertificate'])) {
             return false;
-        }
-        if (empty($this->CAs)) {
-            return $chain;
         }
         while (true) {
             $currentCert = $chain[count($chain) - 1];


### PR DESCRIPTION
`X509::getChain()` is supposed to return the chain as an array of `X509` objects (see `X509.php:1977`). However, when the certificate has no CAs loaded, the function would return early (`X509.php:1953`) without converting the `currentCert` into X509.

As a result, the caller would always have to check like this:

```php
foreach ($cert->getChain() as $part) {
    if (is_array($part)) {
       $x509 = new X509();
       $x509->loadX509($part);
       $part = $x509;
    }
    // Do something with $part as X509
}
```

This PR fixes this bug, ensuring the returned array always consists of X509 objects.