### PR TITLE
fix: consider already integer value

### DIFF
--- a/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
+++ b/phpseclib/Crypt/RSA/Formats/Keys/PSS.php
@@ -142,7 +142,11 @@ abstract class PSS extends Progenitor
         $result['hash'] = str_replace('id-', '', $params['hashAlgorithm']['algorithm']);
         $result['MGFHash'] = str_replace('id-', '', $params['maskGenAlgorithm']['parameters']['algorithm']);
         if (isset($params['saltLength'])) {
-            $result['saltLength'] = (int) $params['saltLength']->toString();
+            if (is_int($params['saltLength'])) {
+                $result['saltLength'] = $params['saltLength'];
+            } else {
+                $result['saltLength'] = (int) $params['saltLength']->toString();
+            }
         }
 
         if (isset($key['meta'])) {


### PR DESCRIPTION
At my environment, when the saltLength already is an integer value, throw an error because integer isn't object.