### PR TITLE
SSH2: Consolidate get_binary_packet error handling

### DIFF
--- a/phpseclib/Exception/TimeoutException.php
+++ b/phpseclib/Exception/TimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace phpseclib3\Exception;
+
+/**
+ * Indicates a timeout awaiting server response
+ */
+class TimeoutException extends \RuntimeException
+{
+}

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3269,6 +3269,7 @@ class SFTP extends SSH2
         // in SSH2.php the timeout is cumulative per function call. eg. exec() will
         // timeout after 10s. but for SFTP.php it's cumulative per packet
         $this->curTimeout = $this->timeout;
+        $this->is_timeout = false;
 
         $packet = $this->use_request_id ?
             pack('NCNa*', strlen($data) + 5, $type, $request_id, $data) :
@@ -3331,6 +3332,7 @@ class SFTP extends SSH2
         // in SSH2.php the timeout is cumulative per function call. eg. exec() will
         // timeout after 10s. but for SFTP.php it's cumulative per packet
         $this->curTimeout = $this->timeout;
+        $this->is_timeout = false;
 
         $start = microtime(true);
 

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1748,7 +1748,6 @@ class SSH2
 
                 $response = $this->get_binary_packet_or_close(NET_SSH2_MSG_KEXDH_GEX_GROUP);
                 list($type, $primeBytes, $gBytes) = Strings::unpackSSH2('Css', $response);
-
                 $this->updateLogHistory('NET_SSH2_MSG_KEXDH_REPLY', 'NET_SSH2_MSG_KEXDH_GEX_GROUP');
                 $prime = new BigInteger($primeBytes, -256);
                 $g = new BigInteger($gBytes, -256);
@@ -2412,7 +2411,6 @@ class SSH2
         $this->send_binary_packet($packet, $logged);
 
         $response = $this->get_binary_packet_or_close();
-
         list($type) = Strings::unpackSSH2('C', $response);
         switch ($type) {
             case NET_SSH2_MSG_USERAUTH_PASSWD_CHANGEREQ: // in theory, the password can be changed
@@ -4023,7 +4021,10 @@ class SSH2
                 }
                 return true;
             }
-            list($type, $channel) = Strings::unpackSSH2('CN', $response);
+            list($type) = Strings::unpackSSH2('C', $response);
+            if (strlen($response) >= 4) {
+                list($channel) = Strings::unpackSSH2('N', $response);
+            }
 
             // will not be setup yet on incoming channel open request
             if (isset($channel) && isset($this->channel_status[$channel]) && isset($this->window_size_server_to_client[$channel])) {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -4481,12 +4481,14 @@ class SSH2
     protected function send_channel_packet($client_channel, $data)
     {
         while (strlen($data)) {
-            while (!$this->window_size_client_to_server[$client_channel]) {
-                if ($this->isTimeout()) {
-                    throw new TimeoutException('Timed out waiting for server');
-                }
+            if (!$this->window_size_client_to_server[$client_channel]) {
                 // using an invalid channel will let the buffers be built up for the valid channels
                 $this->get_channel_packet(-$client_channel);
+                if ($this->isTimeout()) {
+                    throw new TimeoutException('Timed out waiting for server');
+                } elseif (!$this->window_size_client_to_server[$client_channel]) {
+                    throw new \RuntimeException('Client to server window was not adjusted');
+                }
             }
 
             /* The maximum amount of data allowed is determined by the maximum

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2678,11 +2678,11 @@ class SSH2
         $packet = $part1 . chr(0) . $part2;
         $this->send_binary_packet($packet);
 
-        $response = $this->get_binary_packet_or_close([
+        $response = $this->get_binary_packet_or_close(
             NET_SSH2_MSG_USERAUTH_SUCCESS,
             NET_SSH2_MSG_USERAUTH_FAILURE,
             NET_SSH2_MSG_USERAUTH_PK_OK,
-        ]);
+        );
 
         list($type) = Strings::unpackSSH2('C', $response);
         switch ($type) {
@@ -2715,10 +2715,10 @@ class SSH2
 
         $this->send_binary_packet($packet);
 
-        $response = $this->get_binary_packet_or_close([
+        $response = $this->get_binary_packet_or_close(
             NET_SSH2_MSG_USERAUTH_SUCCESS,
             NET_SSH2_MSG_USERAUTH_FAILURE,
-        ]);
+        );
 
         list($type) = Strings::unpackSSH2('C', $response);
         switch ($type) {
@@ -3486,18 +3486,15 @@ class SSH2
     /**
      * Retrieves the next packet with added timeout and type handling
      *
-     * @param string|string[]|null $message_types Message types to enforce in response, closing if not met
+     * @param string $message_types Message types to enforce in response, closing if not met
      * @return string
      * @throws ConnectionClosedException If an error has occurred preventing read of the next packet
      */
-    private function get_binary_packet_or_close($message_types = null)
+    private function get_binary_packet_or_close(...$message_types)
     {
-        if (is_int($message_types)) {
-            $message_types = [$message_types];
-        }
         try {
             $packet = $this->get_binary_packet();
-            if (is_array($message_types) && !in_array(ord($packet[0]), $message_types)) {
+            if (count($message_types) > 0 && !in_array(ord($packet[0]), $message_types)) {
                 $this->disconnect_helper(NET_SSH2_DISCONNECT_PROTOCOL_ERROR);
                 throw new ConnectionClosedException('Bad message type. Expected: #'
                     . implode(', #', $message_types) . '. Got: #' . ord($packet[0]));

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2681,7 +2681,7 @@ class SSH2
         $response = $this->get_binary_packet_or_close(
             NET_SSH2_MSG_USERAUTH_SUCCESS,
             NET_SSH2_MSG_USERAUTH_FAILURE,
-            NET_SSH2_MSG_USERAUTH_PK_OK,
+            NET_SSH2_MSG_USERAUTH_PK_OK
         );
 
         list($type) = Strings::unpackSSH2('C', $response);
@@ -2717,7 +2717,7 @@ class SSH2
 
         $response = $this->get_binary_packet_or_close(
             NET_SSH2_MSG_USERAUTH_SUCCESS,
-            NET_SSH2_MSG_USERAUTH_FAILURE,
+            NET_SSH2_MSG_USERAUTH_FAILURE
         );
 
         list($type) = Strings::unpackSSH2('C', $response);

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -12,7 +12,6 @@ use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\InsufficientSetupException;
 use phpseclib3\Exception\TimeoutException;
 use phpseclib3\Net\SSH2;
-use phpseclib3\Net\SSH2\MessageType;
 use phpseclib3\Tests\PhpseclibTestCase;
 
 class SSH2UnitTest extends PhpseclibTestCase
@@ -291,7 +290,7 @@ class SSH2UnitTest extends PhpseclibTestCase
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')
-            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, 'hello world'));
+            ->with(Strings::packSSH2('CNs', NET_SSH2_MSG_CHANNEL_DATA, 1, 'hello world'));
         self::setVar($ssh, 'server_channels', [1 => 1]);
         self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
         self::setVar($ssh, 'window_size_client_to_server', [1 => 0]);
@@ -318,7 +317,7 @@ class SSH2UnitTest extends PhpseclibTestCase
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')
-            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, ' world'));
+            ->with(Strings::packSSH2('CNs', NET_SSH2_MSG_CHANNEL_DATA, 1, ' world'));
         self::setVar($ssh, 'channel_buffers_write', [1 => 'hello']);
         self::setVar($ssh, 'server_channels', [1 => 1]);
         self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
@@ -349,7 +348,7 @@ class SSH2UnitTest extends PhpseclibTestCase
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')
-            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, 'hello'));
+            ->with(Strings::packSSH2('CNs', NET_SSH2_MSG_CHANNEL_DATA, 1, 'hello'));
         self::setVar($ssh, 'server_channels', [1 => 1]);
         self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
         self::setVar($ssh, 'window_size_client_to_server', [1 => 5]);

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -8,8 +8,11 @@
 
 namespace phpseclib3\Tests\Unit\Net;
 
+use phpseclib3\Common\Functions\Strings;
 use phpseclib3\Exception\InsufficientSetupException;
+use phpseclib3\Exception\TimeoutException;
 use phpseclib3\Net\SSH2;
+use phpseclib3\Net\SSH2\MessageType;
 use phpseclib3\Tests\PhpseclibTestCase;
 
 class SSH2UnitTest extends PhpseclibTestCase
@@ -269,6 +272,116 @@ class SSH2UnitTest extends PhpseclibTestCase
         $ssh->setKeepAlive(2);
         self::setVar($ssh, 'last_packet', microtime(true) - 2);
         $this->assertEquals([0, 0], self::callFunc($ssh, 'get_stream_timeout'));
+    }
+
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testSendChannelPacketNoBufferedData()
+    {
+        $ssh = $this->getMockBuilder('phpseclib3\Net\SSH2')
+            ->disableOriginalConstructor()
+            ->setMethods(['get_channel_packet', 'send_binary_packet'])
+            ->getMock();
+        $ssh->expects($this->once())
+            ->method('get_channel_packet')
+            ->with(-1)
+            ->willReturnCallback(function () use ($ssh) {
+                self::setVar($ssh, 'window_size_client_to_server', [1 => 0x7FFFFFFF]);
+            });
+        $ssh->expects($this->once())
+            ->method('send_binary_packet')
+            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, 'hello world'));
+        self::setVar($ssh, 'server_channels', [1 => 1]);
+        self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
+        self::setVar($ssh, 'window_size_client_to_server', [1 => 0]);
+        self::setVar($ssh, 'window_size_server_to_client', [1 => 0x7FFFFFFF]);
+
+        self::callFunc($ssh, 'send_channel_packet', [1, 'hello world']);
+        $this->assertEmpty(self::getVar($ssh, 'channel_buffers_write'));
+    }
+
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testSendChannelPacketBufferedData()
+    {
+        $ssh = $this->getMockBuilder('phpseclib3\Net\SSH2')
+            ->disableOriginalConstructor()
+            ->setMethods(['get_channel_packet', 'send_binary_packet'])
+            ->getMock();
+        $ssh->expects($this->once())
+            ->method('get_channel_packet')
+            ->with(-1)
+            ->willReturnCallback(function () use ($ssh) {
+                self::setVar($ssh, 'window_size_client_to_server', [1 => 0x7FFFFFFF]);
+            });
+        $ssh->expects($this->once())
+            ->method('send_binary_packet')
+            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, ' world'));
+        self::setVar($ssh, 'channel_buffers_write', [1 => 'hello']);
+        self::setVar($ssh, 'server_channels', [1 => 1]);
+        self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
+        self::setVar($ssh, 'window_size_client_to_server', [1 => 0]);
+        self::setVar($ssh, 'window_size_server_to_client', [1 => 0x7FFFFFFF]);
+
+        self::callFunc($ssh, 'send_channel_packet', [1, 'hello world']);
+        $this->assertEmpty(self::getVar($ssh, 'channel_buffers_write'));
+    }
+
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testSendChannelPacketTimeout()
+    {
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('Timed out waiting for server');
+
+        $ssh = $this->getMockBuilder('phpseclib3\Net\SSH2')
+            ->disableOriginalConstructor()
+            ->setMethods(['get_channel_packet', 'send_binary_packet'])
+            ->getMock();
+        $ssh->expects($this->once())
+            ->method('get_channel_packet')
+            ->with(-1)
+            ->willReturnCallback(function () use ($ssh) {
+                self::setVar($ssh, 'is_timeout', true);
+            });
+        $ssh->expects($this->once())
+            ->method('send_binary_packet')
+            ->with(Strings::packSSH2('CNs', MessageType::CHANNEL_DATA, 1, 'hello'));
+        self::setVar($ssh, 'server_channels', [1 => 1]);
+        self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
+        self::setVar($ssh, 'window_size_client_to_server', [1 => 5]);
+        self::setVar($ssh, 'window_size_server_to_client', [1 => 0x7FFFFFFF]);
+
+        self::callFunc($ssh, 'send_channel_packet', [1, 'hello world']);
+        $this->assertEquals([1 => 'hello'], self::getVar($ssh, 'channel_buffers_write'));
+    }
+
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testSendChannelPacketNoWindowAdjustment()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Data window was not adjusted');
+
+        $ssh = $this->getMockBuilder('phpseclib3\Net\SSH2')
+            ->disableOriginalConstructor()
+            ->setMethods(['get_channel_packet', 'send_binary_packet'])
+            ->getMock();
+        $ssh->expects($this->once())
+            ->method('get_channel_packet')
+            ->with(-1);
+        $ssh->expects($this->never())
+            ->method('send_binary_packet');
+        self::setVar($ssh, 'server_channels', [1 => 1]);
+        self::setVar($ssh, 'packet_size_client_to_server', [1 => 0x7FFFFFFF]);
+        self::setVar($ssh, 'window_size_client_to_server', [1 => 0]);
+        self::setVar($ssh, 'window_size_server_to_client', [1 => 0x7FFFFFFF]);
+
+        self::callFunc($ssh, 'send_channel_packet', [1, 'hello world']);
     }
 
     /**


### PR DESCRIPTION
This is meant to address #2014 and is a follow-on to #2006, which modified the contract of `get_binary_packet` when timeout events occur (now returning `true` where previously either `true` or a `ConnectionClosedException` would be thrown).

With this change, `get_binary_packet` is modified to always return a `string` representing the next packet or to throw an exception in the event that it cannot. A new `TimeoutException` is introduced and thrown in the respective event while waiting for the next packet.

In order to maintain current behavior of most callers of `get_binary_packet`, a helper `get_binary_packet_or_close` is introduced which handles timeout exceptions by closing the connection and throwing a `ConnectionClosedException` instead. This helper also enables callers to set a message type expectation on the retrieved packet, and to close the connection when not met, a common pattern throughout.