### PR TITLE
Move JIT check to BigInteger

### DIFF
--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -136,16 +136,6 @@ class BigInteger implements \JsonSerializable
     private static function initialize_static_variables()
     {
         if (!isset(self::$mainEngine)) {
-            // see https://github.com/php/php-src/issues/11917
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && function_exists('opcache_get_status') && !defined('PHPSECLIB_ALLOW_JIT')) {
-                $status = opcache_get_status();
-                if ($status && isset($status['jit']) && $status['jit']['enabled'] && $status['jit']['on']) {
-                    throw new UnexpectedValueException(
-                        'JIT on Windows is not currently supported'
-                    );
-                }
-            }
-
             $engines = [
                 ['GMP', ['DefaultEngine']],
                 ['PHP64', ['OpenSSL']],
@@ -154,13 +144,16 @@ class BigInteger implements \JsonSerializable
                 ['PHP64', ['DefaultEngine']],
                 ['PHP32', ['DefaultEngine']]
             ];
+
             foreach ($engines as $engine) {
                 try {
                     self::setEngine($engine[0], $engine[1]);
-                    break;
+                    return;
                 } catch (\Exception $e) {
                 }
             }
+
+            throw new UnexpectedValueException('No valid BigInteger found. This is only possible when JIT is enabled on Windows and neither the GMP or BCMath extensions are available so either disable JIT or install GMP / BCMath');
         }
     }
 

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -29,6 +29,7 @@ namespace phpseclib3\Math;
 
 use phpseclib3\Exception\BadConfigurationException;
 use phpseclib3\Math\BigInteger\Engines\Engine;
+use UnexpectedValueException;
 
 /**
  * Pure-PHP arbitrary precision integer arithmetic library. Supports base-2, base-10, base-16, and base-256
@@ -135,6 +136,16 @@ class BigInteger implements \JsonSerializable
     private static function initialize_static_variables()
     {
         if (!isset(self::$mainEngine)) {
+            // see https://github.com/php/php-src/issues/11917
+            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && function_exists('opcache_get_status') && !defined('PHPSECLIB_ALLOW_JIT')) {
+                $status = opcache_get_status();
+                if ($status && isset($status['jit']) && $status['jit']['enabled'] && $status['jit']['on']) {
+                    throw new UnexpectedValueException(
+                        'JIT on Windows is not currently supported'
+                    );
+                }
+            }
+
             $engines = [
                 ['GMP', ['DefaultEngine']],
                 ['PHP64', ['OpenSSL']],

--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -1326,4 +1326,18 @@ abstract class PHP extends Engine
 
         return array_reverse($vals);
     }
+
+    /**
+     * @return bool
+     */
+    protected static function testJITOnWindows()
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && function_exists('opcache_get_status') && !defined('PHPSECLIB_ALLOW_JIT')) {
+            $status = opcache_get_status();
+            if ($status && isset($status['jit']) && $status['jit']['enabled'] && $status['jit']['on']) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/phpseclib/Math/BigInteger/Engines/PHP32.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP32.php
@@ -102,7 +102,7 @@ class PHP32 extends PHP
      */
     public static function isValidEngine()
     {
-        return PHP_INT_SIZE >= 4;
+        return PHP_INT_SIZE >= 4 && !self::testJITOnWindows();
     }
 
     /**

--- a/phpseclib/Math/BigInteger/Engines/PHP64.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP64.php
@@ -103,7 +103,7 @@ class PHP64 extends PHP
      */
     public static function isValidEngine()
     {
-        return PHP_INT_SIZE >= 8;
+        return PHP_INT_SIZE >= 8 && !self::testJITOnWindows();
     }
 
     /**

--- a/phpseclib/bootstrap.php
+++ b/phpseclib/bootstrap.php
@@ -20,13 +20,3 @@ if (extension_loaded('mbstring')) {
         );
     }
 }
-
-// see https://github.com/php/php-src/issues/11917
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && function_exists('opcache_get_status') && !defined('PHPSECLIB_ALLOW_JIT')) {
-    $status = opcache_get_status();
-    if ($status && isset($status['jit']) && $status['jit']['enabled'] && $status['jit']['on']) {
-        throw new UnexpectedValueException(
-            'JIT on Windows is not currently supported'
-        );
-    }
-}


### PR DESCRIPTION
This fixes static analysis with Psalm v5 (which enables JIT by default) of projects which require phpseclib as a dependency.