### PR TITLE
Excluding extra lines before version string from server_identifier

### DIFF
--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1487,7 +1487,7 @@ class SSH2
 
         $extra = $matches[1];
 
-        $this->server_identifier = trim($data, "\r\n");
+        $this->server_identifier = trim($temp, "\r\n");
         if (strlen($extra)) {
             $this->errors[] = $data;
         }


### PR DESCRIPTION
https://github.com/phpseclib/phpseclib/issues/2082

Existing comment in `SSH2::connect()`:
```php
/* According to the SSH2 specs,

          "The server MAY send other lines of data before sending the version
           string.  Each line SHOULD be terminated by a Carriage Return and Line
           Feed.  Such lines MUST NOT begin with "SSH-", and SHOULD be encoded
           in ISO-10646 UTF-8 [RFC3629] (language is not specified).  Clients
           MUST be able to process such lines." */
```
Link to specs in question: [RFC 4253: Section 4.2](https://datatracker.ietf.org/doc/html/rfc4253#section-4.2)

Starting in version **3.0.42** the assignment of `$this->server_identifier` changed from using `$temp` to using `$data`. This change causes it to include any lines *before* the SSH version indicator. This apparently causes problems, possibly causing it to read to the end of the buffer early. The exception is thrown later on in `get_binary_packet()` on line 3618.

We can use 3.0.41 for now, but this stops us from upgrading further.

My solution is to simply revert the single change to use `$temp` again.