### PR TITLE
Ensure that users of PHP 8.2.26-nmm1 users don't utilize the GMP functions to prevent base and exponent error from occurring

### DIFF
--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -249,7 +249,7 @@ class Math_BigInteger
             // https://github.com/php/php-src/commit/e0a0e216a909dc4ee4ea7c113a5f41d49525f02e broke GMP
             // https://github.com/php/php-src/commit/424ba0f2ff9677d16b4e339e90885bd4bc49fcf1 fixed it
             // see https://github.com/php/php-src/issues/16870 for more info
-            if (version_compare(PHP_VERSION, '8.2.26', '<')) {
+            if (version_compare(PHP_VERSION, '8.2.25', '<=')) {
                 $gmpOK = true;
             } else {
                 $gmpOK = !in_array(PHP_VERSION_ID, array(80226, 80314, 80400, 80401));


### PR DESCRIPTION
It appears that PHP 8.2.26-nmm1 users are still experiencing the "base and exponent overflow" issue during the call to `gmp_pow()` function

PHP 8.2.26-nmm1 is considered lower than PHP 8.2.26 thus GMP extension will be used for arbitrary-length integer operations. Therefore, we'd like to propose a change in this PR.