### PR TITLE
feat: add OpenSSL support for Ed25519/Ed448

### DIFF
--- a/phpseclib/Crypt/EC.php
+++ b/phpseclib/Crypt/EC.php
@@ -153,7 +153,7 @@ abstract class EC extends AsymmetricKey
 
         $curve = strtolower($curve);
 
-        // Use OpenSSL for Ed25519/Ed448 if available (PHP 8.4+ with OpenSSL 3.0+)
+        // OpenSSL supports Ed25519/Ed448 when OPENSSL_KEYTYPE_ED25519/ED448 constants are defined
         if (self::$engines['OpenSSL'] && $curve == 'ed25519' && defined('OPENSSL_KEYTYPE_ED25519')) {
             $key = openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_ED25519]);
             openssl_pkey_export($key, $privateKeyStr);

--- a/phpseclib/Crypt/EC/PrivateKey.php
+++ b/phpseclib/Crypt/EC/PrivateKey.php
@@ -115,13 +115,12 @@ final class PrivateKey extends EC implements Common\PrivateKey
         }
 
         if ($this->curve instanceof TwistedEdwardsCurve) {
-            // Use OpenSSL for Ed25519/Ed448 signing if available (PHP 8.4+)
-            // Ed25519ctx (with context) is not supported by OpenSSL, so skip if context is set
+            // OpenSSL supports Ed25519/Ed448 but not Ed25519ctx (context), so skip if context is set
             if (self::$engines['OpenSSL'] && !isset($this->context)) {
                 $keyTypeConstant = $this->curve instanceof Ed25519 ? 'OPENSSL_KEYTYPE_ED25519' : 'OPENSSL_KEYTYPE_ED448';
                 if (defined($keyTypeConstant)) {
                     $result = '';
-                    // Ed25519/Ed448 use algorithm 0 (no separate hash - EdDSA has built-in hash)
+                    // algorithm 0 is used because EdDSA has a built-in hash
                     openssl_sign($message, $result, $this->withPassword()->toString('PKCS8'), 0);
                     $signature = $shortFormat == 'SSH2'
                         ? Strings::packSSH2('ss', 'ssh-' . strtolower($this->getCurve()), $result)

--- a/phpseclib/Crypt/EC/PublicKey.php
+++ b/phpseclib/Crypt/EC/PublicKey.php
@@ -58,13 +58,11 @@ final class PublicKey extends EC implements Common\PublicKey
                 [, $signature] = Strings::unpackSSH2('ss', $signature);
             }
 
-            // Use OpenSSL for Ed25519/Ed448 verification if available (PHP 8.4+)
-            // Ed25519ctx (with context) is not supported by OpenSSL, so skip if context is set
+            // OpenSSL supports Ed25519/Ed448 but not Ed25519ctx (context), so skip if context is set
             if (self::$engines['OpenSSL'] && !isset($this->context)) {
                 $keyTypeConstant = $this->curve instanceof Ed25519 ? 'OPENSSL_KEYTYPE_ED25519' : 'OPENSSL_KEYTYPE_ED448';
                 if (defined($keyTypeConstant)) {
-                    // Ed25519/Ed448 use algorithm 0 (no separate hash)
-                    // Returns 1 if valid, 0 if invalid, -1 on error
+                    // algorithm 0 is used because EdDSA has a built-in hash
                     return openssl_verify($message, $signature, $this->toString('PKCS8'), 0) === 1;
                 }
             }

--- a/tests/Unit/Crypt/EC/KeyTest.php
+++ b/tests/Unit/Crypt/EC/KeyTest.php
@@ -445,13 +445,10 @@ Private-MAC: 8a06821a1c8b8b40fc40f876e543c4ea3fb81bb9
         $this->assertSameNL($expected, $key->toString('libsodium'));
     }
 
-    /**
-     * Test OpenSSL Ed25519 key generation, signing, and verification
-     */
     public function testOpenSSLEd25519(): void
     {
         if (!extension_loaded('openssl') || !defined('OPENSSL_KEYTYPE_ED25519')) {
-            self::markTestSkipped('OpenSSL Ed25519 support is not available (requires PHP 8.4+ with OpenSSL 3.0+).');
+            self::markTestSkipped('OpenSSL Ed25519 support is not available.');
         }
 
         // Force OpenSSL engine
@@ -483,13 +480,10 @@ Private-MAC: 8a06821a1c8b8b40fc40f876e543c4ea3fb81bb9
         $this->assertTrue($publicKey->verify($message, $loadedKey->sign($message)));
     }
 
-    /**
-     * Test OpenSSL Ed448 key generation, signing, and verification
-     */
     public function testOpenSSLEd448(): void
     {
         if (!extension_loaded('openssl') || !defined('OPENSSL_KEYTYPE_ED448')) {
-            self::markTestSkipped('OpenSSL Ed448 support is not available (requires PHP 8.4+ with OpenSSL 3.0+).');
+            self::markTestSkipped('OpenSSL Ed448 support is not available.');
         }
 
         EC::useBestEngine();
@@ -509,9 +503,6 @@ Private-MAC: 8a06821a1c8b8b40fc40f876e543c4ea3fb81bb9
         $this->assertFalse($publicKey->verify('Tampered message', $signature));
     }
 
-    /**
-     * Test that OpenSSL and libsodium produce compatible Ed25519 keys
-     */
     public function testOpenSSLLibsodiumInterop(): void
     {
         if (!extension_loaded('openssl') || !defined('OPENSSL_KEYTYPE_ED25519')) {


### PR DESCRIPTION
PHP 8.4 added `OPENSSL_KEYTYPE_ED25519` and `OPENSSL_KEYTYPE_ED448`, so phpseclib can now use OpenSSL for these curves instead of requiring libsodium.

## Why?

phpseclib already prefers OpenSSL for other EC curves (secp256k1, secp384r1, etc). This brings Ed25519/Ed448 in line with that.

## Changes

- `EC::createKey()` - use OpenSSL for Ed25519/Ed448 key generation when available
- `EC\PrivateKey::sign()` - use OpenSSL for signing
- `EC\PublicKey::verify()` - use OpenSSL for verification
- Added tests for the new code paths

Falls back to libsodium (then pure-PHP) when OpenSSL isn't available, so fully backward compatible.

Ed25519ctx still uses the existing implementation since OpenSSL doesn't support contexts.

## Testing

All existing tests pass. New tests cover key generation, signing, verification, format round-trips, and libsodium interop.
