### PR TITLE
Prevent loops during disconnect

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -104,6 +104,7 @@ class SSH2
     const MASK_LOGIN_REQ     = 0x00000004;
     const MASK_LOGIN         = 0x00000008;
     const MASK_SHELL         = 0x00000010;
+    const MASK_DISCONNECT    = 0x00000020;
 
     /*
      * Channel constants
@@ -4593,7 +4594,12 @@ class SSH2
      */
     protected function disconnect_helper($reason)
     {
-        if ($this->bitmap & self::MASK_CONNECTED) {
+        if ($this->bitmap & self::MASK_DISCONNECT) {
+            // Disregard subsequent disconnect requests
+            return false;
+        }
+        $this->bitmap |= self::MASK_DISCONNECT;
+        if ($this->isConnected()) {
             $data = Strings::packSSH2('CNss', NET_SSH2_MSG_DISCONNECT, $reason, '', '');
             try {
                 $this->send_binary_packet($data);

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -34,6 +34,24 @@ class SSH2UnitTest extends PhpseclibTestCase
     }
 
     /**
+     * @requires PHPUnit < 10
+     * Verify that MASK_* constants remain distinct
+     */
+    public function testBitmapMasks()
+    {
+        $reflection = new \ReflectionClass(SSH2::class);
+        $masks = array_filter($reflection->getConstants(), function ($k) {
+            return strpos($k, 'MASK_') === 0;
+        }, ARRAY_FILTER_USE_KEY);
+        $bitmap = 0;
+        foreach ($masks as $mask => $bit) {
+            $this->assertEquals(0, $bitmap & $bit, "Got unexpected mask {$mask}");
+            $bitmap |= $bit;
+            $this->assertEquals($bit, $bitmap & $bit, "Absent expected mask {$mask}");
+        }
+    }
+
+    /**
      * @dataProvider formatLogDataProvider
      * @requires PHPUnit < 10
      */
@@ -382,6 +400,31 @@ class SSH2UnitTest extends PhpseclibTestCase
         self::setVar($ssh, 'window_size_server_to_client', [1 => 0x7FFFFFFF]);
 
         self::callFunc($ssh, 'send_channel_packet', [1, 'hello world']);
+    }
+
+    /**
+     * @requires PHPUnit < 10
+     */
+    public function testDisconnectHelper()
+    {
+        $ssh = $this->getMockBuilder('phpseclib3\Net\SSH2')
+            ->disableOriginalConstructor()
+            ->setMethods(['__destruct', 'isConnected', 'send_binary_packet'])
+            ->getMock();
+        $ssh->expects($this->once())
+            ->method('isConnected')
+            ->willReturn(true);
+        $ssh->expects($this->once())
+            ->method('send_binary_packet')
+            ->with($this->isType('string'))
+            ->willReturnCallback(function () use ($ssh) {
+                self::callFunc($ssh, 'disconnect_helper', [1]);
+                throw new \Exception('catch me');
+            });
+
+        $this->assertEquals(0, self::getVar($ssh, 'bitmap'));
+        self::callFunc($ssh, 'disconnect_helper', [1]);
+        $this->assertEquals(0, self::getVar($ssh, 'bitmap'));
     }
 
     /**


### PR DESCRIPTION
This attempts to address #2030 where it was reported the potential to enter an infinite loop while disconnecting, seemingly due to an absent check for a closed/eof socket prior to issuing a final DISCONNECT message. This change prevents sending said DISCONNECT message on a closed socket, and also adds further protection for looping for other possible error paths.