### PR TITLE
fix #2010 back-ported for master of phpseclib

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3369,7 +3369,7 @@ class SSH2
                     ? "SSH_MSG_$constantName"
                     : "UNKNOWN ($value)",
                 round($current - $this->last_packet, 4),
-                round($stop - $start, 4)
+                round($elapsed, 4)
             );
             $this->append_log($message_number, $payload);
             $this->last_packet = $current;


### PR DESCRIPTION
fix #2010 back-ported  for master from the 3.0 branch . As the 3.0 branch is different then the master branch