### PR TITLE
Update Base.php

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -514,11 +514,11 @@ abstract class Base
             switch (true) {
                 // PHP_OS & "\xDF\xDF\xDF" == strtoupper(substr(PHP_OS, 0, 3)), but a lot faster
                 case (PHP_OS & "\xDF\xDF\xDF") === 'WIN':
-                case (php_uname('m') & "\xDF\xDF\xDF") != 'ARM':
+                case (php_uname('m') != null && php_uname('m') & "\xDF\xDF\xDF") != 'ARM':
                 case PHP_INT_SIZE == 8:
                     define('CRYPT_BASE_USE_REG_INTVAL', true);
                     break;
-                case (php_uname('m') & "\xDF\xDF\xDF") == 'ARM':
+                case (PHP_OS == "Linux" || php_uname('m') & "\xDF\xDF\xDF") == 'ARM':
                     switch (true) {
                         /* PHP 7.0.0 introduced a bug that affected 32-bit ARM processors:
 


### PR DESCRIPTION
At some hosting providers php_uname('m') function returns NULL which causes fatal php error preventing further execution (the bit with `php_uname('m') & "\xDF\xDF\xDF"`).

Applied a fix that would use PHP_OS const in such cases instead.