### PR TITLE
Support loading Ed448 in PKCS8 format

### DIFF
--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
@@ -129,13 +129,22 @@ abstract class PKCS8 extends Progenitor
         $components = [];
 
         if (isset($key['privateKey'])) {
-            $components['curve'] = $key['privateKeyAlgorithm']['algorithm'] == 'id-Ed25519' ? new Ed25519() : new Ed448();
-
-            // 0x04 == octet string
-            // 0x20 == length (32 bytes)
-            if (substr($key['privateKey'], 0, 2) != "\x04\x20") {
-                throw new RuntimeException('The first two bytes of the private key field should be 0x0420');
+            if ($key['privateKeyAlgorithm']['algorithm'] == 'id-Ed25519') {
+                $components['curve'] = new Ed25519();
+                // 0x04 == octet string
+                // 0x20 == length (32 bytes)
+                if (substr($key['privateKey'], 0, 2) != "\x04\x20") {
+                    throw new \RuntimeException('The first two bytes of the Ed25519 private key field should be 0x0420');
+                }
+            } else {
+                $components['curve'] = new Ed448();
+                // 0x04 == octet string
+                // 0x39 == length (57 bytes)
+                if (substr($key['privateKey'], 0, 2) != "\x04\x39") {
+                    throw new \RuntimeException('The first two bytes of the Ed448 private key field should be 0x0439');
+                }
             }
+
             $arr = $components['curve']->extractSecret(substr($key['privateKey'], 2));
             $components['dA'] = $arr['dA'];
             $components['secret'] = $arr['secret'];


### PR DESCRIPTION
For Ed448, the private key component is expected to be 57 bytes in length, not 32 like with Ed25519.

This patch will properly support loading Ed448 keys in PKCS8 format

To test, create an Ed448 key with OpenSSL:

```shell
openssl genpkey -algorithm ed448 -out ed448-key.pem
```

Then load the key with PHPSecLib
```php
$private_key_pem = file_get_contents('ed448-key.pem');
$private_key = EC::loadPrivateKey($private_key_pem);
```

Without this proposed patch, PHPSecLib would not be able to load this Ed448 key.