### PR TITLE
Allow paragonie/constant_time_encoding version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "paragonie/constant_time_encoding": "^2"
+        "paragonie/constant_time_encoding": "^2|^3"
     },
     "require-dev": {
         "ext-xml": "*",


### PR DESCRIPTION
[Supports PHP 8.4 without deprecation warnings for implicit null](https://github.com/paragonie/constant_time_encoding/releases/tag/v3.0.0)