### PR TITLE
Remove mcrypt suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
     "suggest": {
         "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
         "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations.",
-        "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
         "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
         "ext-dom": "Install the DOM extension to load XML formatted public keys."
     },


### PR DESCRIPTION
This was already done on the master branch a few years ago. Having the recommendation can be misleading especially when OpenSSL is already installed as it's not clear that OpenSSL will be used already. Mcrypt is abandoned and probably not a good idea to install in the first place but can also be problematic to install at all.

If you still prefer that mcrypt is listed as recommended extensions then it would at least be good to update the description to make it more clear that it's not needed in case openssl is already installed.