### PR TITLE
Agent: reset supported_private_key_algorithms for every key

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2335,10 +2335,12 @@ class SSH2
     {
         $this->agent = $agent;
         $keys = $agent->requestIdentities();
+        $orig_algorithms = $this->supported_private_key_algorithms;
         foreach ($keys as $key) {
             if ($this->privatekey_login($username, $key)) {
                 return true;
             }
+            $this->supported_private_key_algorithms = $orig_algorithms;
         }
 
         return false;


### PR DESCRIPTION
Hi, I think I found a bug in the agent login.

I have ssh-agent with 3 certificates loaded. I'm able to log in to my server with a classic ssh client but not with Agent from this library. I figured out that the problem is after the first key is not accepted (if it is not accepted), in the `supported_private_key_algorithms` property are ommited `rsa-sha2-256` and `rsa-sha2-512` algorithms and only `ssh-rsa` is kept. But `ssh-rsa` is disabled by default in my `sshd` and then the second and next keys are tried only with `ssh-rsa` which is declined by `sshd`.

I think every key from the agent should start with all algorithms in the `supported_private_key_algorithms` property. I'm not an expert in this nor in this library - I prepare a simple fix that works for me. But I suppose that the correct solution will be different :-)