### PR TITLE
SSH2: Reorganize get_binary_packet to fetch entire packet before processing

### DIFF
--- a/phpseclib/Exception/InvalidPacketLengthException.php
+++ b/phpseclib/Exception/InvalidPacketLengthException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpseclib3\Exception;
+
+/**
+ * Indicates an absent or malformed packet length header
+ */
+class InvalidPacketLengthException extends ConnectionClosedException
+{
+}

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -503,7 +503,7 @@ class SFTP extends SSH2
                 throw $e;
             }
             $this->canonicalize_paths = false;
-            $this->reset_connection(DisconnectReason::CONNECTION_LOST);
+            $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
         }
 
         $this->update_stat_cache($this->pwd, []);
@@ -2910,9 +2910,9 @@ class SFTP extends SSH2
     /**
      * Resets a connection for re-use
      */
-    protected function reset_connection(int $reason): void
+    protected function reset_connection(): void
     {
-        parent::reset_connection($reason);
+        parent::reset_connection();
         $this->use_request_id = false;
         $this->pwd = false;
         $this->requestBuffer = [];

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1919,10 +1919,8 @@ class SSH2
      *
      * @link https://www.chiark.greenend.org.uk/~sgtatham/putty/wishlist/ssh2-aesctr-openssh.html
      * @link https://bugzilla.mindrot.org/show_bug.cgi?id=1291
-     * @param string $algorithm Name of the encryption algorithm
-     * @return bool
      */
-    private static function bad_algorithm_candidate($algorithm): bool
+    private static function bad_algorithm_candidate(string $algorithm): bool
     {
         switch ($algorithm) {
             case 'arcfour256':
@@ -3039,9 +3037,6 @@ class SSH2
      * 2: phpseclib takes an active approach to see if the connection is still active by sending an SSH_MSG_CHANNEL_OPEN
      *    packet and imediately trying to close that channel. some routers, in particular, however, will only let you
      *    open one channel, so this approach could yield false positives
-     *
-     * @param int $level
-     * @return bool
      */
     public function isConnected(int $level = 0): bool
     {
@@ -3229,7 +3224,7 @@ class SSH2
             }
             $this->send_keep_alive();
 
-            list($sec, $usec) = $this->get_stream_timeout();
+            [$sec, $usec] = $this->get_stream_timeout();
             stream_set_timeout($this->fsock, $sec, $usec);
             $start = microtime(true);
             $raw = stream_get_contents($this->fsock, $packet->size - strlen($packet->raw));
@@ -4050,7 +4045,7 @@ class SSH2
     /**
      * Sends a keep-alive message, if keep-alive is enabled and interval is met
      */
-    private function send_keep_alive()
+    private function send_keep_alive(): void
     {
         $elapsed = microtime(true) - $this->keep_alive_sent;
         if ($this->keepAlive > 0 && $elapsed >= $this->keepAlive) {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -66,6 +66,7 @@ use phpseclib3\Crypt\Twofish;
 use phpseclib3\Exception\ConnectionClosedException;
 use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Exception\InvalidArgumentException;
+use phpseclib3\Exception\InvalidPacketLengthException;
 use phpseclib3\Exception\LengthException;
 use phpseclib3\Exception\LogicException;
 use phpseclib3\Exception\NoSupportedAlgorithmsException;
@@ -675,6 +676,13 @@ class SSH2
     private int|null $keepAlive = null;
 
     /**
+     * Timestamp for the last sent keep alive message
+     *
+     * @see self::send_keep_alive()
+     */
+    private float|null $keep_alive_sent = null;
+
+    /**
      * Real-time log file pointer
      *
      * @see self::_append_log()
@@ -863,7 +871,7 @@ class SSH2
     /**
      * Binary Packet Buffer
      */
-    private string|false $binary_packet_buffer = false;
+    private object|null $binary_packet_buffer = null;
 
     /**
      * Authentication Credentials
@@ -1378,15 +1386,13 @@ class SSH2
         // we don't initialize any crypto-objects, yet - we do that, later. for now, we need the lengths to make the
         // diffie-hellman key exchange as fast as possible
         $decrypt = self::array_intersect_first($s2c_encryption_algorithms, $this->encryption_algorithms_server_to_client);
-        $decryptKeyLength = $this->encryption_algorithm_to_key_size($decrypt);
-        if ($decryptKeyLength === null) {
+        if (!$decrypt || ($decryptKeyLength = $this->encryption_algorithm_to_key_size($decrypt)) === null) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible server to client encryption algorithms found');
         }
 
         $encrypt = self::array_intersect_first($c2s_encryption_algorithms, $this->encryption_algorithms_client_to_server);
-        $encryptKeyLength = $this->encryption_algorithm_to_key_size($encrypt);
-        if ($encryptKeyLength === null) {
+        if (!$encrypt || ($encryptKeyLength = $this->encryption_algorithm_to_key_size($encrypt)) === null) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible client to server encryption algorithms found');
         }
@@ -1908,7 +1914,7 @@ class SSH2
         }
     }
 
-    /*
+    /**
      * Tests whether or not proposed algorithm has a potential for issues
      *
      * @link https://www.chiark.greenend.org.uk/~sgtatham/putty/wishlist/ssh2-aesctr-openssh.html
@@ -2070,12 +2076,14 @@ class SSH2
 
             try {
                 $response = $this->get_binary_packet();
-            } catch (\Exception $e) {
-                if ($this->retry_connect) {
-                    $this->retry_connect = false;
-                    $this->connect();
-                    return $this->login_helper($username, $password);
+            } catch (InvalidPacketLengthException $e) {
+                if (!$this->bad_key_size_fix && self::bad_algorithm_candidate($this->decrypt ? $this->decryptName : '')) {
+                    // the first opportunity to encounter the "bad key size" error
+                    $this->bad_key_size_fix = true;
+                    return $this->reconnect();
                 }
+                throw $e;
+            } catch (\Exception $e) {
                 $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
                 throw $e;
             }
@@ -3133,30 +3141,57 @@ class SSH2
      */
     private function reconnect(): bool
     {
-        $this->reset_connection(DisconnectReason::CONNECTION_LOST);
+        $this->disconnect_helper(DisconnectReason::BY_APPLICATION);
         $this->retry_connect = true;
         $this->connect();
         foreach ($this->auth as $auth) {
             $result = $this->login(...$auth);
         }
+        $this->retry_connect = false;
         return $result;
     }
 
     /**
      * Resets a connection for re-use
      */
-    protected function reset_connection(int $reason): void
+    protected function reset_connection(): void
     {
-        $this->disconnect_helper($reason);
+        if (is_resource($this->fsock) && get_resource_type($this->fsock) === 'stream') {
+            fclose($this->fsock);
+        }
+        $this->fsock = null;
+        $this->bitmap = 0;
+        $this->binary_packet_buffer = null;
         $this->decrypt = $this->encrypt = false;
         $this->decrypt_block_size = $this->encrypt_block_size = 8;
         $this->hmac_check = $this->hmac_create = false;
         $this->hmac_size = false;
         $this->session_id = false;
-        $this->retry_connect = true;
+        $this->keep_alive_sent = null;
         $this->get_seq_no = $this->send_seq_no = 0;
         $this->channel_status = [];
         $this->channel_id_last_interactive = 0;
+    }
+
+    /**
+     * @return int[] second and microsecond stream timeout options based on user-requested timeout and keep-alive, 0 by default
+     */
+    private function get_stream_timeout()
+    {
+        $sec = 0;
+        $usec = 0;
+        if ($this->curTimeout > 0) {
+            $sec = (int) floor($this->curTimeout);
+            $usec = (int) (1000000 * ($this->curTimeout - $sec));
+        }
+        if ($this->keepAlive > 0) {
+            $elapsed = microtime(true) - $this->keep_alive_sent;
+            if ($elapsed < $this->curTimeout) {
+                $sec = (int) floor($elapsed);
+                $usec = (int) (1000000 * ($elapsed - $sec));
+            }
+        }
+        return [$sec, $usec];
     }
 
     /**
@@ -3167,78 +3202,64 @@ class SSH2
      * @return bool|string
      * @see self::_send_binary_packet()
      */
-    private function get_binary_packet(bool $skip_channel_filter = false)
+    private function get_binary_packet()
     {
-        if ($skip_channel_filter) {
-            if (!is_resource($this->fsock)) {
-                throw new InvalidArgumentException('fsock is not a resource.');
+        if (!is_resource($this->fsock)) {
+            throw new InvalidArgumentException('fsock is not a resource.');
+        }
+        if ($this->binary_packet_buffer == null) {
+            // buffer the packet to permit continued reads across timeouts
+            $this->binary_packet_buffer = (object) [
+                'raw' => '', // the raw payload read from the socket
+                'plain' => '', // the packet in plain text, excluding packet_length header
+                'packet_length' => null, // the packet_length value pulled from the payload
+                'size' => $this->decrypt_block_size, // the total size of this packet to be read from the socket
+                                                     // initialize to read single block until packet_length is available
+            ];
+        }
+        $packet = $this->binary_packet_buffer;
+        while (strlen($packet->raw) < $packet->size) {
+            if (feof($this->fsock)) {
+                $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
+                throw new ConnectionClosedException('Connection closed by server');
             }
-            $read = [$this->fsock];
-            $write = $except = null;
+            if ($this->curTimeout < 0) {
+                $this->is_timeout = true;
+                return true;
+            }
+            $this->send_keep_alive();
 
-            if (!$this->curTimeout) {
-                if ($this->keepAlive <= 0) {
-                    static::stream_select($read, $write, $except, null);
-                } else {
-                    if (!static::stream_select($read, $write, $except, $this->keepAlive)) {
-                        $this->send_binary_packet(pack('CN', MessageType::IGNORE, 0));
-                        return $this->get_binary_packet(true);
-                    }
-                }
-            } else {
-                if ($this->curTimeout < 0) {
-                    $this->is_timeout = true;
-                    return true;
-                }
-
-                $start = microtime(true);
-
-                if ($this->keepAlive > 0 && $this->keepAlive < $this->curTimeout) {
-                    if (!static::stream_select($read, $write, $except, $this->keepAlive)) {
-                        $this->send_binary_packet(pack('CN', MessageType::IGNORE, 0));
-                        $elapsed = microtime(true) - $start;
-                        $this->curTimeout -= $elapsed;
-                        return $this->get_binary_packet(true);
-                    }
-                    $elapsed = microtime(true) - $start;
-                    $this->curTimeout -= $elapsed;
-                }
-
-                $sec = (int) floor($this->curTimeout);
-                $usec = (int) (1000000 * ($this->curTimeout - $sec));
-
-                // this can return a "stream_select(): unable to select [4]: Interrupted system call" error
-                if (!static::stream_select($read, $write, $except, $sec, $usec)) {
-                    $this->is_timeout = true;
-                    return true;
-                }
-                $elapsed = microtime(true) - $start;
+            list($sec, $usec) = $this->get_stream_timeout();
+            stream_set_timeout($this->fsock, $sec, $usec);
+            $start = microtime(true);
+            $raw = stream_get_contents($this->fsock, $packet->size - strlen($packet->raw));
+            $elapsed = microtime(true) - $start;
+            if ($this->curTimeout > 0) {
                 $this->curTimeout -= $elapsed;
             }
-        }
-
-        if (!is_resource($this->fsock) || feof($this->fsock)) {
-            $this->bitmap = 0;
-            $str = 'Connection closed (by server) prematurely';
-            if (isset($elapsed)) {
-                $str .= ' ' . $elapsed . 's';
+            if ($raw === false) {
+                $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
+                throw new ConnectionClosedException('Connection closed by server');
+            } elseif (!strlen($raw)) {
+                continue;
             }
-            throw new ConnectionClosedException($str);
-        }
+            $packet->raw .= $raw;
+            if (!$packet->packet_length) {
+                $this->get_binary_packet_size($packet);
+            }
+        };
 
-        $start = microtime(true);
-        if ($this->curTimeout) {
-            $sec = (int) floor($this->curTimeout);
-            $usec = (int) (1000000 * ($this->curTimeout - $sec));
-            stream_set_timeout($this->fsock, $sec, $usec);
+        if (strlen($packet->raw) != $packet->size) {
+            throw new \RuntimeException('Size of packet was not expected length');
         }
-        $raw = stream_get_contents($this->fsock, $this->decrypt_block_size);
-
-        if (!strlen($raw)) {
-            $this->bitmap = 0;
-            throw new ConnectionClosedException('No data received from server');
+        // destroy buffer as packet represents the entire payload and should be processed in full
+        $this->binary_packet_buffer = null;
+        // copy the raw payload, so as not to destroy original
+        $raw = $packet->raw;
+        if ($this->hmac_check instanceof Hash) {
+            $hmac = Strings::pop($raw, $this->hmac_size);
         }
-
+        $packet_length_header_size = 4;
         if ($this->decrypt) {
             switch ($this->decryptName) {
                 case 'aes128-gcm@openssh.com':
@@ -3248,40 +3269,16 @@ class SSH2
                         $this->decryptInvocationCounter
                     );
                     Strings::increment_str($this->decryptInvocationCounter);
-                    $this->decrypt->setAAD($temp = Strings::shift($raw, 4));
-                    extract(unpack('Npacket_length', $temp));
-                    /**
-                     * @var integer $packet_length
-                     */
-
-                    $raw .= $this->read_remaining_bytes($packet_length - $this->decrypt_block_size + 4);
-                    $stop = microtime(true);
-                    $tag = stream_get_contents($this->fsock, $this->decrypt_block_size);
-                    $this->decrypt->setTag($tag);
-                    $raw = $this->decrypt->decrypt($raw);
-                    $raw = $temp . $raw;
-                    $remaining_length = 0;
+                    $this->decrypt->setAAD(Strings::shift($raw, $packet_length_header_size));
+                    $this->decrypt->setTag(Strings::pop($raw, $this->decrypt_block_size));
+                    $packet->plain = $this->decrypt->decrypt($raw);
                     break;
                 case 'chacha20-poly1305@openssh.com':
                     // This should be impossible, but we are checking anyway to narrow the type for Psalm.
                     if (!($this->decrypt instanceof ChaCha20)) {
                         throw new LogicException('$this->decrypt is not a ' . ChaCha20::class);
                     }
-
-                    $nonce = pack('N2', 0, $this->get_seq_no);
-
-                    $this->lengthDecrypt->setNonce($nonce);
-                    $temp = $this->lengthDecrypt->decrypt($aad = Strings::shift($raw, 4));
-                    extract(unpack('Npacket_length', $temp));
-                    /**
-                     * @var integer $packet_length
-                     */
-
-                    $raw .= $this->read_remaining_bytes($packet_length - $this->decrypt_block_size + 4);
-                    $stop = microtime(true);
-                    $tag = stream_get_contents($this->fsock, 16);
-
-                    $this->decrypt->setNonce($nonce);
+                    $this->decrypt->setNonce(pack('N2', 0, $this->get_seq_no));
                     $this->decrypt->setCounter(0);
                     // this is the same approach that's implemented in Salsa20::createPoly1305Key()
                     // but we don't want to use the same AEAD construction that RFC8439 describes
@@ -3289,78 +3286,57 @@ class SSH2
                     $this->decrypt->setPoly1305Key(
                         $this->decrypt->encrypt(str_repeat("\0", 32))
                     );
-                    $this->decrypt->setAAD($aad);
+                    $this->decrypt->setAAD(Strings::shift($raw, $packet_length_header_size));
                     $this->decrypt->setCounter(1);
-                    $this->decrypt->setTag($tag);
-                    $raw = $this->decrypt->decrypt($raw);
-                    $raw = $temp . $raw;
-                    $remaining_length = 0;
+                    $this->decrypt->setTag(Strings::pop($raw, 16));
+                    $packet->plain = $this->decrypt->decrypt($raw);
                     break;
                 default:
                     if (!$this->hmac_check instanceof Hash || !$this->hmac_check_etm) {
-                        $raw = $this->decrypt->decrypt($raw);
-                        break;
+                        // first block was already decrypted for contained packet_length header
+                        Strings::shift($raw, $this->decrypt_block_size);
+                        if (strlen($raw) > 0) {
+                            $packet->plain .= $this->decrypt->decrypt($raw);
+                        }
+                    } else {
+                        Strings::shift($raw, $packet_length_header_size);
+                        $packet->plain = $this->decrypt->decrypt($raw);
                     }
-                    extract(unpack('Npacket_length', $temp = Strings::shift($raw, 4)));
-                    /**
-                     * @var integer $packet_length
-                     */
-                    $raw .= $this->read_remaining_bytes($packet_length - $this->decrypt_block_size + 4);
-                    $stop = microtime(true);
-                    $encrypted = $temp . $raw;
-                    $raw = $temp . $this->decrypt->decrypt($raw);
-                    $remaining_length = 0;
+                    break;
             }
+        } else {
+            Strings::shift($raw, $packet_length_header_size);
+            $packet->plain = $raw;
         }
-
-        if (strlen($raw) < 5) {
-            $this->bitmap = 0;
-            throw new RuntimeException('Plaintext is too short');
-        }
-        extract(unpack('Npacket_length/Cpadding_length', Strings::shift($raw, 5)));
-        /**
-         * @var integer $packet_length
-         * @var integer $padding_length
-         */
-
-        if (!isset($remaining_length)) {
-            $remaining_length = $packet_length + 4 - $this->decrypt_block_size;
-        }
-
-        $buffer = $this->read_remaining_bytes($remaining_length);
-
-        if (!isset($stop)) {
-            $stop = microtime(true);
-        }
-        if (strlen($buffer)) {
-            $raw .= $this->decrypt ? $this->decrypt->decrypt($buffer) : $buffer;
-        }
-
-        $payload = Strings::shift($raw, $packet_length - $padding_length - 1);
-        $padding = Strings::shift($raw, $padding_length); // should leave $raw empty
-
         if ($this->hmac_check instanceof Hash) {
-            $hmac = stream_get_contents($this->fsock, $this->hmac_size);
-            if ($hmac === false || strlen($hmac) != $this->hmac_size) {
-                $this->disconnect_helper(DisconnectReason::MAC_ERROR);
-                throw new RuntimeException('Error reading socket');
-            }
-
             $reconstructed = !$this->hmac_check_etm ?
-                pack('NCa*', $packet_length, $padding_length, $payload . $padding) :
-                $encrypted;
+                pack('Na*', $packet->packet_length, $packet->plain) :
+                substr($packet->raw, 0, -$this->hmac_size);
             if (($this->hmac_check->getHash() & "\xFF\xFF\xFF\xFF") == 'umac') {
                 $this->hmac_check->setNonce("\0\0\0\0" . pack('N', $this->get_seq_no));
                 if ($hmac != $this->hmac_check->hash($reconstructed)) {
                     $this->disconnect_helper(DisconnectReason::MAC_ERROR);
-                    throw new RuntimeException('Invalid UMAC');
+                    throw new ConnectionClosedException('Invalid UMAC');
                 }
             } else {
                 if ($hmac != $this->hmac_check->hash(pack('Na*', $this->get_seq_no, $reconstructed))) {
                     $this->disconnect_helper(DisconnectReason::MAC_ERROR);
-                    throw new RuntimeException('Invalid HMAC');
+                    throw new ConnectionClosedException('Invalid HMAC');
                 }
             }
+        }
+
+        $payload = $packet->plain;
+        extract(unpack('Cpadding_length', Strings::shift($payload, 1)));
+        /**
+         * @var int $padding_length
+         */
+        if ($padding_length > 0) {
+            Strings::pop($payload, $padding_length);
+        }
+        if (empty($payload)) {
+            $this->disconnect_helper(DisconnectReason::PROTOCOL_ERROR);
+            throw new ConnectionClosedException('Plaintext is too short');
         }
 
         switch ($this->decompress) {
@@ -3416,62 +3392,73 @@ class SSH2
             $this->last_packet = $current;
         }
 
-        return $this->filter($payload, $skip_channel_filter);
+        return $this->filter($payload);
     }
 
     /**
-     * Read Remaining Bytes
-     *
-     * @return string
-     * @see self::get_binary_packet()
+     * @param object $packet The packet object being constructed, passed by reference
+     *        The size, packet_length, and plain properties of this object may be modified in processing
+     * @throws InvalidPacketLengthException if the packet length header is invalid
      */
-    private function read_remaining_bytes(int $remaining_length)
+    private function get_binary_packet_size(object &$packet): void
     {
-        if (!$remaining_length) {
-            return '';
+        $packet_length_header_size = 4;
+        if (strlen($packet->raw) < $packet_length_header_size) {
+            return;
         }
-
-        $adjustLength = false;
+        $extractPacketLength = function ($payload) {
+            extract(unpack('Npacket_length', $payload));
+            /**
+             * @var integer $packet_length
+             */
+            return $packet_length;
+        };
+        $added_validation_length = 0; // indicates when the packet length header is included when validating packet length against block size
         if ($this->decrypt) {
-            switch (true) {
-                case $this->decryptName == 'aes128-gcm@openssh.com':
-                case $this->decryptName == 'aes256-gcm@openssh.com':
-                case $this->decryptName == 'chacha20-poly1305@openssh.com':
-                case $this->hmac_check instanceof Hash && $this->hmac_check_etm:
-                    $remaining_length += $this->decrypt_block_size - 4;
-                    $adjustLength = true;
+            switch ($this->decryptName) {
+                case 'aes128-gcm@openssh.com':
+                case 'aes256-gcm@openssh.com':
+                    $packet->packet_length = $extractPacketLength(substr($packet->raw, 0, $packet_length_header_size));
+                    $packet->size = $packet_length_header_size + $packet->packet_length + $this->decrypt_block_size; // expect tag
+                    break;
+                case 'chacha20-poly1305@openssh.com':
+                    $this->lengthDecrypt->setNonce(pack('N2', 0, $this->get_seq_no));
+                    $packet_length_header = $this->lengthDecrypt->decrypt(substr($packet->raw, 0, $packet_length_header_size));
+                    $packet->packet_length = $extractPacketLength($packet_length_header);
+                    $packet->size = $packet_length_header_size + $packet->packet_length + 16; // expect tag
+                    break;
+                default:
+                    if (!$this->hmac_check instanceof Hash || !$this->hmac_check_etm) {
+                        if (strlen($packet->raw) < $this->decrypt_block_size) {
+                            return;
+                        }
+                        $packet->plain .= $this->decrypt->decrypt(substr($packet->raw, 0, $this->decrypt_block_size));
+                        $packet->packet_length = $extractPacketLength(Strings::shift($packet->plain, $packet_length_header_size));
+                        $packet->size = $packet_length_header_size + $packet->packet_length;
+                        $added_validation_length = $packet_length_header_size;
+                    } else {
+                        $packet->packet_length = $extractPacketLength(substr($packet->raw, 0, $packet_length_header_size));
+                        $packet->size = $packet_length_header_size + $packet->packet_length;
+                    }
+                    break;
             }
+        } else {
+            $packet->packet_length = $extractPacketLength(substr($packet->raw, 0, $packet_length_header_size));
+            $packet->size = $packet_length_header_size + $packet->packet_length;
+            $added_validation_length = $packet_length_header_size;
         }
-
         // quoting <http://tools.ietf.org/html/rfc4253#section-6.1>,
         // "implementations SHOULD check that the packet length is reasonable"
         // PuTTY uses 0x9000 as the actual max packet size and so to shall we
-        // don't do this when GCM mode is used since GCM mode doesn't encrypt the length
-        if ($remaining_length < -$this->decrypt_block_size || $remaining_length > 0x9000 || $remaining_length % $this->decrypt_block_size != 0) {
-            if (!$this->bad_key_size_fix && self::bad_algorithm_candidate($this->decrypt ? $this->decryptName : '') && !($this->bitmap & SSH2::MASK_LOGIN)) {
-                $this->bad_key_size_fix = true;
-                $this->reset_connection(DisconnectReason::KEY_EXCHANGE_FAILED);
-                return false;
-            }
-            throw new RuntimeException('Invalid size');
+        if ($packet->packet_length <= 0 || $packet->packet_length > 0x9000
+            || ($packet->packet_length + $added_validation_length) % $this->decrypt_block_size != 0
+        ) {
+            $this->disconnect_helper(DisconnectReason::PROTOCOL_ERROR);
+            throw new InvalidPacketLengthException('Invalid packet length');
         }
-
-        if ($adjustLength) {
-            $remaining_length -= $this->decrypt_block_size - 4;
+        if ($this->hmac_check instanceof Hash) {
+            $packet->size += $this->hmac_size;
         }
-
-        $buffer = '';
-        while ($remaining_length > 0) {
-            $temp = stream_get_contents($this->fsock, $remaining_length);
-            if ($temp === false || feof($this->fsock)) {
-                $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
-                throw new RuntimeException('Error reading from socket');
-            }
-            $buffer .= $temp;
-            $remaining_length -= strlen($temp);
-        }
-
-        return $buffer;
     }
 
     /**
@@ -3482,7 +3469,7 @@ class SSH2
      * @return string|bool
      * @see self::_get_binary_packet()
      */
-    private function filter(string $payload, bool $skip_channel_filter)
+    private function filter(string $payload)
     {
         switch (ord($payload[0])) {
             case MessageType::DISCONNECT:
@@ -3493,14 +3480,14 @@ class SSH2
                 return false;
             case MessageType::IGNORE:
                 $this->extra_packets++;
-                $payload = $this->get_binary_packet($skip_channel_filter);
+                $payload = $this->get_binary_packet();
                 break;
             case MessageType::DEBUG:
                 $this->extra_packets++;
                 Strings::shift($payload, 2); // second byte is "always_display"
                 [$message] = Strings::unpackSSH2('s', $payload);
                 $this->errors[] = "SSH_MSG_DEBUG: $message";
-                $payload = $this->get_binary_packet($skip_channel_filter);
+                $payload = $this->get_binary_packet();
                 break;
             case MessageType::UNIMPLEMENTED:
                 return false;
@@ -3511,7 +3498,7 @@ class SSH2
                         $this->bitmap = 0;
                         return false;
                     }
-                    $payload = $this->get_binary_packet($skip_channel_filter);
+                    $payload = $this->get_binary_packet();
                 }
         }
 
@@ -3536,18 +3523,8 @@ class SSH2
                             if (ord(substr($payload, 9 + $length))) { // want reply
                                 $this->send_binary_packet(pack('CN', MessageType::CHANNEL_SUCCESS, $this->server_channels[$channel]));
                             }
-                            $payload = $this->get_binary_packet($skip_channel_filter);
+                            $payload = $this->get_binary_packet();
                         }
-                    }
-                    break;
-                case MessageType::CHANNEL_DATA:
-                case MessageType::CHANNEL_EXTENDED_DATA:
-                case MessageType::CHANNEL_CLOSE:
-                case MessageType::CHANNEL_EOF:
-                    if (!$skip_channel_filter && !empty($this->server_channels)) {
-                        $this->binary_packet_buffer = $payload;
-                        $this->get_channel_packet(true);
-                        $payload = $this->get_binary_packet();
                     }
                     break;
                 case MessageType::GLOBAL_REQUEST: // see http://tools.ietf.org/html/rfc4254#section-4
@@ -3561,7 +3538,7 @@ class SSH2
                         return $this->disconnect_helper(DisconnectReason::BY_APPLICATION);
                     }
 
-                    $payload = $this->get_binary_packet($skip_channel_filter);
+                    $payload = $this->get_binary_packet();
                     break;
                 case MessageType::CHANNEL_OPEN: // see http://tools.ietf.org/html/rfc4254#section-5.1
                     Strings::shift($payload, 1);
@@ -3614,7 +3591,7 @@ class SSH2
                             }
                     }
 
-                    $payload = $this->get_binary_packet($skip_channel_filter);
+                    $payload = $this->get_binary_packet();
                     break;
                 case MessageType::CHANNEL_WINDOW_ADJUST:
                     Strings::shift($payload, 1);
@@ -3622,7 +3599,7 @@ class SSH2
 
                     $this->window_size_client_to_server[$channel] += $window_size;
 
-                    $payload = ($this->bitmap & self::MASK_WINDOW_ADJUST) ? true : $this->get_binary_packet($skip_channel_filter);
+                    $payload = ($this->bitmap & self::MASK_WINDOW_ADJUST) ? true : $this->get_binary_packet();
             }
         }
 
@@ -3727,23 +3704,17 @@ class SSH2
         }
 
         while (true) {
-            if ($this->binary_packet_buffer !== false) {
-                $response = $this->binary_packet_buffer;
-                $this->binary_packet_buffer = false;
-            } else {
-                $response = $this->get_binary_packet(true);
-                if ($response === true && $this->is_timeout) {
-                    if ($client_channel == self::CHANNEL_EXEC && !$this->request_pty) {
-                        $this->close_channel($client_channel);
-                    }
-                    return true;
+            $response = $this->get_binary_packet();
+            if ($response === true && $this->is_timeout) {
+                if ($client_channel == self::CHANNEL_EXEC && !$this->request_pty) {
+                    $this->close_channel($client_channel);
                 }
-                if ($response === false) {
-                    $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
-                    throw new ConnectionClosedException('Connection closed by server');
-                }
+                return true;
             }
-
+            if ($response === false) {
+                $this->disconnect_helper(DisconnectReason::CONNECTION_LOST);
+                throw new ConnectionClosedException('Connection closed by server');
+            }
             if ($client_channel == -1 && $response === true) {
                 return true;
             }
@@ -4076,6 +4047,18 @@ class SSH2
     }
 
     /**
+     * Sends a keep-alive message, if keep-alive is enabled and interval is met
+     */
+    private function send_keep_alive()
+    {
+        $elapsed = microtime(true) - $this->keep_alive_sent;
+        if ($this->keepAlive > 0 && $elapsed >= $this->keepAlive) {
+            $this->keep_alive_sent = microtime(true);
+            $this->send_binary_packet(pack('CN', MessageType::IGNORE, 0));
+        }
+    }
+
+    /**
      * Logs data packets
      *
      * Makes sure that only the last 1MB worth of packets will be logged
@@ -4273,10 +4256,7 @@ class SSH2
             }
         }
 
-        $this->bitmap = 0;
-        if (is_resource($this->fsock) && get_resource_type($this->fsock) === 'stream') {
-            fclose($this->fsock);
-        }
+        $this->reset_connection();
 
         return false;
     }

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3427,7 +3427,7 @@ class SSH2
                         if (strlen($packet->raw) < $this->decrypt_block_size) {
                             return;
                         }
-                        $packet->plain .= $this->decrypt->decrypt(substr($packet->raw, 0, $this->decrypt_block_size));
+                        $packet->plain = $this->decrypt->decrypt(substr($packet->raw, 0, $this->decrypt_block_size));
                         $packet->packet_length = $extractPacketLength(Strings::shift($packet->plain, $packet_length_header_size));
                         $packet->size = $packet_length_header_size + $packet->packet_length;
                         $added_validation_length = $packet_length_header_size;

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3450,7 +3450,8 @@ class SSH2
         // quoting <http://tools.ietf.org/html/rfc4253#section-6.1>,
         // "implementations SHOULD check that the packet length is reasonable"
         // PuTTY uses 0x9000 as the actual max packet size and so to shall we
-        if ($packet->packet_length <= 0 || $packet->packet_length > 0x9000
+        if (
+            $packet->packet_length <= 0 || $packet->packet_length > 0x9000
             || ($packet->packet_length + $added_validation_length) % $this->decrypt_block_size != 0
         ) {
             $this->disconnect_helper(DisconnectReason::PROTOCOL_ERROR);

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 
 namespace phpseclib3\Tests\Functional\Net;
 
-use phpseclib3\Net\SSH2;
 use phpseclib3\Exception\NoSupportedAlgorithmsException;
+use phpseclib3\Net\SSH2;
 use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
 class SSH2Test extends PhpseclibFunctionalTestCase

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace phpseclib3\Tests\Functional\Net;
 
 use phpseclib3\Net\SSH2;
+use phpseclib3\Exception\NoSupportedAlgorithmsException;
 use phpseclib3\Tests\PhpseclibFunctionalTestCase;
 
 class SSH2Test extends PhpseclibFunctionalTestCase
@@ -554,5 +555,92 @@ class SSH2Test extends PhpseclibFunctionalTestCase
         $this->assertSame(1, $ssh->getOpenChannelCount());
         $ssh->reset(SSH2::CHANNEL_SHELL);
         $this->assertSame(0, $ssh->getOpenChannelCount());
+    }
+
+    public function testPing(): void
+    {
+        $ssh = $this->getSSH2();
+        // assert on unauthenticated ssh2
+        $this->assertNotEmpty($ssh->getServerIdentification());
+        $this->assertFalse($ssh->ping());
+        $this->assertTrue($ssh->isConnected());
+        $this->assertSame(0, $ssh->getOpenChannelCount());
+
+        $ssh = $this->getSSH2Login();
+        $this->assertTrue($ssh->ping());
+        $this->assertSame(0, $ssh->getOpenChannelCount());
+    }
+
+    public function getCryptoAlgorithms(): array
+    {
+        $map = [
+            'kex' => SSH2::getSupportedKEXAlgorithms(),
+            'hostkey' => SSH2::getSupportedHostKeyAlgorithms(),
+            'comp' => SSH2::getSupportedCompressionAlgorithms(),
+            'crypt' => SSH2::getSupportedEncryptionAlgorithms(),
+            'mac' => SSH2::getSupportedMACAlgorithms(),
+        ];
+        $tests = [];
+        foreach ($map as $type => $algorithms) {
+            foreach ($algorithms as $algorithm) {
+                $tests[] = [$type, $algorithm];
+            }
+        }
+        return $tests;
+    }
+
+    /**
+     * @dataProvider getCryptoAlgorithms
+     */
+    public function testCryptoAlgorithms(string $type, string $algorithm): void
+    {
+        $ssh = $this->getSSH2();
+        try {
+            switch ($type) {
+                case 'kex':
+                case 'hostkey':
+                    $ssh->setPreferredAlgorithms([$type => [$algorithm]]);
+                    $this->assertEquals($algorithm, $ssh->getAlgorithmsNegotiated()[$type]);
+                    break;
+                case 'comp':
+                case 'crypt':
+                    $ssh->setPreferredAlgorithms([
+                        'client_to_server' => [$type => [$algorithm]],
+                        'server_to_client' => [$type => [$algorithm]],
+                    ]);
+                    $this->assertEquals($algorithm, $ssh->getAlgorithmsNegotiated()['client_to_server'][$type]);
+                    $this->assertEquals($algorithm, $ssh->getAlgorithmsNegotiated()['server_to_client'][$type]);
+                    break;
+                case 'mac':
+                    $macCryptAlgorithms = array_filter(
+                        SSH2::getSupportedEncryptionAlgorithms(),
+                        function ($algorithm) use ($ssh) {
+                            return !self::callFunc($ssh, 'encryption_algorithm_to_crypt_instance', [$algorithm])
+                                ->usesNonce();
+                        }
+                    );
+                    $ssh->setPreferredAlgorithms([
+                        'client_to_server' => ['crypt' => $macCryptAlgorithms, 'mac' => [$algorithm]],
+                        'server_to_client' => ['crypt' => $macCryptAlgorithms, 'mac' => [$algorithm]],
+                    ]);
+                    $this->assertEquals($algorithm, $ssh->getAlgorithmsNegotiated()['client_to_server']['mac']);
+                    $this->assertEquals($algorithm, $ssh->getAlgorithmsNegotiated()['server_to_client']['mac']);
+                    break;
+            }
+        } catch (NoSupportedAlgorithmsException $e) {
+            self::markTestSkipped("{$type} algorithm {$algorithm} is not supported by server");
+        }
+
+        $username = $this->getEnv('SSH_USERNAME');
+        $password = $this->getEnv('SSH_PASSWORD');
+        $this->assertTrue(
+            $ssh->login($username, $password),
+            "SSH2 login using {$type} {$algorithm} failed."
+        );
+
+        $ssh->setTimeout(1);
+        $ssh->write("pwd\n");
+        $this->assertNotEmpty($ssh->read('', SSH2::READ_NEXT));
+        $ssh->disconnect();
     }
 }


### PR DESCRIPTION
This attempts to address issue #1993.

With this change, all stream I/O is moved to the head of `get_binary_packet`, with applicable timeouts applied, and processing of the payload only commences once read in full. This ensures that an under-read of the remainder of the packet from the stream does not lead to false-positive errors during subsequent processing, as with e.g. potential for decrypt errors in handling of the `$tag` value in GCM/ChaCha decrypt logic. The partial packet is also buffered in the repurposed `binary_packet_buffer` such that graceful re-entry into `get_binary_packet` is accommodated during timeout events, where packets previously could be lost and client corruption was a possibility with the remainder of the packet left in the buffer.

The `$skip_channel_filter` parameter is removed from both `get_binary_packet` and `filter` method signatures. It was previously used to enact timeout enforcement at the head of `get_binary_packet`, but became extraneous to that end with the added timeout enforcement of c20dd78 and its predecessor, i.e. with all paths through `get_binary_packet` now enforcing timeouts. Some channel packet type cases (`MessageType::CHANNEL_DATA`, `MessageType::CHANNEL_EXTENDED_DATA`, `MessageType::CHANNEL_CLOSE`, `MessageType::CHANNEL_EOF`) were removed from `filter()` packet processing, deemed extraneous considering that `exec()` no longer consumes `get_binary_packet` directly, as was the case when a3325d1 was authored, preferring `get_channel_packet`, and that `get_channel_packet` already loops over `get_binary_packet` to prompt fetch of the next packet under appropriate circumstances, i.e. such as receipt of packet on another channel. This allowed for some cleanup within `get_channel_packet` as well.

The exception `InvalidPacketLengthException` is introduced and thrown from the added `get_binary_packet_size` when encountering a bad `packet_length` value. This maintains handling of the OpenSSL 0.9.8e issue (reported in #1171 , changed with e5b4eef) from within `_login_helper` without importing the knowledge of the issue into low-level packet processing. Validation is added for a `packet_length` value of 0 or negative value.

Lastly, `reset_connection` and `disconnect_helper` are reorganized such that any use of `disconnect_helper` will now prompt reset of the `SSH2` instance, or at least of what was previously captured by `reset_connection`, and including `binary_packet_buffer` and added `keep_alive_sent`.

Through the added SSH2 functional test `testCryptoAlgorithms()`, I was able to test the following algorithms and also provide decent coverage of the changes. See attachments [coverage-getbinarypacket-crap4j.txt](https://github.com/phpseclib/phpseclib/files/15341060/coverage-getbinarypacket-crap4j.txt) and [coverage-getbinarypacket-cobertura.txt](https://github.com/phpseclib/phpseclib/files/15341050/coverage-getbinarypacket-cobertura.txt) for excised coverage analysis of the functions `get_binary_packet` and `get_binary_packet_size`. Lack of coverage is mostly reflected in the error/breakout states, debug logging, and the `zlib` compression implementation, however unmodified here.
```
KEX:
- curve25519-sha256
- curve25519-sha256@libssh.org
- ecdh-sha2-nistp256
- ecdh-sha2-nistp384
- ecdh-sha2-nistp521
- diffie-hellman-group14-sha256
- diffie-hellman-group14-sha1
- diffie-hellman-group1-sha1

HostKey:
- rsa-sha2-256
- rsa-sha2-512
- ssh-rsa

Crypt:
- aes128-gcm@openssh.com
- aes128-ctr
- aes192-ctr
- aes256-ctr
- chacha20-poly1305@openssh.com

MAC:
- hmac-sha2-256-etm@openssh.com
- hmac-sha2-256
- hmac-sha1-96
- hmac-sha1
```

In order to prompt testing of the `chacha20-poly1305@openssh.com` encryption algorithm, I had to comment out this logic in `getSupportedEncyrptionAlgorithms()`. I only dug a little, but it looked to me like `chacha20-poly1305@openssh.com` might not be viable according to this as it doesn't provide a `setupInlineCrypt()` method or invoke `createInlineCryptFunction()`. Something to look into perhaps.
```
case 'chacha20-poly1305@openssh.com':
case 'arcfour128':
case 'arcfour256':
if ($engine != 'Eval') {
    continue 2;
}
break;
```