### PR TITLE
Add EOF test to SSH2::isConnected

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2969,7 +2969,7 @@ class SSH2
      */
     public function isConnected(): bool
     {
-        return (bool) ($this->bitmap & self::MASK_CONNECTED);
+        return (bool) ($this->bitmap & self::MASK_CONNECTED) && is_resource($this->fsock) && !feof($this->fsock);
     }
 
     /**


### PR DESCRIPTION
I'm not sure if you're interested in merging this, but I think it makes sense to add this. In my opinion, this would make the behavior from `SSH2::isConnected` more intuitive to use.

This simply adds an EOF test against the internal socket. Happy to make any desired changes, also fine if you don't think it belongs. After some initial testing, I can also work around the issue of #1923 at the application level.

Relates to undesired behavior observed in #1923.