### PR TITLE
fix deprecated

### DIFF
--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -3362,7 +3362,7 @@ class X509
      *
      * @param array $csr optional
      */
-    public function getRequestedCertificateExtensions(array $csr = null)
+    public function getRequestedCertificateExtensions(?array $csr = null)
     {
         if (empty($csr)) {
             $csr = $this->currentCert;


### PR DESCRIPTION
Deprecated: phpseclib3\File\X509::getRequestedCertificateExtensions(): Implicitly marking parameter $csr as nullable is deprecated, the explicit nullable type must be used instead

fixed this for PHP8.4