### PR TITLE
Check if realpath succeeded when changing SFTP directory

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -727,6 +727,9 @@ class SFTP extends SSH2
         }
 
         $dir = $this->realpath($dir);
+        if ($dir === false) {
+            return false;
+        }
 
         // confirm that $dir is, in fact, a valid directory
         if ($this->use_stat_cache && is_array($this->query_stat_cache($dir))) {


### PR DESCRIPTION

I've been troubleshooting an interesting intermittent issue with SFTP, where sometimes realpath() would fail but chdir would return true. pwd would be false though so future commands would fail the precheck with 'Please close the channel (256) before trying to open it again'. 

I've added a simple check, wasn't quite sure if that was the preferred way. 
Happy to change it to 
```
$dir = $this->realpath($dir);
if ($dir === false) {
    return false;
}
```
or whatever.
