### PR TITLE
Set up ECS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,8 @@ jobs:
                     update: true
             -   name: Composer Install
                 run: composer install --classmap-authoritative --no-interaction --no-cache
-            -   name: PHP_CodeSniffer
-                run: vendor/bin/phpcs --standard=build/php_codesniffer.xml
-            -   name: PHP CS Fixer
-                run: vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --dry-run --using-cache=no
+            -   name: ECS
+                run: vendor/bin/ecs
             -   name: Psalm
                 run: vendor/bin/psalm --config=build/psalm.xml --no-cache --long-progress --report-show-info=false
         strategy:

--- a/composer.json
+++ b/composer.json
@@ -63,9 +63,8 @@
     "require-dev": {
         "ext-xml": "*",
         "brianium/paratest": "^6.6",
-        "friendsofphp/php-cs-fixer": "^3.12",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "squizlabs/php_codesniffer": "^3.7",
+        "symplify/easy-coding-standard": "^12.3",
         "vimeo/psalm": "^4.29"
     },
     "suggest": {
@@ -92,10 +91,6 @@
     },
     "scripts": {
         "lint": "vendor/bin/parallel-lint --show-deprecated build phpseclib tests",
-        "php_codesniffer": "vendor/bin/phpcs --standard=build/php_codesniffer.xml",
-        "php_codesniffer-fix": "vendor/bin/phpcbf --standard=build/php_codesniffer.xml",
-        "php-cs-fixer": "vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --using-cache=no --dry-run",
-        "php-cs-fixer-fix": "vendor/bin/php-cs-fixer fix --config=build/php-cs-fixer.php --diff --using-cache=no",
         "psalm": "vendor/bin/psalm --config=build/psalm.xml --no-cache --long-progress --threads=4",
         "psalm-set-baseline": "vendor/bin/psalm --config=build/psalm.xml --no-cache --long-progress --set-baseline=psalm_baseline.xml --threads=4",
         "test": "vendor/bin/paratest --verbose --configuration=tests/phpunit.xml --runner=WrapperRunner",
@@ -105,6 +100,8 @@
             "@php-cs-fixer",
             "@psalm",
             "@test"
-        ]
+        ],
+        "check-cs": "vendor/bin/ecs check --ansi",
+        "fix-cs": "vendor/bin/ecs check --fix --ansi"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -96,8 +96,7 @@
         "test": "vendor/bin/paratest --verbose --configuration=tests/phpunit.xml --runner=WrapperRunner",
         "all-quality-tools": [
             "@lint",
-            "@phpcs",
-            "@php-cs-fixer",
+            "@check-cs",
             "@psalm",
             "@test"
         ],

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([__DIR__ . '/phpseclib', __DIR__ . '/tests'])
+    ->withRootFiles()
+    ->withPhpCsFixerSets(perCS20: true)
+;


### PR DESCRIPTION
This PR sets up ECS (https://github.com/easy-coding-standard/easy-coding-standard)
to use PER2 coding style.

https://www.php-fig.org/per/coding-style


Before this is merged, but after it is reviewed, a maintainer should run the following commands:
1. Checkout this PR branch
2. Run `composer install`
3. Run `composer fix-cs`, see that there are 174 changed files.
4. Run `git commit -a -m "chore(cs): initial PER2 formatting" -n`
5. Run `git push`


This makes sure that the big unreviewable change of transforming all files is done by a trusted user.