### PR TITLE
Fix E_DEPRECATED in PHP 8.2 because of creation of a dynamic property (in 2.0)

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -456,6 +456,14 @@ abstract class Base
     var $skip_key_adjustment = false;
 
     /**
+     * Name of the algorithm
+     *
+     * @var string
+     * @access public
+     */
+    var $name = "";
+
+    /**
      * Default Constructor.
      *
      * Determines whether or not the mcrypt extension should be used.

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -149,6 +149,14 @@ class Hash
     var $engine;
 
     /**
+     * Name of the algorithm
+     *
+     * @var string
+     * @access public
+     */
+    var $name = "";
+
+    /**
      * Default Constructor.
      *
      * @param string $hash


### PR DESCRIPTION
This commit just adds a "$name" property to the Crypto/Base and Crypto/Hash classes to prevent a E_DEPRECATED error in Net/SSH2 which uses this property.