### PR TITLE
Undefined php_uname function due to hosting restriction

### DIFF
--- a/phpseclib/Crypt/Base.php
+++ b/phpseclib/Crypt/Base.php
@@ -514,7 +514,7 @@ abstract class Base
             switch (true) {
                 // PHP_OS & "\xDF\xDF\xDF" == strtoupper(substr(PHP_OS, 0, 3)), but a lot faster
                 case (PHP_OS & "\xDF\xDF\xDF") === 'WIN':
-                case !(is_string(php_uname('m')) && (php_uname('m') & "\xDF\xDF\xDF") == 'ARM'):
+                case !(function_exists('php_uname') && is_string(php_uname('m')) && (php_uname('m') & "\xDF\xDF\xDF") == 'ARM'):
                 case PHP_INT_SIZE == 8:
                     define('CRYPT_BASE_USE_REG_INTVAL', true);
                     break;

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -866,7 +866,7 @@ class Hash
             $result+= $argument < 0 ? ($argument & 0x7FFFFFFF) + 0x80000000 : $argument;
         }
 
-        if (function_exists('php_uname') && (php_uname('m') & "\xDF\xDF\xDF") != 'ARM') {
+        if (function_exists('php_uname') && is_string(php_uname('m')) && (php_uname('m') & "\xDF\xDF\xDF") != 'ARM') {
             return fmod($result, $mod);
         }
 

--- a/phpseclib/Crypt/Hash.php
+++ b/phpseclib/Crypt/Hash.php
@@ -866,7 +866,7 @@ class Hash
             $result+= $argument < 0 ? ($argument & 0x7FFFFFFF) + 0x80000000 : $argument;
         }
 
-        if ((php_uname('m') & "\xDF\xDF\xDF") != 'ARM') {
+        if (function_exists('php_uname') && (php_uname('m') & "\xDF\xDF\xDF") != 'ARM') {
             return fmod($result, $mod);
         }
 


### PR DESCRIPTION
For security reasons, it appears that some hosting providers have decided to disable `php_uname` function, unfortunately this has led to a PHP fatal error when the function gets called without first checking its existence. We'd like to propose changes in the `/Crypt/Base.php` and `Crypt/Hash.php` which is to use `function_exists()` to check the `php_uname` existence.