### PR TITLE
[3.0] Remove extract function - Possible Variable Overwrite

### DIFF
--- a/phpseclib/Common/Functions/Strings.php
+++ b/phpseclib/Common/Functions/Strings.php
@@ -126,7 +126,9 @@ abstract class Strings
                     // 64-bit floats can be used to get larger numbers then 32-bit signed ints would allow
                     // for. sure, you're not gonna get the full precision of 64-bit numbers but just because
                     // you need > 32-bit precision doesn't mean you need the full 64-bit precision
-                    extract(unpack('Nupper/Nlower', self::shift($data, 8)));
+                    $unpacked = unpack('Nupper/Nlower', self::shift($data, 8));
+                    $upper = $unpacked['upper'];
+                    $lower = $unpacked['lower'];
                     $temp = $upper ? 4294967296 * $upper : 0;
                     $temp += $lower < 0 ? ($lower & 0x7FFFFFFFF) + 0x80000000 : $lower;
                     // $temp = hexdec(bin2hex(self::shift($data, 8)));

--- a/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
@@ -56,7 +56,10 @@ abstract class PuTTY extends Progenitor
         if (!isset($components['private'])) {
             return $components;
         }
-        extract($components);
+        $type = $components['type'];
+        $comment = $components['comment'];
+        $public = $components['public'];
+        $private = $components['private'];
         unset($components['public'], $components['private']);
 
         list($p, $q, $g, $y) = Strings::unpackSSH2('iiii', $public);

--- a/phpseclib/Crypt/DSA/PrivateKey.php
+++ b/phpseclib/Crypt/DSA/PrivateKey.php
@@ -88,7 +88,9 @@ final class PrivateKey extends DSA implements Common\PrivateKey
                     return $signature;
                 }
 
-                extract(ASN1Signature::load($signature));
+                $loaded = ASN1Signature::load($signature);
+                $r = $loaded['r'];
+                $s = $loaded['s'];
 
                 return $format::save($r, $s);
             }

--- a/phpseclib/Crypt/DSA/PublicKey.php
+++ b/phpseclib/Crypt/DSA/PublicKey.php
@@ -40,7 +40,8 @@ final class PublicKey extends DSA implements Common\PublicKey
         if ($params === false || count($params) != 2) {
             return false;
         }
-        extract($params);
+        $r = $params['r'];
+        $s = $params['s'];
 
         if (self::$engines['OpenSSL'] && in_array($this->hash->getHash(), openssl_get_md_methods())) {
             $sig = $format != 'ASN1' ? ASN1Signature::save($r, $s) : $signature;

--- a/phpseclib/Crypt/EC/PrivateKey.php
+++ b/phpseclib/Crypt/EC/PrivateKey.php
@@ -157,7 +157,10 @@ final class PrivateKey extends EC implements Common\PrivateKey
                     return $signature;
                 }
 
-                extract(ASN1Signature::load($signature));
+                $loaded = ASN1Signature::load($signature);
+                $r = $loaded['r'];
+                $s = $loaded['s'];
+
 
                 return $this->formatSignature($r, $s);
             }

--- a/phpseclib/Crypt/EC/PublicKey.php
+++ b/phpseclib/Crypt/EC/PublicKey.php
@@ -115,7 +115,8 @@ final class PublicKey extends EC implements Common\PublicKey
         if ($params === false || count($params) != 2) {
             return false;
         }
-        extract($params);
+        $r = $params['r'];
+        $s = $params['s'];
 
         if (self::$engines['OpenSSL'] && in_array($this->hash->getHash(), openssl_get_md_methods())) {
             $sig = $format != 'ASN1' ? ASN1Signature::save($r, $s) : $signature;

--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -357,10 +357,9 @@ abstract class RSA extends AsymmetricKey
                 if ($i != $num_primes) {
                     $primes[$i] = BigInteger::randomPrime($regSize);
                 } else {
-                    extract(BigInteger::minMaxBits($bits));
-                    /** @var BigInteger $min
-                     *  @var BigInteger $max
-                     */
+                    $minMax = BigInteger::minMaxBits($bits);
+                    $min = $minMax['min'];
+                    $max = $minMax['max'];
                     list($min) = $min->divide($n);
                     $min = $min->add(self::$one);
                     list($max) = $max->divide($n);

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -88,13 +88,11 @@ abstract class MSBLOB
 
         // PUBLICKEYSTRUC  publickeystruc
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa387453(v=vs.85).aspx
-        extract(unpack('atype/aversion/vreserved/Valgo', Strings::shift($key, 8)));
-        /**
-         * @var string $type
-         * @var string $version
-         * @var integer $reserved
-         * @var integer $algo
-         */
+        $unpacked = unpack('atype/aversion/vreserved/Valgo', Strings::shift($key, 8));
+        $type = $unpacked['type'];
+        $version = $unpacked['version'];
+        $reserved = $unpacked['reserved'];
+        $algo = $unpacked['algo'];
         switch (ord($type)) {
             case self::PUBLICKEYBLOB:
             case self::PUBLICKEYBLOBEX:
@@ -121,12 +119,10 @@ abstract class MSBLOB
         // RSAPUBKEY rsapubkey
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa387685(v=vs.85).aspx
         // could do V for pubexp but that's unsigned 32-bit whereas some PHP installs only do signed 32-bit
-        extract(unpack('Vmagic/Vbitlen/a4pubexp', Strings::shift($key, 12)));
-        /**
-         * @var integer $magic
-         * @var integer $bitlen
-         * @var string $pubexp
-         */
+        $unpacked = unpack('Vmagic/Vbitlen/a4pubexp', Strings::shift($key, 12));
+        $magic = $unpacked['magic'];
+        $bitlen = $unpacked['bitlen'];
+        $pubexp = $unpacked['pubexp'];
         switch ($magic) {
             case self::RSA2:
                 $components['isPublicKey'] = false;

--- a/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
@@ -56,7 +56,10 @@ abstract class PuTTY extends Progenitor
         if (!isset($components['private'])) {
             return $components;
         }
-        extract($components);
+        $type = $components['type'];
+        $comment = $components['comment'];
+        $public = $components['public'];
+        $private = $components['private'];
         unset($components['public'], $components['private']);
 
         $isPublicKey = false;

--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -273,8 +273,7 @@ abstract class ASN1
             // tags of indefinte length don't really have a header length; this length includes the tag
             $current += ['headerlength' => $length + 2];
             $start += $length;
-            extract(unpack('Nlength', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4)));
-            /** @var integer $length */
+            $length = unpack('Nlength', substr(str_pad($temp, 4, chr(0), STR_PAD_LEFT), -4))['length'];
         } else {
             $current += ['headerlength' => 2];
         }

--- a/phpseclib/File/X509.php
+++ b/phpseclib/File/X509.php
@@ -626,7 +626,9 @@ class X509
         $extensions = &$this->subArray($root, $path, !empty($this->extensionValues));
 
         foreach ($this->extensionValues as $id => $data) {
-            extract($data);
+            $critical = $data['critical'];
+            $replace = $data['replace'];
+            $value = $data['value'];
             $newext = [
                 'extnId' => $id,
                 'extnValue' => $value,
@@ -1858,7 +1860,7 @@ class X509
                 $dn = $this->getDN(self::DN_CANON, $dn);
                 $hash = new Hash('sha1');
                 $hash = $hash->hash($dn);
-                extract(unpack('Vhash', $hash));
+                $hash = unpack('Vhash', $hash)['hash'];
                 return strtolower(Strings::bin2hex(pack('N', $hash)));
         }
 

--- a/phpseclib/Math/BigInteger.php
+++ b/phpseclib/Math/BigInteger.php
@@ -333,12 +333,10 @@ class BigInteger implements \JsonSerializable
      */
     public function extendedGCD(BigInteger $n)
     {
-        extract($this->value->extendedGCD($n->value));
-        /**
-         * @var BigInteger $gcd
-         * @var BigInteger $x
-         * @var BigInteger $y
-         */
+        $extended = $this->value->extendedGCD($n->value);
+        $gcd = $extended['gcd'];
+        $x = $extended['x'];
+        $y = $extended['y'];
         return [
             'gcd' => new static($gcd),
             'x' => new static($x),
@@ -617,10 +615,9 @@ class BigInteger implements \JsonSerializable
         self::initialize_static_variables();
 
         $class = self::$mainEngine;
-        extract($class::minMaxBits($bits));
-        /** @var BigInteger $min
-         * @var BigInteger $max
-         */
+        $minMax = $class::minMaxBits($bits);
+        $min = $minMax['min'];
+        $max = $minMax['max'];
         return [
             'min' => new static($min),
             'max' => new static($max)

--- a/phpseclib/Math/BigInteger/Engines/BCMath.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath.php
@@ -297,8 +297,7 @@ class BCMath extends Engine
      */
     public function gcd(BCMath $n)
     {
-        extract($this->extendedGCD($n));
-        /** @var BCMath $gcd */
+        $gcd = $this->extendedGCD($n)['gcd'];
         return $gcd;
     }
 

--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/Barrett.php
@@ -96,7 +96,9 @@ abstract class Barrett extends Base
                 'm1' => $m1 // m.length
             ];
         } else {
-            extract($cache[self::DATA][$key]);
+            $cacheValues = $cache[self::DATA][$key];
+            $u = $cacheValues['u'];
+            $m1 = $cacheValues['m1'];
         }
 
         $cutoff = $m_length + ($m_length >> 1);

--- a/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -316,11 +316,9 @@ abstract class Engine implements \JsonSerializable
             return $this->normalize($n->subtract($temp));
         }
 
-        extract($this->extendedGCD($n));
-        /**
-         * @var Engine $gcd
-         * @var Engine $x
-         */
+        $extended = $this->extendedGCD($n);
+        $gcd = $extended['gcd'];
+        $x = $extended['x'];
 
         if (!$gcd->equals(static::$one[static::class])) {
             return false;
@@ -740,11 +738,9 @@ abstract class Engine implements \JsonSerializable
      */
     public static function random($size)
     {
-        extract(static::minMaxBits($size));
-        /**
-         * @var BigInteger $min
-         * @var BigInteger $max
-         */
+        $minMax = static::minMaxBits($size);
+        $min = $minMax['min'];
+        $max = $minMax['max'];
         return static::randomRange($min, $max);
     }
 
@@ -758,11 +754,9 @@ abstract class Engine implements \JsonSerializable
      */
     public static function randomPrime($size)
     {
-        extract(static::minMaxBits($size));
-        /**
-         * @var static $min
-         * @var static $max
-         */
+        $minMax = static::minMaxBits($size);
+        $min = $minMax['min'];
+        $max = $minMax['max'];
         return static::randomRangePrime($min, $max);
     }
 

--- a/phpseclib/Math/BigInteger/Engines/GMP.php
+++ b/phpseclib/Math/BigInteger/Engines/GMP.php
@@ -296,7 +296,10 @@ class GMP extends Engine
      */
     public function extendedGCD(GMP $n)
     {
-        extract(gmp_gcdext($this->value, $n->value));
+        $extended = gmp_gcdext($this->value, $n->value);
+        $g = $extended['g'];
+        $s = $extended['s'];
+        $t = $extended['t'];
 
         return [
             'gcd' => $this->normalize(new self($g)),

--- a/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP/Reductions/Barrett.php
@@ -98,7 +98,9 @@ abstract class Barrett extends Base
                 'm1' => $m1 // m.length
             ];
         } else {
-            extract($cache[self::DATA][$key]);
+            $cacheValues = $cache[self::DATA][$key];
+            $u = $cacheValues['u'];
+            $m1 = $cacheValues['m1'];
         }
 
         $cutoff = $m_length + ($m_length >> 1);

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3357,8 +3357,7 @@ class SFTP extends SSH2
         if (strlen($this->packet_buffer) < 4) {
             throw new \RuntimeException('Packet is too small');
         }
-        extract(unpack('Nlength', Strings::shift($this->packet_buffer, 4)));
-        /** @var integer $length */
+        $length = unpack('Nlength', Strings::shift($this->packet_buffer, 4))['length'];
 
         $tempLength = $length;
         $tempLength -= strlen($this->packet_buffer);
@@ -3388,7 +3387,7 @@ class SFTP extends SSH2
         $this->packet_type = ord(Strings::shift($this->packet_buffer));
 
         if ($this->use_request_id) {
-            extract(unpack('Npacket_id', Strings::shift($this->packet_buffer, 4))); // remove the request id
+            $packet_id = unpack('Npacket_id', Strings::shift($this->packet_buffer, 4))['packet_id']; // remove the request id
             $length -= 5; // account for the request id and the packet type
         } else {
             $length -= 1; // account for the packet type

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -139,7 +139,15 @@ class Stream
     protected function parse_path($path)
     {
         $orig = $path;
-        extract(parse_url($path) + ['port' => 22]);
+        $url = parse_url($path) + ['port' => 22];
+
+        $keys = ['scheme', 'host', 'port', 'user', 'pass', 'path', 'query', 'fragment'];
+        foreach ($keys as $key) {
+            if (isset($url[$key])) {
+                $$key = $url[$key];
+            }
+        }
+
         if (isset($query)) {
             $path .= '?' . $query;
         } elseif (preg_match('/(\?|\?#)$/', $orig)) {


### PR DESCRIPTION
This PR attempts to remediate the Possible Variable Overwrite: Global Scope vulnerability (CWE 473).

I opened PR https://github.com/phpseclib/phpseclib/pull/2063, but it uses PHP 7.1+ features and has been merged into the `master` branch.
This one replaces `extract()` function by using PHP 5 features, targeting the `3.0` branch.