### PR TITLE
Remove extract function - Possible Variable Overwrite

### DIFF
--- a/phpseclib/Common/Functions/Strings.php
+++ b/phpseclib/Common/Functions/Strings.php
@@ -119,7 +119,7 @@ abstract class Strings
                     // 64-bit floats can be used to get larger numbers then 32-bit signed ints would allow
                     // for. sure, you're not gonna get the full precision of 64-bit numbers but just because
                     // you need > 32-bit precision doesn't mean you need the full 64-bit precision
-                    extract(unpack('Nupper/Nlower', self::shift($data, 8)));
+                    ['upper' => $upper, 'lower' => $lower] = unpack('Nupper/Nlower', self::shift($data, 8));
                     $temp = $upper ? 4294967296 * $upper : 0;
                     $temp += $lower < 0 ? ($lower & 0x7FFFFFFFF) + 0x80000000 : $lower;
                     // $temp = hexdec(bin2hex(self::shift($data, 8)));

--- a/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PuTTY.php
@@ -186,7 +186,7 @@ abstract class PuTTY
 
         $source = Strings::packSSH2('ssss', $type, $encryption, $components['comment'], $public);
 
-        extract(unpack('Nlength', Strings::shift($public, 4)));
+        ['length' => $length] = unpack('Nlength', Strings::shift($public, 4));
         $newtype = Strings::shift($public, $length);
         if ($newtype != $type) {
             throw new RuntimeException('The binary type does not match the human readable type field');
@@ -214,7 +214,11 @@ abstract class PuTTY
                         $parallelism = trim(preg_replace('#Argon2-Parallelism: (\d+)#', '$1', $key[$offset++]));
                         $salt = Strings::hex2bin(trim(preg_replace('#Argon2-Salt: ([0-9a-f]+)#', '$1', $key[$offset++])));
 
-                        extract(self::generateV3Key($password, $flavour, (int)$memory, (int)$passes, $salt));
+                        [
+                            'symkey' => $symkey,
+                            'symiv' => $symiv,
+                            'hashkey' => $hashkey
+                        ] = self::generateV3Key($password, $flavour, (int)$memory, (int)$passes, $salt);
 
                         break;
                     case 2:
@@ -306,7 +310,11 @@ abstract class PuTTY
                     $key .= "Argon2-Passes: 13\r\n";
                     $key .= "Argon2-Parallelism: 1\r\n";
                     $key .= "Argon2-Salt: " . Strings::bin2hex($salt) . "\r\n";
-                    extract(self::generateV3Key($password, 'Argon2id', 8192, 13, $salt));
+                    [
+                        'symkey' => $symkey,
+                        'symiv' => $symiv,
+                        'hashkey' => $hashkey
+                    ] = self::generateV3Key($password, 'Argon2id', 8192, 13, $salt);
 
                     $hash = new Hash('sha256');
                     $hash->setKey($hashkey);

--- a/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
@@ -59,7 +59,12 @@ abstract class PuTTY extends Progenitor
         if (!isset($components['private'])) {
             return $components;
         }
-        extract($components);
+        [
+            'type' => $type,
+            'comment' => $comment,
+            'public' => $public,
+            'private' => $private
+        ] = $components;
         unset($components['public'], $components['private']);
 
         [$p, $q, $g, $y] = Strings::unpackSSH2('iiii', $public);

--- a/phpseclib/Crypt/DSA/PrivateKey.php
+++ b/phpseclib/Crypt/DSA/PrivateKey.php
@@ -88,7 +88,7 @@ final class PrivateKey extends DSA implements Common\PrivateKey
                     return $signature;
                 }
 
-                extract(ASN1Signature::load($signature));
+                ['r' => $r, 's' => $s] = ASN1Signature::load($signature);
 
                 return $format::save($r, $s);
             }

--- a/phpseclib/Crypt/DSA/PublicKey.php
+++ b/phpseclib/Crypt/DSA/PublicKey.php
@@ -41,7 +41,7 @@ final class PublicKey extends DSA implements Common\PublicKey
         if ($params === false || count($params) != 2) {
             return false;
         }
-        extract($params);
+        ['r' => $r, 's' => $s] = $params;
 
         if (self::$engines['OpenSSL'] && in_array($this->hash->getHash(), openssl_get_md_methods())) {
             $sig = $format != 'ASN1' ? ASN1Signature::save($r, $s) : $signature;

--- a/phpseclib/Crypt/EC/PrivateKey.php
+++ b/phpseclib/Crypt/EC/PrivateKey.php
@@ -156,7 +156,7 @@ final class PrivateKey extends EC implements Common\PrivateKey
                     return $signature;
                 }
 
-                extract(ASN1Signature::load($signature));
+                ['r' => $r, 's' => $s] = ASN1Signature::load($signature);
 
                 return $this->formatSignature($r, $s);
             }

--- a/phpseclib/Crypt/EC/PublicKey.php
+++ b/phpseclib/Crypt/EC/PublicKey.php
@@ -116,7 +116,7 @@ final class PublicKey extends EC implements Common\PublicKey
         if ($params === false || count($params) != 2) {
             return false;
         }
-        extract($params);
+        ['r' => $r, 's' => $s] = $params;
 
         if (self::$engines['OpenSSL'] && in_array($this->hash->getHash(), openssl_get_md_methods())) {
             $sig = $format != 'ASN1' ? ASN1Signature::save($r, $s) : $signature;

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -353,9 +353,6 @@ abstract class RSA extends AsymmetricKey
                     $primes[$i] = BigInteger::randomPrime($regSize);
                 } else {
                     ['min' => $min, 'max' => $max] = BigInteger::minMaxBits($bits);
-                    /** @var BigInteger $min
-                     *  @var BigInteger $max
-                     */
                     [$min] = $min->divide($n);
                     $min = $min->add(self::$one);
                     [$max] = $max->divide($n);

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -352,7 +352,7 @@ abstract class RSA extends AsymmetricKey
                 if ($i != $num_primes) {
                     $primes[$i] = BigInteger::randomPrime($regSize);
                 } else {
-                    extract(BigInteger::minMaxBits($bits));
+                    ['min' => $min, 'max' => $max] = BigInteger::minMaxBits($bits);
                     /** @var BigInteger $min
                      *  @var BigInteger $max
                      */

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -83,7 +83,12 @@ abstract class MSBLOB
 
         // PUBLICKEYSTRUC  publickeystruc
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa387453(v=vs.85).aspx
-        extract(unpack('atype/aversion/vreserved/Valgo', Strings::shift($key, 8)));
+        [
+            'type' => $type,
+            'version' => $version,
+            'reserved' => $reserved,
+            'algo' => $algo
+        ] = unpack('atype/aversion/vreserved/Valgo', Strings::shift($key, 8));
         /**
          * @var string $type
          * @var string $version
@@ -116,7 +121,11 @@ abstract class MSBLOB
         // RSAPUBKEY rsapubkey
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa387685(v=vs.85).aspx
         // could do V for pubexp but that's unsigned 32-bit whereas some PHP installs only do signed 32-bit
-        extract(unpack('Vmagic/Vbitlen/a4pubexp', Strings::shift($key, 12)));
+        [
+            'magic' => $magic,
+            'bitlen' => $bitlen,
+            'pubexp' => $pubexp
+        ] = unpack('Vmagic/Vbitlen/a4pubexp', Strings::shift($key, 12));
         /**
          * @var integer $magic
          * @var integer $bitlen

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -89,12 +89,6 @@ abstract class MSBLOB
             'reserved' => $reserved,
             'algo' => $algo
         ] = unpack('atype/aversion/vreserved/Valgo', Strings::shift($key, 8));
-        /**
-         * @var string $type
-         * @var string $version
-         * @var integer $reserved
-         * @var integer $algo
-         */
         switch (ord($type)) {
             case self::PUBLICKEYBLOB:
             case self::PUBLICKEYBLOBEX:
@@ -126,11 +120,6 @@ abstract class MSBLOB
             'bitlen' => $bitlen,
             'pubexp' => $pubexp
         ] = unpack('Vmagic/Vbitlen/a4pubexp', Strings::shift($key, 12));
-        /**
-         * @var integer $magic
-         * @var integer $bitlen
-         * @var string $pubexp
-         */
         switch ($magic) {
             case self::RSA2:
                 $components['isPublicKey'] = false;

--- a/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
@@ -60,7 +60,12 @@ abstract class PuTTY extends Progenitor
         if (!isset($components['private'])) {
             return $components;
         }
-        extract($components);
+        [
+            'type' => $type,
+            'comment' => $comment,
+            'public' => $public,
+            'private' => $private
+        ] = $components;
         unset($components['public'], $components['private']);
 
         $isPublicKey = false;

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -272,7 +272,7 @@ abstract class ASN1
             // tags of indefinte length don't really have a header length; this length includes the tag
             $current += ['headerlength' => $length + 2];
             $start += $length;
-            extract(unpack('Nlength', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4)));
+            ['length' => $length] = unpack('Nlength', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
             /** @var integer $length */
         } else {
             $current += ['headerlength' => 2];

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -273,7 +273,6 @@ abstract class ASN1
             $current += ['headerlength' => $length + 2];
             $start += $length;
             ['length' => $length] = unpack('Nlength', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4));
-            /** @var integer $length */
         } else {
             $current += ['headerlength' => 2];
         }

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -613,7 +613,11 @@ class X509
         $extensions = &$this->subArray($root, $path, !empty($this->extensionValues));
 
         foreach ($this->extensionValues as $id => $data) {
-            extract($data);
+            [
+                'critical' => $critical,
+                'replace' => $replace,
+                'value' => $value
+            ] = $data;
             $newext = [
                 'extnId' => $id,
                 'extnValue' => $value,
@@ -1787,7 +1791,7 @@ class X509
                 $dn = $this->getDN(self::DN_CANON, $dn);
                 $hash = new Hash('sha1');
                 $hash = $hash->hash($dn);
-                extract(unpack('Vhash', $hash));
+                ['hash' => $hash] = unpack('Vhash', $hash);
                 return strtolower(Strings::bin2hex(pack('N', $hash)));
         }
 

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -309,7 +309,7 @@ class BigInteger implements \JsonSerializable
      */
     public function extendedGCD(BigInteger $n): array
     {
-        extract($this->value->extendedGCD($n->value));
+        ['gcd' => $gcd, 'x' => $x, 'y' => $y] = $this->value->extendedGCD($n->value);
         /**
          * @var BigInteger $gcd
          * @var BigInteger $x
@@ -550,7 +550,7 @@ class BigInteger implements \JsonSerializable
         self::initialize_static_variables();
 
         $class = self::$mainEngine;
-        extract($class::minMaxBits($bits));
+        ['min' => $min, 'max' => $max] = $class::minMaxBits($bits);
         /** @var BigInteger $min
          * @var BigInteger $max
          */

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -310,11 +310,6 @@ class BigInteger implements \JsonSerializable
     public function extendedGCD(BigInteger $n): array
     {
         ['gcd' => $gcd, 'x' => $x, 'y' => $y] = $this->value->extendedGCD($n->value);
-        /**
-         * @var BigInteger $gcd
-         * @var BigInteger $x
-         * @var BigInteger $y
-         */
         return [
             'gcd' => new static($gcd),
             'x' => new static($x),
@@ -551,9 +546,6 @@ class BigInteger implements \JsonSerializable
 
         $class = self::$mainEngine;
         ['min' => $min, 'max' => $max] = $class::minMaxBits($bits);
-        /** @var BigInteger $min
-         * @var BigInteger $max
-         */
         return [
             'min' => new static($min),
             'max' => new static($max),

--- a/phpseclib/Math/BigInteger/Engines/BCMath.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath.php
@@ -275,7 +275,6 @@ class BCMath extends Engine
     public function gcd(BCMath $n): BCMath
     {
         ['gcd' => $gcd] = $this->extendedGCD($n);
-        /** @var BCMath $gcd */
         return $gcd;
     }
 

--- a/phpseclib/Math/BigInteger/Engines/BCMath.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath.php
@@ -274,7 +274,7 @@ class BCMath extends Engine
      */
     public function gcd(BCMath $n): BCMath
     {
-        extract($this->extendedGCD($n));
+        ['gcd' => $gcd] = $this->extendedGCD($n);
         /** @var BCMath $gcd */
         return $gcd;
     }

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
@@ -92,7 +92,10 @@ abstract class Barrett extends Base
                 'm1' => $m1, // m.length
             ];
         } else {
-            extract($cache[self::DATA][$key]);
+            [
+                'u' => $u,
+                'm1' => $m1
+            ] = $cache[self::DATA][$key];
         }
 
         $cutoff = $m_length + ($m_length >> 1);

--- a/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -312,10 +312,6 @@ abstract class Engine implements \JsonSerializable
         }
 
         ['gcd' => $gcd, 'x' => $x] = $this->extendedGCD($n);
-        /**
-         * @var Engine $gcd
-         * @var Engine $x
-         */
 
         if (!$gcd->equals(static::$one[static::class])) {
             return false;
@@ -707,10 +703,6 @@ abstract class Engine implements \JsonSerializable
     public static function random(int $size): Engine
     {
         ['min' => $min, 'max' => $max] = static::minMaxBits($size);
-        /**
-         * @var BigInteger $min
-         * @var BigInteger $max
-         */
         return static::randomRange($min, $max);
     }
 
@@ -722,10 +714,6 @@ abstract class Engine implements \JsonSerializable
     public static function randomPrime(int $size): Engine
     {
         ['min' => $min, 'max' => $max] = static::minMaxBits($size);
-        /**
-         * @var static $min
-         * @var static $max
-         */
         return static::randomRangePrime($min, $max);
     }
 

--- a/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -311,7 +311,7 @@ abstract class Engine implements \JsonSerializable
             return $this->normalize($n->subtract($temp));
         }
 
-        extract($this->extendedGCD($n));
+        ['gcd' => $gcd, 'x' => $x] = $this->extendedGCD($n);
         /**
          * @var Engine $gcd
          * @var Engine $x
@@ -706,7 +706,7 @@ abstract class Engine implements \JsonSerializable
      */
     public static function random(int $size): Engine
     {
-        extract(static::minMaxBits($size));
+        ['min' => $min, 'max' => $max] = static::minMaxBits($size);
         /**
          * @var BigInteger $min
          * @var BigInteger $max
@@ -721,7 +721,7 @@ abstract class Engine implements \JsonSerializable
      */
     public static function randomPrime(int $size): Engine
     {
-        extract(static::minMaxBits($size));
+        ['min' => $min, 'max' => $max] = static::minMaxBits($size);
         /**
          * @var static $min
          * @var static $max

--- a/phpseclib/Math/BigInteger/Engines/GMP.php
+++ b/phpseclib/Math/BigInteger/Engines/GMP.php
@@ -271,7 +271,11 @@ class GMP extends Engine
      */
     public function extendedGCD(GMP $n): array
     {
-        extract(gmp_gcdext($this->value, $n->value));
+        [
+            'g' => $g,
+            's' => $s,
+            't' => $t
+        ] = gmp_gcdext($this->value, $n->value);
 
         return [
             'gcd' => $this->normalize(new self($g)),

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
@@ -97,7 +97,10 @@ abstract class Barrett extends Base
                 'm1' => $m1, // m.length
             ];
         } else {
-            extract($cache[self::DATA][$key]);
+            [
+                'u' => $u,
+                'm1' => $m1
+            ] = $cache[self::DATA][$key];
         }
 
         $cutoff = $m_length + ($m_length >> 1);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3025,7 +3025,7 @@ class SFTP extends SSH2
         if (strlen($this->packet_buffer) < 4) {
             throw new RuntimeException('Packet is too small');
         }
-        extract(unpack('Nlength', Strings::shift($this->packet_buffer, 4)));
+        ['length' => $length] = unpack('Nlength', Strings::shift($this->packet_buffer, 4));
         /** @var integer $length */
 
         $tempLength = $length;
@@ -3056,7 +3056,7 @@ class SFTP extends SSH2
         $this->packet_type = ord(Strings::shift($this->packet_buffer));
 
         if ($this->use_request_id) {
-            extract(unpack('Npacket_id', Strings::shift($this->packet_buffer, 4))); // remove the request id
+            ['packet_id' => $packet_id] = unpack('Npacket_id', Strings::shift($this->packet_buffer, 4)); // remove the request id
             $length -= 5; // account for the request id and the packet type
         } else {
             $length -= 1; // account for the packet type

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3026,7 +3026,6 @@ class SFTP extends SSH2
             throw new RuntimeException('Packet is too small');
         }
         ['length' => $length] = unpack('Nlength', Strings::shift($this->packet_buffer, 4));
-        /** @var integer $length */
 
         $tempLength = $length;
         $tempLength -= strlen($this->packet_buffer);

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -126,29 +126,11 @@ class Stream
         $orig = $path;
         $url = parse_url($path) + ['port' => 22];
 
-        if (isset($url['scheme'])) {
-            $scheme = $url['scheme'];
-        }
-        if (isset($url['host'])) {
-            $host = $url['host'];
-        }
-        if (isset($url['port'])) {
-            $port = $url['port'];
-        }
-        if (isset($url['user'])) {
-            $user = $url['user'];
-        }
-        if (isset($url['pass'])) {
-            $pass = $url['pass'];
-        }
-        if (isset($url['path'])) {
-            $path = $url['path'];
-        }
-        if (isset($url['query'])) {
-            $query = $url['query'];
-        }
-        if (isset($url['fragment'])) {
-            $fragment = $url['fragment'];
+        $keys = ['scheme', 'host', 'port', 'user', 'pass', 'path', 'query', 'fragment'];
+        foreach ($keys as $key) {
+            if (isset($url[$key])) {
+                $$key = $url[$key];
+            }
         }
 
         if (isset($query)) {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -124,16 +124,33 @@ class Stream
     protected function parse_path(string $path)
     {
         $orig = $path;
-        [
-            'scheme' => $scheme,
-            'host' => $host,
-            'port' => $port,
-            'user' => $user,
-            'pass' => $pass,
-            'path' => $path,
-            'query' => $query,
-            'fragment' => $fragment
-        ] = parse_url($path) + ['port' => 22];
+        $url = parse_url($path) + ['port' => 22];
+
+        if (isset($url['scheme'])) {
+            $scheme = $url['scheme'];
+        }
+        if (isset($url['host'])) {
+            $host = $url['host'];
+        }
+        if (isset($url['port'])) {
+            $port = $url['port'];
+        }
+        if (isset($url['user'])) {
+            $user = $url['user'];
+        }
+        if (isset($url['pass'])) {
+            $pass = $url['pass'];
+        }
+        if (isset($url['path'])) {
+            $path = $url['path'];
+        }
+        if (isset($url['query'])) {
+            $query = $url['query'];
+        }
+        if (isset($url['fragment'])) {
+            $fragment = $url['fragment'];
+        }
+
         if (isset($query)) {
             $path .= '?' . $query;
         } elseif (preg_match('/(\?|\?#)$/', $orig)) {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -124,7 +124,16 @@ class Stream
     protected function parse_path(string $path)
     {
         $orig = $path;
-        extract(parse_url($path) + ['port' => 22]);
+        [
+            'scheme' => $scheme,
+            'host' => $host,
+            'port' => $port,
+            'user' => $user,
+            'pass' => $pass,
+            'path' => $path,
+            'query' => $query,
+            'fragment' => $fragment
+        ] = parse_url($path) + ['port' => 22];
         if (isset($query)) {
             $path .= '?' . $query;
         } elseif (preg_match('/(\?|\?#)$/', $orig)) {

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -3387,7 +3387,7 @@ class SSH2
         }
         $padding_length = 0;
         $payload = $packet->plain;
-        extract(unpack('Cpadding_length', Strings::shift($payload, 1)));
+        ['padding_length' => $padding_length] = unpack('Cpadding_length', Strings::shift($payload, 1));
         if ($padding_length > 0) {
             Strings::pop($payload, $padding_length);
         }
@@ -3479,13 +3479,13 @@ class SSH2
             switch ($this->decryptName) {
                 case 'aes128-gcm@openssh.com':
                 case 'aes256-gcm@openssh.com':
-                    extract(unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size)));
+                    ['packet_length' => $packet_length] = unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size));
                     $packet->size = $packet_length_header_size + $packet_length + $this->decrypt_block_size; // expect tag
                     break;
                 case 'chacha20-poly1305@openssh.com':
                     $this->lengthDecrypt->setNonce(pack('N2', 0, $this->get_seq_no));
                     $packet_length_header = $this->lengthDecrypt->decrypt(substr($packet->raw, 0, $packet_length_header_size));
-                    extract(unpack('Npacket_length', $packet_length_header));
+                    ['packet_length' => $packet_length] = unpack('Npacket_length', $packet_length_header);
                     $packet->size = $packet_length_header_size + $packet_length + 16; // expect tag
                     break;
                 default:
@@ -3494,17 +3494,17 @@ class SSH2
                             return;
                         }
                         $packet->plain = $this->decrypt->decrypt(substr($packet->raw, 0, $this->decrypt_block_size));
-                        extract(unpack('Npacket_length', Strings::shift($packet->plain, $packet_length_header_size)));
+                        ['packet_length' => $packet_length] = unpack('Npacket_length', Strings::shift($packet->plain, $packet_length_header_size));
                         $packet->size = $packet_length_header_size + $packet_length;
                         $added_validation_length = $packet_length_header_size;
                     } else {
-                        extract(unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size)));
+                        ['packet_length' => $packet_length] = unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size));
                         $packet->size = $packet_length_header_size + $packet_length;
                     }
                     break;
             }
         } else {
-            extract(unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size)));
+            ['packet_length' => $packet_length] = unpack('Npacket_length', substr($packet->raw, 0, $packet_length_header_size));
             $packet->size = $packet_length_header_size + $packet_length;
             $added_validation_length = $packet_length_header_size;
         }
@@ -3600,7 +3600,11 @@ class SSH2
             switch (ord($payload[0])) {
                 case MessageType::CHANNEL_REQUEST:
                     if (strlen($payload) == 31) {
-                        extract(unpack('cpacket_type/Nchannel/Nlength', $payload));
+                        [
+                            'packet_type' => $packet_type,
+                            'channel' => $channel,
+                            'length' => $length
+                        ] = unpack('cpacket_type/Nchannel/Nlength', $payload);
                         if (substr($payload, 9, $length) == 'keepalive@openssh.com' && isset($this->server_channels[$channel])) {
                             if (ord(substr($payload, 9 + $length))) { // want reply
                                 $this->send_binary_packet(pack('CN', MessageType::CHANNEL_SUCCESS, $this->server_channels[$channel]));


### PR DESCRIPTION
This PR attempts to remediate the `Possible Variable Overwrite: Global Scope` vulnerability (CWE 473).

I opened PR #2045, but it was reverted due to too many failed tests.
Basically, it fails because the `EXTR_SKIP` parameter in `extract()` function were not writing values in existing variables, which is not the intended behavior in some cases.

So I'm proposing a new approach: replace `extract()` with variable assignment.
In addition to preventing user input from rewriting global variables, this improves code readability, as it becomes clear which variables are being assigned.