### PR TITLE
SSH2: Defer to default socket timeout in absence of more specific value

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -2747,7 +2747,7 @@ class SSH2
      * Set Timeout
      *
      * $ssh->exec('ping 127.0.0.1'); on a Linux host will never return and will run indefinitely.  setTimeout() makes it so it'll timeout.
-     * Setting $timeout to false or 0 will mean there is no timeout.
+     * Setting $timeout to false or 0 will revert to the default socket timeout.
      *
      * @param mixed $timeout
      */
@@ -3462,11 +3462,11 @@ class SSH2
     }
 
     /**
-     * @return int[] second and microsecond stream timeout options based on user-requested timeout and keep-alive, 0 by default
+     * @return int[] second and microsecond stream timeout options based on user-requested timeout and keep-alive, or the default socket timeout by default, which mirrors PHP socket streams.
      */
     private function get_stream_timeout()
     {
-        $sec = 0;
+        $sec = ini_get('default_socket_timeout');
         $usec = 0;
         if ($this->curTimeout > 0) {
             $sec = (int) floor($this->curTimeout);

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -228,9 +228,10 @@ class SSH2UnitTest extends PhpseclibTestCase
      */
     public function testGetStreamTimeout()
     {
+        $default = ini_get('default_socket_timeout');
         // no curTimeout, no keepAlive
         $ssh = $this->createSSHMock();
-        $this->assertEquals([0, 0], self::callFunc($ssh, 'get_stream_timeout'));
+        $this->assertEquals([$default, 0], self::callFunc($ssh, 'get_stream_timeout'));
 
         // curTimeout, no keepAlive
         $ssh = $this->createSSHMock();


### PR DESCRIPTION
Attempting to address #2020, this issue formalizes the implied behavior prior to #1999 regarding PHP stream timeouts, by defaulting to PHP's `default_socket_timeout` for stream read functions when the user has not requested a timeout or keep-alive interval. This change mirrors the default timeout behavior of PHP socket streams, as evidenced [here](https://github.com/php/php-src/blob/master/main/streams/xp_socket.c#L964), and thus the behavior prior to #1999 changes, when `stream_set_timeout` was conditionally invoked. It is noteworthy that the prior implementation would not permit an update to remove a timeout via `SSH2:setTimeout`, given the conditional invocation of `stream_set_timeout`, now supported.

The following simple test confirms the underlying use of the default socket timeout when `stream_set_timeout` is never invoked, as execution terminates after 10 seconds, as defined.
```
<?php
$start = time();
ini_set('default_socket_timeout', 10);
$fsock = fsockopen('127.0.0.1', 22);
stream_get_contents($fsock);
printf("Time: %d", (time() - $start));
```