### PR TITLE
Fix support for Ed448 private keys in PKCS#8 format

### DIFF
--- a/tests/Unit/Crypt/EC/KeyTest.php
+++ b/tests/Unit/Crypt/EC/KeyTest.php
@@ -297,6 +297,33 @@ WEKBIQAZv0QJaYTN/oVBusFn3DuWyFCGqjC2tssMXDitcDFm4Q==
         $this->assertSameNL('Ed25519', $key->getPublicKey()->getCurve());
     }
 
+    // Generate with:
+    // openssl genpkey -algorithm ed448 | openssl ec -pubout
+    public function testEd448PublicKey()
+    {
+        $expected = '-----BEGIN PUBLIC KEY-----
+MEMwBQYDK2VxAzoAsA7zbld48IfDhm7Qd6FYrvnljtjhPRRqZi04NWyj8VXrWe1x
+BMLQFJEE0JDmKayUWpUWsRXwmb6A
+-----END PUBLIC KEY-----';
+        $key = PublicKeyLoader::load($expected);
+        $this->assertSameNL('Ed448', $key->getCurve());
+        $this->assertSameNL($expected, $key->toString('PKCS8'));
+    }
+
+    // Generate with:
+    // openssl genpkey -algorithm ed448
+    public function testEd448PrivateKey()
+    {
+        $expected = '-----BEGIN PRIVATE KEY-----
+MEcCAQAwBQYDK2VxBDsEOettXaJYob4hJNKJNOD+FfMvdesLKNp0KwochI6AKmAb
+tWhtkn99WOjd1PsGMh9zz2Vhdg3MwasOMQ==
+-----END PRIVATE KEY-----';
+        $key = PublicKeyLoader::load($expected);
+        $this->assertSameNL($expected, $key->toString('PKCS8'));
+        $this->assertSameNL('Ed448', $key->getCurve());
+        $this->assertSameNL('Ed448', $key->getPublicKey()->getCurve());
+    }
+
     public function testPuTTYnistp256()
     {
         $key = PublicKeyLoader::load($expected = 'PuTTY-User-Key-File-2: ecdsa-sha2-nistp256


### PR DESCRIPTION
This is the second attempt at a PR for Ed448 private key support in PKCS#8 format against 3.0 branch (original PR: [2000](https://github.com/phpseclib/phpseclib/pull/2000) )

- Fixes parsing of Ed448 private keys in PKCS#8 format (`PKCS8.loadEdDSA()`)
- Fixes exporting of Ed448 private keys in PKCS#8 format (`PKCS8.savePrivateKey()`)
- Adds unittests `testEd448PublicKey()` and `testEd448PrivateKey()`

I tried to retain the original coding style, so the if/else structure will assume Ed448 if the curve is not Ed25519 (which mimics the ternary operator that was there before this patch), it would be cleaner to refactor this to a switch statement in the future.


Also, I'd recommend adding a proper wrapper for an ASN.1 `OCTET STRING`, instead relying on the hardcoded `\x04\x20` and `\x04\x39`.

In case it wasn't yet clear: In the ASN.1 of an Ed448 private key the key data is a double wrapped octet string. So, the error text `"The first two bytes of the private key field should be 0x0420"` is incorrect, it's not part of the key, is an octet string header (0x04) and length field (0x20/0x39).

See for example:
https://lapo.it/asn1js/#MEcCAQAwBQYDK2VxBDsEOettXaJYob4hJNKJNOD-FfMvdesLKNp0KwochI6AKmAbtWhtkn99WOjd1PsGMh9zz2Vhdg3MwasOMQ

As you can see, lots of improvements to be done here, but I didn't want to increase the scope of this PR. The important thing is that Ed448 private keys in PKCS#8 are now at least supported, and tested.
