### PR TITLE
assert valid JWK

### DIFF
--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -143,7 +143,7 @@ abstract class AsymmetricKey
             }
             try {
                 $components = $format::load($key, $password);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $components = false;
             }
             if ($components !== false) {

--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -143,7 +143,7 @@ abstract class AsymmetricKey
             }
             try {
                 $components = $format::load($key, $password);
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 $components = false;
             }
             if ($components !== false) {

--- a/phpseclib/Crypt/Common/Formats/Keys/JWK.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/JWK.php
@@ -43,6 +43,14 @@ abstract class JWK
             return $key;
         }
 
+        if (!is_object($key)) {
+            throw new \RuntimeException('invalid JWK: not an object');
+        }
+
+        if (!isset($key->keys)) {
+            throw new \RuntimeException('invalid JWK: object has no property "keys"');
+        }
+
         if (count($key->keys) != 1) {
             throw new \RuntimeException('Although the JWK key format supports multiple keys phpseclib does not');
         }

--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -32,6 +32,7 @@ abstract class PublicKeyLoader
      * Loads a public or private key
      *
      * @param string|array $key
+     * @throws NoKeyLoadedException if key is not valid
      */
     public static function load($key, ?string $password = null): AsymmetricKey
     {

--- a/tests/Unit/Crypt/RSA/LoadKeyTest.php
+++ b/tests/Unit/Crypt/RSA/LoadKeyTest.php
@@ -24,6 +24,8 @@ use phpseclib3\Exception\UnsupportedFormatException;
 use phpseclib3\Math\BigInteger;
 use phpseclib3\Tests\PhpseclibTestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class LoadKeyTest extends PhpseclibTestCase
 {
     public static function setUpBeforeClass(): void
@@ -32,11 +34,41 @@ class LoadKeyTest extends PhpseclibTestCase
         OpenSSH::setComment('phpseclib-generated-key');
     }
 
-    public function testBadKey(): void
+    public static function getGarbageStrings()
+    {
+        return [
+            // [''], TODO this throws error, add check for empty string?
+            ['a'],
+            ['Hello, World!'],
+            ['  Some text  '],
+            ['   '],
+            ['12345'],
+            ['abc123'],
+            ['Hello@World!'],
+            [str_repeat('a', 8190)], // https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize
+            ['<p>This is a paragraph</p>'],
+            ["'; DROP TABLE users; --"],
+            ["<script>alert('XSS');</script>"],
+            ['こんにちは世界'],
+            ["Hello 👋 World 🌍"],
+            ["Line 1\nLine 2"],
+            ["Column1\tColumn2"],
+            ['MiXeD cAsE'],
+            ['https://www.example.com'],
+            ['user@example.com'],
+            ['{"key": "value"}'],
+            ['SGVsbG8sIFdvcmxkIQ=='],
+            ["Hello\x00World"],
+            [mb_convert_encoding("Hello, World!", "UTF-16")]
+        ];
+    }
+
+    /**
+     * @dataProvider getGarbageStrings
+     */
+    public function testBadKey($key): void
     {
         $this->expectException(NoKeyLoadedException::class);
-
-        $key = 'zzzzzzzzzzzzzz';
         PublicKeyLoader::load($key);
     }
 


### PR DESCRIPTION
fixes https://github.com/phpseclib/phpseclib/issues/2076, https://github.com/phpseclib/phpseclib/issues/2077

`JWK::loadHelper` does not do the necessary assertions on the result of `json_decode`. It assumes that if the key is valid JSON, then it must become an object and it must have the `keys` property. Because of these bad assumptions, there is an uncaught TypeError. AsymmetricKey catches any exceptions and throws NoKeyLoadedException, but errors are not exceptions.

* Added assertions to `JWK::loadHelper`
* added test cases for garbage keys
* added `@throws` to docblock for `PublicKeyLoader::load`.