### PR TITLE
added ev subjects

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -312,6 +312,10 @@ class X509
                 'id-at-uniqueIdentifier' => '2.5.4.45',
                 'id-at-role' => '2.5.4.72',
                 'id-at-postalAddress' => '2.5.4.16',
+                'jurisdictionOfIncorporationCountryName' => '1.3.6.1.4.1.311.60.2.1.3',
+                'jurisdictionOfIncorporationStateOrProvinceName' => '1.3.6.1.4.1.311.60.2.1.2',
+                'jurisdictionLocalityName' => '1.3.6.1.4.1.311.60.2.1.1',
+                'id-at-businessCategory' => '2.5.4.15',
 
                 //'id-domainComponent' => '0.9.2342.19200300.100.1.25',
                 //'pkcs-9' => '1.2.840.113549.1.9',
@@ -1479,6 +1483,20 @@ class X509
     private function translateDNProp(string $propName)
     {
         switch (strtolower($propName)) {
+            case 'jurisdictionofincorporationcountryname':
+            case 'jurisdictioncountryname':
+            case 'jurisdictionc':
+                return 'jurisdictionOfIncorporationCountryName';
+            case 'jurisdictionofincorporationstateorprovincename':
+            case 'jurisdictionstateorprovincename':
+            case 'jurisdictionst':
+                return 'jurisdictionOfIncorporationStateOrProvinceName';
+            case 'jurisdictionlocalityname':
+            case 'jurisdictionl':
+                return 'jurisdictionLocalityName';
+            case 'id-at-businesscategory':
+            case 'businesscategory':
+                return 'id-at-businessCategory';
             case 'id-at-countryname':
             case 'countryname':
             case 'c':


### PR DESCRIPTION
Hey guys,

just added the following distinguished names:
- "jurisdictionOfIncorporationCountryName"
- "jurisdictionOfIncorporationStateOrProvinceName"
- "jurisdictionLocalityName"
- "businessCategory"

they are being used in extended validation certificates. it will be very nice if they are going to be added to phpseclib for creating certificates with such dns. 

For more information see:
- https://en.wikipedia.org/wiki/Extended_Validation_Certificate
- https://www.digicert.com/content/dam/digicert/pdfs/legal/digicert-ev-cps-1.0.1.pdf (Page 49 and 50)

Thanks, 
Tobias