### PR TITLE
Fixed the IEEE signature format error that caused variable length sig…

### DIFF
--- a/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
@@ -28,6 +28,8 @@ use phpseclib3\Math\BigInteger;
  */
 abstract class IEEE
 {
+    const PART_LENGTH = 66;
+
     /**
      * Loads a signature
      *
@@ -58,7 +60,7 @@ abstract class IEEE
     {
         $r = $r->toBytes();
         $s = $s->toBytes();
-        $len = max(strlen($r), strlen($s));
+        $len = static::PART_LENGTH;
         return str_pad($r, $len, "\0", STR_PAD_LEFT) . str_pad($s, $len, "\0", STR_PAD_LEFT);
     }
 }

--- a/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
@@ -28,7 +28,7 @@ use phpseclib3\Math\BigInteger;
  */
 abstract class IEEE
 {
-    const PART_LENGTH = 66;
+    const PART_LENGTHS = [32, 48, 66];
 
     /**
      * Loads a signature
@@ -60,7 +60,11 @@ abstract class IEEE
     {
         $r = $r->toBytes();
         $s = $s->toBytes();
-        $len = static::PART_LENGTH;
+        $min = max(strlen($r), strlen($s));
+        $len = array_reduce(static::PART_LENGTHS, function ($accumulator, $item) use ($min) {
+            return $item >= $min && (null === $accumulator || $item < $accumulator) ? $item : $accumulator;
+        });
+
         return str_pad($r, $len, "\0", STR_PAD_LEFT) . str_pad($s, $len, "\0", STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
IEEE signature format [specs](https://datatracker.ietf.org/doc/html/rfc4754#section-7) state that

> The bit lengths of r and s are enforced, if necessary, by pre-pending
   the value with zeros.

The valid bit lengths, when converted to bytes, are 32, 48 and 66 depending on the algorithm. Without knowing the algorithm, we choose the smallest option that is bigger than both r and s values.