### PR TITLE
Fix Undefined index jit notice

### DIFF
--- a/phpseclib/bootstrap.php
+++ b/phpseclib/bootstrap.php
@@ -24,7 +24,7 @@ if (extension_loaded('mbstring')) {
 // see https://github.com/php/php-src/issues/11917
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && function_exists('opcache_get_status') && !defined('PHPSECLIB_ALLOW_JIT')) {
     $status = opcache_get_status();
-    if ($status && $status['jit']['enabled'] && $status['jit']['on']) {
+    if ($status && isset($status['jit']) && $status['jit']['enabled'] && $status['jit']['on']) {
         throw new UnexpectedValueException(
             'JIT on Windows is not currently supported'
         );


### PR DESCRIPTION
If "jit" is not defined in $status array, it generates an "Undefined index: jit" notice.