### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -282,7 +282,7 @@ abstract class AsymmetricKey
      *
      * @param string|null $method optional
      */
-    protected static function validatePlugin(string $format, string $type, string $method = null)
+    protected static function validatePlugin(string $format, string $type, ?string $method = null)
     {
         $type = strtolower($type);
         if (!isset(self::$plugins[static::ALGORITHM][$format][$type])) {

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
@@ -506,7 +506,7 @@ abstract class PKCS8 extends PKCS
      * @param string $publicKey optional
      * @param array $options optional
      */
-    protected static function wrapPrivateKey(string $key, $attr, $params, $password, string $oid = null, string $publicKey = '', array $options = []): string
+    protected static function wrapPrivateKey(string $key, $attr, $params, $password, ?string $oid = null, string $publicKey = '', array $options = []): string
     {
         self::initialize_static_variables();
 
@@ -610,7 +610,7 @@ abstract class PKCS8 extends PKCS
     /**
      * Wrap a public key appropriately
      */
-    protected static function wrapPublicKey(string $key, $params, string $oid = null): string
+    protected static function wrapPublicKey(string $key, $params, ?string $oid = null): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/phpseclib/Crypt/Common/SymmetricKey.php
@@ -614,7 +614,7 @@ abstract class SymmetricKey
      * @throws LengthException if the key isn't long enough
      * @throws BadMethodCallException if Poly1305 is enabled whilst in GCM mode
      */
-    public function setPoly1305Key(string $key = null): void
+    public function setPoly1305Key(?string $key = null): void
     {
         if ($this->mode == self::MODE_GCM) {
             throw new BadMethodCallException('Poly1305 cannot be used in GCM mode');

--- a/phpseclib/Crypt/EC.php
+++ b/phpseclib/Crypt/EC.php
@@ -407,7 +407,7 @@ abstract class EC extends AsymmetricKey
      * @see self::verify()
           * @see self::sign()
      */
-    public function withContext(string $context = null): EC
+    public function withContext(?string $context = null): EC
     {
         if (!$this->curve instanceof TwistedEdwardsCurve) {
             throw new UnsupportedCurveException('Only Ed25519 and Ed448 support contexts');

--- a/phpseclib/Crypt/EC/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/XML.php
@@ -115,7 +115,7 @@ abstract class XML
      * @param bool $decode optional
      * @return \DOMNodeList|string
      */
-    private static function query(\DOMXPath $xpath, string $name, string $error = null, bool $decode = true)
+    private static function query(\DOMXPath $xpath, string $name, ?string $error = null, bool $decode = true)
     {
         $query = '/';
         $names = explode('/', $name);

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -1641,7 +1641,7 @@ class X509
     /**
      * Get Distinguished Name properties
      */
-    public function getDNProp(string $propName, array $dn = null, bool $withType = false)
+    public function getDNProp(string $propName, ?array $dn = null, bool $withType = false)
     {
         if (!isset($dn)) {
             $dn = $this->dn;
@@ -1744,7 +1744,7 @@ class X509
      * @param array|null $dn optional
      * @return array|bool|string
      */
-    public function getDN($format = self::DN_ARRAY, array $dn = null)
+    public function getDN($format = self::DN_ARRAY, ?array $dn = null)
     {
         if (!isset($dn)) {
             $dn = isset($this->currentCert['tbsCertList']) ? $this->currentCert['tbsCertList']['issuer'] : $this->dn;
@@ -3074,7 +3074,7 @@ class X509
      * @param bool $create optional
      * @return array|false
      */
-    private function &extensions(?array &$root, string $path = null, bool $create = false)
+    private function &extensions(?array &$root, ?string $path = null, bool $create = false)
     {
         if (!isset($root)) {
             $root = $this->currentCert;
@@ -3125,7 +3125,7 @@ class X509
      *
      * @param string|null $path optional
      */
-    private function removeExtensionHelper(string $id, string $path = null): bool
+    private function removeExtensionHelper(string $id, ?string $path = null): bool
     {
         $extensions = &$this->extensions($this->currentCert, $path);
 
@@ -3157,7 +3157,7 @@ class X509
      * @param array|null $cert optional
      * @param string|null $path optional
      */
-    private function getExtensionHelper(string $id, array $cert = null, string $path = null)
+    private function getExtensionHelper(string $id, ?array $cert = null, ?string $path = null)
     {
         $extensions = $this->extensions($cert, $path);
 
@@ -3180,7 +3180,7 @@ class X509
      * @param array|null $cert optional
      * @param string|null $path optional
      */
-    private function getExtensionsHelper(array $cert = null, string $path = null): array
+    private function getExtensionsHelper(?array $cert = null, ?string $path = null): array
     {
         $exts = $this->extensions($cert, $path);
         $extensions = [];
@@ -3201,7 +3201,7 @@ class X509
      * @param bool $replace optional
      * @param string|null $path optional
      */
-    private function setExtensionHelper(string $id, $value, bool $critical = false, bool $replace = true, string $path = null): bool
+    private function setExtensionHelper(string $id, $value, bool $critical = false, bool $replace = true, ?string $path = null): bool
     {
         $extensions = &$this->extensions($this->currentCert, $path, true);
 
@@ -3241,7 +3241,7 @@ class X509
      *
      * @param array|null $cert optional
      */
-    public function getExtension(string $id, array $cert = null, string $path = null)
+    public function getExtension(string $id, ?array $cert = null, ?string $path = null)
     {
         return $this->getExtensionHelper($id, $cert, $path);
     }
@@ -3252,7 +3252,7 @@ class X509
      * @param array|null $cert optional
      * @param string|null $path optional
      */
-    public function getExtensions(array $cert = null, string $path = null): array
+    public function getExtensions(?array $cert = null, ?string $path = null): array
     {
         return $this->getExtensionsHelper($cert, $path);
     }
@@ -3321,7 +3321,7 @@ class X509
      * @param int $disposition optional
      * @param array|null $csr optional
      */
-    public function getAttribute(string $id, int $disposition = self::ATTR_ALL, array $csr = null)
+    public function getAttribute(string $id, int $disposition = self::ATTR_ALL, ?array $csr = null)
     {
         if (empty($csr)) {
             $csr = $this->currentCert;
@@ -3359,7 +3359,7 @@ class X509
      *
      * @param array|null $csr optional
      */
-    public function getAttributes(array $csr = null): array
+    public function getAttributes(?array $csr = null): array
     {
         if (empty($csr)) {
             $csr = $this->currentCert;
@@ -3627,7 +3627,7 @@ class X509
      *
      * @param string|null $date optional
      */
-    public function revoke(string $serial, string $date = null): bool
+    public function revoke(string $serial, ?string $date = null): bool
     {
         if (isset($this->currentCert['tbsCertList'])) {
             if (is_array($rclist = &$this->subArray($this->currentCert, 'tbsCertList/revokedCertificates', true))) {
@@ -3682,7 +3682,7 @@ class X509
      * @param array|null $crl optional
      * @return array|bool
      */
-    public function listRevoked(array $crl = null)
+    public function listRevoked(?array $crl = null)
     {
         if (!isset($crl)) {
             $crl = $this->currentCert;
@@ -3724,7 +3724,7 @@ class X509
      *
      * @param array|null $crl optional
      */
-    public function getRevokedCertificateExtension(string $serial, string $id, array $crl = null)
+    public function getRevokedCertificateExtension(string $serial, string $id, ?array $crl = null)
     {
         if (!isset($crl)) {
             $crl = $this->currentCert;
@@ -3745,7 +3745,7 @@ class X509
      * @param array|null $crl optional
      * @return array|bool
      */
-    public function getRevokedCertificateExtensions(string $serial, array $crl = null)
+    public function getRevokedCertificateExtensions(string $serial, ?array $crl = null)
     {
         if (!isset($crl)) {
             $crl = $this->currentCert;

--- a/phpseclib/Math/BinaryField.php
+++ b/phpseclib/Math/BinaryField.php
@@ -162,7 +162,7 @@ class BinaryField extends FiniteField
     /**
      * Converts a base-2 string to a base-256 string
      */
-    public static function base2ToBase256(string $x, int $size = null): string
+    public static function base2ToBase256(string $x, ?int $size = null): string
     {
         $str = Strings::bits2bin($x);
 

--- a/phpseclib/Math/PrimeField/Integer.php
+++ b/phpseclib/Math/PrimeField/Integer.php
@@ -64,7 +64,7 @@ class Integer extends Base
     /**
      * Default constructor
      */
-    public function __construct(int $instanceID, BigInteger $num = null)
+    public function __construct(int $instanceID, ?BigInteger $num = null)
     {
         $this->instanceID = $instanceID;
         if (!isset($num)) {

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -1296,7 +1296,7 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function touch(string $filename, int $time = null, int $atime = null): bool
+    public function touch(string $filename, ?int $time = null, ?int $atime = null): bool
     {
         if (!$this->precheck()) {
             return false;
@@ -1813,7 +1813,7 @@ class SFTP extends SSH2
      * @throws BadFunctionCallException if you're uploading via a callback and the callback function is invalid
      * @throws FileNotFoundException if you're uploading via a file and the file doesn't exist
      */
-    public function put(string $remote_file, $data, int $mode = self::SOURCE_STRING, int $start = -1, int $local_start = -1, callable $progressCallback = null): bool
+    public function put(string $remote_file, $data, int $mode = self::SOURCE_STRING, int $start = -1, int $local_start = -1, ?callable $progressCallback = null): bool
     {
         if (!$this->precheck()) {
             return false;
@@ -2060,7 +2060,7 @@ class SFTP extends SSH2
      * @return string|bool
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function get(string $remote_file, $local_file = false, int $offset = 0, int $length = -1, callable $progressCallback = null)
+    public function get(string $remote_file, $local_file = false, int $offset = 0, int $length = -1, ?callable $progressCallback = null)
     {
         if (!$this->precheck()) {
             return false;

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2526,7 +2526,7 @@ class SSH2
      * @psalm-return ($callback is callable ? bool : string|bool)
      * @throws RuntimeException on connection error
      */
-    public function exec(string $command, callable $callback = null)
+    public function exec(string $command, ?callable $callback = null)
     {
         $this->curTimeout = $this->timeout;
         $this->is_timeout = false;
@@ -2833,7 +2833,7 @@ class SSH2
      * @throws InsufficientSetupException on unexpected channel status, possibly due to closure
      * @see self::write()
      */
-    public function read(string $expect = '', int $mode = self::READ_SIMPLE, int $channel = null)
+    public function read(string $expect = '', int $mode = self::READ_SIMPLE, ?int $channel = null)
     {
         if (!$this->isAuthenticated()) {
             throw new InsufficientSetupException('Operation disallowed prior to login()');
@@ -2892,7 +2892,7 @@ class SSH2
      * @throws InsufficientSetupException on unexpected channel status, possibly due to closure
      * @see SSH2::read()
      */
-    public function write(string $cmd, int $channel = null): void
+    public function write(string $cmd, ?int $channel = null): void
     {
         if (!$this->isAuthenticated()) {
             throw new InsufficientSetupException('Operation disallowed prior to login()');
@@ -2977,7 +2977,7 @@ class SSH2
      *
      * @param int|null $channel Channel id returned by self::getInteractiveChannelId()
      */
-    public function reset(int $channel = null): void
+    public function reset(?int $channel = null): void
     {
         if ($channel === null) {
             $channel = $this->get_interactive_channel();
@@ -3931,7 +3931,7 @@ class SSH2
      *
      * @see self::_get_binary_packet()
      */
-    protected function send_binary_packet(string $data, string $logged = null): void
+    protected function send_binary_packet(string $data, ?string $logged = null): void
     {
         if (!is_resource($this->fsock) || feof($this->fsock)) {
             $this->bitmap = 0;

--- a/tests/PhpseclibFunctionalTestCase.php
+++ b/tests/PhpseclibFunctionalTestCase.php
@@ -15,7 +15,7 @@ abstract class PhpseclibFunctionalTestCase extends PhpseclibTestCase
     /**
      * @return null
      */
-    protected function requireEnv(string $variable, string $message = null)
+    protected function requireEnv(string $variable, ?string $message = null)
     {
         if ($this->_getEnv($variable) === false) {
             $msg = $message ? $message : sprintf(


### PR DESCRIPTION
Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)