### PR TITLE
Add #[SensitiveParameter]-Attribute for password parameters to prevent leakage in stack traces

### DIFF
--- a/phpseclib/Crypt/Common/AsymmetricKey.php
+++ b/phpseclib/Crypt/Common/AsymmetricKey.php
@@ -127,7 +127,7 @@ abstract class AsymmetricKey
      * @param string|array $key
      * @return PublicKey|PrivateKey
      */
-    public static function load($key, ?string $password = null): AsymmetricKey
+    public static function load($key, #[SensitiveParameter] ?string $password = null): AsymmetricKey
     {
         self::initialize_static_variables();
 
@@ -172,7 +172,7 @@ abstract class AsymmetricKey
      * @param string|array $key
      * @param string $password optional
      */
-    public static function loadPrivateKey($key, string $password = ''): PrivateKey
+    public static function loadPrivateKey($key, #[SensitiveParameter] string $password = ''): PrivateKey
     {
         $key = self::load($key, $password);
         if (!$key instanceof PrivateKey) {
@@ -214,7 +214,7 @@ abstract class AsymmetricKey
      *
      * @return static
      */
-    public static function loadFormat(string $type, string $key, ?string $password = null): AsymmetricKey
+    public static function loadFormat(string $type, string $key, #[SensitiveParameter] ?string $password = null): AsymmetricKey
     {
         self::initialize_static_variables();
 
@@ -242,7 +242,7 @@ abstract class AsymmetricKey
     /**
      * Loads a private key
      */
-    public static function loadPrivateKeyFormat(string $type, string $key, ?string $password = null): PrivateKey
+    public static function loadPrivateKeyFormat(string $type, string $key, #[SensitiveParameter] ?string $password = null): PrivateKey
     {
         $key = self::loadFormat($type, $key, $password);
         if (!$key instanceof PrivateKey) {

--- a/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
@@ -60,7 +60,7 @@ abstract class OpenSSH
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));
@@ -174,7 +174,7 @@ abstract class OpenSSH
      *
      * @param string|false $password
      */
-    protected static function wrapPrivateKey(string $publicKey, string $privateKey, $password, array $options): string
+    protected static function wrapPrivateKey(string $publicKey, string $privateKey, #[SensitiveParameter] $password, array $options): string
     {
         [, $checkint] = unpack('N', Random::string(4));
 

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS1.php
@@ -91,7 +91,7 @@ abstract class PKCS1 extends PKCS
     /**
      * Generate a symmetric key for PKCS#1 keys
      */
-    private static function generateSymmetricKey(string $password, string $iv, int $length): string
+    private static function generateSymmetricKey(#[SensitiveParameter] string $password, string $iv, int $length): string
     {
         $symkey = '';
         $iv = substr($iv, 0, 8);
@@ -107,7 +107,7 @@ abstract class PKCS1 extends PKCS
      * @param string|array $key
      * @return array|string
      */
-    protected static function load($key, ?string $password = null)
+    protected static function load($key, #[SensitiveParameter] ?string $password = null)
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));
@@ -160,7 +160,7 @@ abstract class PKCS1 extends PKCS
      * @param string|false $password
      * @param array $options optional
      */
-    protected static function wrapPrivateKey(string $key, string $type, $password, array $options = []): string
+    protected static function wrapPrivateKey(string $key, string $type, #[SensitiveParameter] $password, array $options = []): string
     {
         if (empty($password) || !is_string($password)) {
             return "-----BEGIN $type PRIVATE KEY-----\r\n" .

--- a/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/Common/Formats/Keys/PKCS8.php
@@ -303,7 +303,7 @@ abstract class PKCS8 extends PKCS
      *
      * @param string|array $key
      */
-    protected static function load($key, ?string $password = null): array
+    protected static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));
@@ -541,7 +541,7 @@ abstract class PKCS8 extends PKCS
      * @param string $publicKey optional
      * @param array $options optional
      */
-    protected static function wrapPrivateKey(string $key, $attr, $params, $password, ?string $oid = null, string $publicKey = '', array $options = []): string
+    protected static function wrapPrivateKey(string $key, $attr, $params, #[SensitiveParameter] $password, ?string $oid = null, string $publicKey = '', array $options = []): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/Common/PrivateKey.php
+++ b/phpseclib/Crypt/Common/PrivateKey.php
@@ -28,5 +28,5 @@ interface PrivateKey
     /**
      * @return static
      */
-    public function withPassword(?string $password = null): PrivateKey;
+    public function withPassword(#[SensitiveParameter] ?string $password = null): PrivateKey;
 }

--- a/phpseclib/Crypt/Common/Traits/PasswordProtected.php
+++ b/phpseclib/Crypt/Common/Traits/PasswordProtected.php
@@ -38,7 +38,7 @@ trait PasswordProtected
      *
      * @return static
      */
-    public function withPassword(?string $password = null): self
+    public function withPassword(#[SensitiveParameter] ?string $password = null): self
     {
         $new = clone $this;
         $new->password = $password;

--- a/phpseclib/Crypt/DH.php
+++ b/phpseclib/Crypt/DH.php
@@ -325,7 +325,7 @@ abstract class DH extends AsymmetricKey
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): AsymmetricKey
+    public static function load($key, #[SensitiveParameter] ?string $password = null): AsymmetricKey
     {
         try {
             return EC::load($key, $password);

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS1.php
@@ -41,7 +41,7 @@ abstract class PKCS1 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::load($key, $password);
 

--- a/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DH/Formats/Keys/PKCS8.php
@@ -60,7 +60,7 @@ abstract class PKCS8 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::load($key, $password);
 
@@ -90,7 +90,7 @@ abstract class PKCS8 extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $prime, BigInteger $base, BigInteger $privateKey, BigInteger $publicKey, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $prime, BigInteger $base, BigInteger $privateKey, BigInteger $publicKey, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $params = [
             'prime' => $prime,

--- a/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/OpenSSH.php
@@ -42,7 +42,7 @@ abstract class OpenSSH extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $parsed = parent::load($key, $password);
 
@@ -96,7 +96,7 @@ abstract class OpenSSH extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $publicKey = self::savePublicKey($p, $q, $g, $y, ['binary' => true]);
         $privateKey = Strings::packSSH2('si5', 'ssh-dss', $p, $q, $g, $y, $x);

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
@@ -48,7 +48,7 @@ abstract class PKCS1 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::load($key, $password);
 
@@ -99,7 +99,7 @@ abstract class PKCS1 extends Progenitor
      * @param string $password optional
      * @param array $options optional
      */
-    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, string $password = '', array $options = []): string
+    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, #[SensitiveParameter] string $password = '', array $options = []): string
     {
         $key = [
             'version' => 0,

--- a/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PKCS8.php
@@ -64,7 +64,7 @@ abstract class PKCS8 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::load($key, $password);
 
@@ -100,7 +100,7 @@ abstract class PKCS8 extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $params = [
             'p' => $p,

--- a/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/PuTTY.php
@@ -76,7 +76,7 @@ abstract class PuTTY extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $p, BigInteger $q, BigInteger $g, BigInteger $y, BigInteger $x, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         if ($q->getLength() != 160) {
             throw new InvalidArgumentException('SSH only supports keys with an N (length of Group Order q) of 160');

--- a/phpseclib/Crypt/DSA/Formats/Keys/Raw.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/Raw.php
@@ -32,7 +32,7 @@ abstract class Raw
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!is_array($key)) {
             throw new UnexpectedValueException('Key should be a array - not a ' . gettype($key));

--- a/phpseclib/Crypt/DSA/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/DSA/Formats/Keys/XML.php
@@ -36,7 +36,7 @@ abstract class XML
     /**
      * Break a public or private key down into its constituent components
      */
-    public static function load(string $key, ?string $password = null): array
+    public static function load(string $key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));

--- a/phpseclib/Crypt/EC/Formats/Keys/JWK.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/JWK.php
@@ -41,7 +41,7 @@ abstract class JWK extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::loadHelper($key);
 
@@ -172,6 +172,7 @@ abstract class JWK extends Progenitor
         BaseCurve $curve,
         array $publicKey,
         ?string $secret = null,
+        #[SensitiveParameter]
         ?string $password = null,
         array $options = []
     ): string {

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPrivate.php
@@ -45,7 +45,7 @@ abstract class MontgomeryPrivate
     /**
      * Break a public or private key down into its constituent components
      */
-    public static function load(string $key, ?string $password = null): array
+    public static function load(string $key, #[SensitiveParameter] ?string $password = null): array
     {
         switch (strlen($key)) {
             case 32:
@@ -82,7 +82,7 @@ abstract class MontgomeryPrivate
      *
      * @param Integer[] $publicKey
      */
-    public static function savePrivateKey(BigInteger $privateKey, MontgomeryCurve $curve, array $publicKey, ?string $password = null): string
+    public static function savePrivateKey(BigInteger $privateKey, MontgomeryCurve $curve, array $publicKey, #[SensitiveParameter] ?string $password = null): string
     {
         if (!empty($password) && is_string($password)) {
             throw new UnsupportedFormatException('MontgomeryPrivate private keys do not support encryption');

--- a/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/MontgomeryPublic.php
@@ -37,7 +37,7 @@ abstract class MontgomeryPublic
     /**
      * Break a public or private key down into its constituent components
      */
-    public static function load(string $key, ?string $password = null): array
+    public static function load(string $key, #[SensitiveParameter] ?string $password = null): array
     {
         switch (strlen($key)) {
             case 32:

--- a/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/OpenSSH.php
@@ -52,7 +52,7 @@ abstract class OpenSSH extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $parsed = parent::load($key, $password);
 

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS1.php
@@ -54,7 +54,7 @@ abstract class PKCS1 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         self::initialize_static_variables();
 
@@ -165,7 +165,7 @@ abstract class PKCS1 extends Progenitor
      *
      * @param Integer[] $publicKey
      */
-    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PKCS8.php
@@ -66,7 +66,7 @@ abstract class PKCS8 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         // initialize_static_variables() is defined in both the trait and the parent class
         // when it's defined in two places it's the traits one that's called
@@ -193,7 +193,7 @@ abstract class PKCS8 extends Progenitor
      *
      * @param Integer[] $publicKey
      */
-    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/PuTTY.php
@@ -91,7 +91,7 @@ abstract class PuTTY extends Progenitor
      *
      * @param Integer[] $publicKey
      */
-    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $privateKey, BaseCurve $curve, array $publicKey, ?string $secret = null, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/EC/Formats/Keys/XML.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/XML.php
@@ -60,7 +60,7 @@ abstract class XML
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
+++ b/phpseclib/Crypt/EC/Formats/Keys/libsodium.php
@@ -42,7 +42,7 @@ abstract class libsodium
     /**
      * Break a public or private key down into its constituent components
      */
-    public static function load(string $key, ?string $password = null): array
+    public static function load(string $key, #[SensitiveParameter] ?string $password = null): array
     {
         switch (strlen($key)) {
             case 32:
@@ -92,7 +92,7 @@ abstract class libsodium
      *
      * @param Integer[] $publicKey
      */
-    public static function savePrivateKey(BigInteger $privateKey, Ed25519 $curve, array $publicKey, ?string $secret = null, ?string $password = null): string
+    public static function savePrivateKey(BigInteger $privateKey, Ed25519 $curve, array $publicKey, ?string $secret = null, #[SensitiveParameter] ?string $password = null): string
     {
         if (!isset($secret)) {
             throw new RuntimeException('Private Key does not have a secret set');

--- a/phpseclib/Crypt/PublicKeyLoader.php
+++ b/phpseclib/Crypt/PublicKeyLoader.php
@@ -34,7 +34,7 @@ abstract class PublicKeyLoader
      * @param string|array $key
      * @throws NoKeyLoadedException if key is not valid
      */
-    public static function load($key, ?string $password = null): AsymmetricKey
+    public static function load($key, #[SensitiveParameter] ?string $password = null): AsymmetricKey
     {
         try {
             return EC::load($key, $password);
@@ -69,7 +69,7 @@ abstract class PublicKeyLoader
      *
      * @param string|array $key
      */
-    public static function loadPrivateKey($key, ?string $password = null): PrivateKey
+    public static function loadPrivateKey($key, #[SensitiveParameter] ?string $password = null): PrivateKey
     {
         $key = self::load($key, $password);
         if (!$key instanceof PrivateKey) {

--- a/phpseclib/Crypt/RSA/Formats/Keys/JWK.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/JWK.php
@@ -31,7 +31,7 @@ abstract class JWK extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::loadHelper($key);
 
@@ -93,7 +93,7 @@ abstract class JWK extends Progenitor
      * @param string $password optional
      * @param array $options optional
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         if (count($primes) != 2) {
             throw new \InvalidArgumentException('JWK does not support multi-prime RSA keys');

--- a/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/MSBLOB.php
@@ -66,7 +66,7 @@ abstract class MSBLOB
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));
@@ -167,7 +167,7 @@ abstract class MSBLOB
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null): string
     {
         if (count($primes) != 2) {
             throw new InvalidArgumentException('MSBLOB does not support multi-prime RSA keys');

--- a/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/OpenSSH.php
@@ -41,7 +41,7 @@ abstract class OpenSSH extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         static $one;
         if (!isset($one)) {
@@ -110,7 +110,7 @@ abstract class OpenSSH extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $publicKey = self::savePublicKey($n, $e, ['binary' => true]);
         $privateKey = Strings::packSSH2('si6', 'ssh-rsa', $n, $e, $d, $coefficients[2], $primes[1], $primes[2]);

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS1.php
@@ -45,7 +45,7 @@ abstract class PKCS1 extends Progenitor
      * @param string|array $key
      * @param string|false $password
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));
@@ -122,7 +122,7 @@ abstract class PKCS1 extends Progenitor
      * @param string|false $password
      * @param array $options optional
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $num_primes = count($primes);
         $key = [

--- a/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PKCS8.php
@@ -64,7 +64,7 @@ abstract class PKCS8 extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         $key = parent::load($key, $password);
 
@@ -88,7 +88,7 @@ abstract class PKCS8 extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         $key = PKCS1::savePrivateKey($n, $e, $d, $primes, $exponents, $coefficients);
         $key = ASN1::extractBER($key);

--- a/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
@@ -96,7 +96,7 @@ abstract class PSS extends Progenitor
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         self::initialize_static_variables();
 
@@ -155,7 +155,7 @@ abstract class PSS extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         self::initialize_static_variables();
 

--- a/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PuTTY.php
@@ -94,7 +94,7 @@ abstract class PuTTY extends Progenitor
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         if (count($primes) != 2) {
             throw new InvalidArgumentException('PuTTY does not support multi-prime RSA keys');

--- a/phpseclib/Crypt/RSA/Formats/Keys/Raw.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/Raw.php
@@ -41,7 +41,7 @@ abstract class Raw
      *
      * @param string|array $key
      */
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!is_array($key)) {
             throw new UnexpectedValueException('Key should be a array - not a ' . gettype($key));
@@ -140,7 +140,7 @@ abstract class Raw
     /**
      * Convert a private key to the appropriate format.
      */
-    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, ?string $password = null, array $options = []): string
+    public static function savePrivateKey(BigInteger $n, BigInteger $e, BigInteger $d, array $primes, array $exponents, array $coefficients, #[SensitiveParameter] ?string $password = null, array $options = []): string
     {
         if (!empty($password) && is_string($password)) {
             throw new UnsupportedFormatException('Raw private keys do not support encryption');

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -1989,7 +1989,7 @@ class SSH2
      * @param string|PrivateKey|array[]|Agent|null ...$args
      * @see self::_login()
      */
-    public function login(string $username, ...$args): bool
+    public function login(string $username, #[SensitiveParameter] ...$args): bool
     {
         if (!$this->login_credentials_finalized) {
             $this->auth[] = func_get_args();
@@ -2017,7 +2017,7 @@ class SSH2
      * @param string|PrivateKey|array[]|Agent|null ...$args
      * @see self::_login_helper()
      */
-    protected function sublogin(string $username, ...$args): bool
+    protected function sublogin(string $username, #[SensitiveParameter] ...$args): bool
     {
         if (!($this->bitmap & self::MASK_CONSTRUCTOR)) {
             $this->connect();
@@ -2259,7 +2259,7 @@ class SSH2
      *
      * @param string|array $password
      */
-    private function keyboard_interactive_login(string $username, $password): bool
+    private function keyboard_interactive_login(string $username, #[SensitiveParameter] $password): bool
     {
         $packet = Strings::packSSH2(
             'Cs5',

--- a/phpseclib/System/SSH/Agent/Identity.php
+++ b/phpseclib/System/SSH/Agent/Identity.php
@@ -306,7 +306,7 @@ class Identity implements PrivateKey
      *
      * @return never
      */
-    public function withPassword(?string $password = null): PrivateKey
+    public function withPassword(#[SensitiveParameter] ?string $password = null): PrivateKey
     {
         throw new RuntimeException('ssh-agent does not provide a mechanism to get the private key');
     }

--- a/phpseclib/bootstrap.php
+++ b/phpseclib/bootstrap.php
@@ -22,3 +22,13 @@ if (extension_loaded('mbstring')) {
         );
     }
 }
+
+if (\PHP_VERSION_ID < 80200) {
+    #[Attribute(Attribute::TARGET_PARAMETER)]
+    final class SensitiveParameter
+    {
+        public function __construct()
+        {
+        }
+    }
+}

--- a/tests/Unit/Crypt/EC/Ed448PrivateKey.php
+++ b/tests/Unit/Crypt/EC/Ed448PrivateKey.php
@@ -11,7 +11,7 @@ use phpseclib3\Exception\UnexpectedValueException;
 
 class Ed448PrivateKey
 {
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));

--- a/tests/Unit/Crypt/EC/Ed448PublicKey.php
+++ b/tests/Unit/Crypt/EC/Ed448PublicKey.php
@@ -14,7 +14,7 @@ class Ed448PublicKey
 {
     use Common;
 
-    public static function load($key, ?string $password = null): array
+    public static function load($key, #[SensitiveParameter] ?string $password = null): array
     {
         if (!Strings::is_stringable($key)) {
             throw new UnexpectedValueException('Key should be a string - not a ' . gettype($key));


### PR DESCRIPTION
Fixes issue #1118, but requires PHP 8.2. As such, a generic polyfill is added to bootstrap.php for the time being.