### PR TITLE
Support ASN.1 tag encoding with values greater than 30.

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -931,7 +931,7 @@ abstract class ASN1
                                     $subtagvalue = $constant->bitwise_and($mask);
                                     $subtagvalue->setPrecision(8);
                                     $subtag = (chr(0x80) | $subtagvalue->toBytes()) . $subtag;
-                                    $constant = $constant->bitwise_rightShift(shift: 7);
+                                    $constant = $constant->bitwise_rightShift(7);
                                 }
                                 $subtag[strlen($subtag) - 1] = $subtag[strlen($subtag) - 1] & chr(0x7F);
                                 $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | 0x1f) . $subtag;

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -923,15 +923,12 @@ abstract class ASN1
                             if ($child['constant'] <= 30) {
                                 $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | $child['constant']);
                             } else {
-                                $zero = new BigInteger();
-                                $mask = new BigInteger(0x7F);
-                                $constant = new BigInteger($child['constant']);
+                                $constant = $child['constant'];
                                 $subtag = '';
-                                while (!$constant->equals($zero)) {
-                                    $subtagvalue = $constant->bitwise_and($mask);
-                                    $subtagvalue->setPrecision(8);
-                                    $subtag = (chr(0x80) | $subtagvalue->toBytes()) . $subtag;
-                                    $constant = $constant->bitwise_rightShift(7);
+                                while ($constant > 0) {
+                                    $subtagvalue = $constant & 0x7F;
+                                    $subtag = (chr(0x80 | $subtagvalue )) . $subtag;
+                                    $constant = $constant >> 7;
                                 }
                                 $subtag[strlen($subtag) - 1] = $subtag[strlen($subtag) - 1] & chr(0x7F);
                                 $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | 0x1f) . $subtag;

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -927,7 +927,7 @@ abstract class ASN1
                                 $subtag = '';
                                 while ($constant > 0) {
                                     $subtagvalue = $constant & 0x7F;
-                                    $subtag = (chr(0x80 | $subtagvalue )) . $subtag;
+                                    $subtag = (chr(0x80 | $subtagvalue)) . $subtag;
                                     $constant = $constant >> 7;
                                 }
                                 $subtag[strlen($subtag) - 1] = $subtag[strlen($subtag) - 1] & chr(0x7F);

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -920,7 +920,22 @@ abstract class ASN1
                             an untagged "DummyReference" (see ITU-T Rec. X.683 | ISO/IEC 8824-4, 8.3)."
                          */
                         if (isset($child['explicit']) || $child['type'] == self::TYPE_CHOICE) {
-                            $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | $child['constant']);
+                            if ($child['constant'] <= 30) {
+                                $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | $child['constant']);
+                            } else {
+                                $zero = new BigInteger();
+                                $mask = new BigInteger(0x7F);
+                                $constant = new BigInteger($child['constant']);
+                                $subtag = '';
+                                while (!$constant->equals($zero)) {
+                                    $subtagvalue = $constant->bitwise_and($mask);
+                                    $subtagvalue->setPrecision(8);
+                                    $subtag = (chr(0x80) | $subtagvalue->toBytes()) . $subtag;
+                                    $constant = $constant->bitwise_rightShift(shift: 7);
+                                }
+                                $subtag[strlen($subtag) - 1] = $subtag[strlen($subtag) - 1] & chr(0x7F);
+                                $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | 0x20 | 0x1f) . $subtag;
+                            }
                             $temp = $subtag . self::encodeLength(strlen($temp)) . $temp;
                         } else {
                             $subtag = chr((self::CLASS_CONTEXT_SPECIFIC << 6) | (ord($temp[0]) & 0x20) | $child['constant']);

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -345,7 +345,8 @@ class ASN1Test extends PhpseclibTestCase
         $this->assertSame($data, $arr);
     }
 
-    public function testBigApplicationTag() : void {
+    public function testBigApplicationTag(): void
+    {
         $map = [
             'type'     => ASN1::TYPE_SEQUENCE,
             'children' => [
@@ -359,11 +360,11 @@ class ASN1Test extends PhpseclibTestCase
                 ],
             ],
         ];
-        
+
         $data = ['demo' => 'v3'];
-        
+
         $str = ASN1::encodeDER($data, $map);
-        
+
         $decoded = ASN1::decodeBER($str);
         $arr = ASN1::asn1map($decoded[0], $map);
 

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -345,6 +345,31 @@ class ASN1Test extends PhpseclibTestCase
         $this->assertSame($data, $arr);
     }
 
+    public function testBigApplicationTag() : void {
+        $map = [
+            'type'     => ASN1::TYPE_SEQUENCE,
+            'children' => [
+                'demo' => [
+                    'constant' => 0xFFFFFFFF,
+                    'optional' => true,
+                    'explicit' => true,
+                    'default'  => 'v1',
+                    'type'     => ASN1::TYPE_INTEGER,
+                    'mapping' => ['v1', 'v2', 'v3'],
+                ],
+            ],
+        ];
+        
+        $data = ['demo' => 'v3'];
+        
+        $str = ASN1::encodeDER($data, $map);
+        
+        $decoded = ASN1::decodeBER($str);
+        $arr = ASN1::asn1map($decoded[0], $map);
+
+        $this->assertSame($data, $arr);
+    }
+
     /**
      * @group github1296
      */


### PR DESCRIPTION
Allow ASN.1 DER encoding of tags with values greater than 30.
From X.690-0207.pdf#page=12 section 8.1.2.4:
> For tags with a number greater than or equal to 31, the identifier shall comprise a leading octet followed by
one or more subsequent octets.
> ...
> c) bits 5 to 1 shall be encoded as 11111<sub>2</sub> .
> ...
> a) bit 8 of each octet shall be set to one unless it is the last octet of the identifier octets;
> b) bits 7 to 1 of the first subsequent octet, followed by bits 7 to 1 of the second subsequent octet, followed in
turn by bits 7 to 1 of each further octet, up to and including the last subsequent octet in the identifier
octets shall be the encoding of an unsigned binary integer equal to the tag number, with bit 7 of the first
subsequent octet as the most significant bit