### PR TITLE
Fixed IEEE signature format non-fixed length signature problem

### DIFF
--- a/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
+++ b/phpseclib/Crypt/EC/Formats/Signature/IEEE.php
@@ -26,6 +26,8 @@ use phpseclib3\Math\BigInteger;
  */
 abstract class IEEE
 {
+    const PART_LENGTHS = [32, 48, 66];
+
     /**
      * Loads a signature
      *
@@ -60,7 +62,11 @@ abstract class IEEE
     {
         $r = $r->toBytes();
         $s = $s->toBytes();
-        $len = max(strlen($r), strlen($s));
+        $minLength = max(strlen($r), strlen($s));
+        $len = array_reduce(static::PART_LENGTHS, function ($accumulator, $item) use ($minLength) {
+            return $item >= $minLength && (null === $accumulator || $item < $accumulator) ? $item : $accumulator;
+        });
+
         return str_pad($r, $len, "\0", STR_PAD_LEFT) . str_pad($s, $len, "\0", STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
IEEE signature format as referred [here](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) is proposed as following [RFC-4754 specs](https://datatracker.ietf.org/doc/html/rfc4754#section-7).

The specs state

>  The bit lengths of r and s are enforced, if necessary, by pre-pending
   the value with zeros.

In order to fully adhere to these specs, we need to pad the r and s values with zeros up to either 256, 384 or 528 bits (32, 48, or 66 bytes respectively).

I implemented the logic that chooses the smallest of these options that is bigger than both the r and s values.