### PR TITLE
Correction to stream timeout for keep alive

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -826,6 +826,8 @@ class SSH2
 
     /**
      * Time of last read/write network activity
+     *
+     * @var float
      */
     private $last_packet = null;
 

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -575,7 +575,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
         $this->assertSame(0, $ssh->getOpenChannelCount());
     }
 
-    public function testKeepAlive(): void
+    public function testKeepAlive()
     {
         $ssh = $this->getSSH2();
         $username = $this->getEnv('SSH_USERNAME');

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -575,6 +575,27 @@ class SSH2Test extends PhpseclibFunctionalTestCase
         $this->assertSame(0, $ssh->getOpenChannelCount());
     }
 
+    public function testKeepAlive(): void
+    {
+        $ssh = $this->getSSH2();
+        $username = $this->getEnv('SSH_USERNAME');
+        $password = $this->getEnv('SSH_PASSWORD');
+
+        $ssh->setKeepAlive(1);
+        $ssh->setTimeout(1);
+
+        $this->assertNotEmpty($ssh->getServerIdentification());
+        $this->assertTrue(
+            $ssh->login($username, $password),
+            'SSH2 login using password failed.'
+        );
+
+        $ssh->write("pwd\n");
+        sleep(1); // permit keep alive to proc on next read
+        $this->assertNotEmpty($ssh->read('', SSH2::READ_NEXT));
+        $ssh->disconnect();
+    }
+
     /**
      * @return array
      */

--- a/tests/PhpseclibTestCase.php
+++ b/tests/PhpseclibTestCase.php
@@ -89,9 +89,39 @@ abstract class PhpseclibTestCase extends TestCase
     protected static function getVar($obj, $var)
     {
         $reflection = new \ReflectionClass(get_class($obj));
-        $prop = $reflection->getProperty($var);
+        // private variables are not inherited, climb hierarchy until located
+        while (true) {
+            try {
+                $prop = $reflection->getProperty($var);
+                break;
+            } catch (\ReflectionException $e) {
+                $reflection = $reflection->getParentClass();
+                if (!$reflection) {
+                    throw $e;
+                }
+            }
+        }
         $prop->setAccessible(true);
         return $prop->getValue($obj);
+    }
+
+    protected static function setVar($obj, $var, $value)
+    {
+        $reflection = new \ReflectionClass(get_class($obj));
+        // private variables are not inherited, climb hierarchy until located
+        while (true) {
+            try {
+                $prop = $reflection->getProperty($var);
+                break;
+            } catch (\ReflectionException $e) {
+                $reflection = $reflection->getParentClass();
+                if (!$reflection) {
+                    throw $e;
+                }
+            }
+        }
+        $prop->setAccessible(true);
+        $prop->setValue($obj, $value);
     }
 
     public static function callFunc($obj, $func, $params = [])

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -221,7 +221,10 @@ class SSH2UnitTest extends PhpseclibTestCase
         $this->assertEquals(20, $ssh->getTimeout());
     }
 
-    public function testGetStreamTimeout(): void
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testGetStreamTimeout()
     {
         // no curTimeout, no keepAlive
         $ssh = $this->createSSHMock();

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -221,6 +221,53 @@ class SSH2UnitTest extends PhpseclibTestCase
         $this->assertEquals(20, $ssh->getTimeout());
     }
 
+    public function testGetStreamTimeout(): void
+    {
+        // no curTimeout, no keepAlive
+        $ssh = $this->createSSHMock();
+        $this->assertEquals([0, 0], self::callFunc($ssh, 'get_stream_timeout'));
+
+        // curTimeout, no keepAlive
+        $ssh = $this->createSSHMock();
+        $ssh->setTimeout(1);
+        $this->assertEquals([1, 0], self::callFunc($ssh, 'get_stream_timeout'));
+
+        // no curTimeout, keepAlive
+        $ssh = $this->createSSHMock();
+        $ssh->setKeepAlive(2);
+        self::setVar($ssh, 'last_packet', microtime(true));
+        list($sec, $usec) = self::callFunc($ssh, 'get_stream_timeout');
+        $this->assertGreaterThanOrEqual(1, $sec);
+        $this->assertLessThanOrEqual(2, $sec);
+
+        // smaller curTimeout, keepAlive
+        $ssh = $this->createSSHMock();
+        $ssh->setTimeout(1);
+        $ssh->setKeepAlive(2);
+        self::setVar($ssh, 'last_packet', microtime(true));
+        $this->assertEquals([1, 0], self::callFunc($ssh, 'get_stream_timeout'));
+
+        // curTimeout, smaller keepAlive
+        $ssh = $this->createSSHMock();
+        $ssh->setTimeout(5);
+        $ssh->setKeepAlive(2);
+        self::setVar($ssh, 'last_packet', microtime(true));
+        list($sec, $usec) = self::callFunc($ssh, 'get_stream_timeout');
+        $this->assertGreaterThanOrEqual(1, $sec);
+        $this->assertLessThanOrEqual(2, $sec);
+
+        // no curTimeout, keepAlive, no last_packet
+        $ssh = $this->createSSHMock();
+        $ssh->setKeepAlive(2);
+        $this->assertEquals([0, 0], self::callFunc($ssh, 'get_stream_timeout'));
+
+        // no curTimeout, keepAlive, last_packet exceeds keepAlive
+        $ssh = $this->createSSHMock();
+        $ssh->setKeepAlive(2);
+        self::setVar($ssh, 'last_packet', microtime(true) - 2);
+        $this->assertEquals([0, 0], self::callFunc($ssh, 'get_stream_timeout'));
+    }
+
     /**
      * @return \phpseclib3\Net\SSH2
      */


### PR DESCRIPTION
Looks like I got sloppy around the keep alive changes, w.r.t. #2009, #2010, #2011. Sorry about that!

I see it's still not quite right though, as we're basing the stream timeout on time since the last read as opposed to time remaining in the keep alive interval. This attempts to fix that along with adding a counter for packet read time and ensuring that `last_packet` is always incremented, even if logging is not enabled.