### PR TITLE
throw exceptions on failures for SSH2 / SFTP operations

### DIFF
--- a/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
+++ b/phpseclib/Math/BigInteger/Engines/BCMath/Reductions/EvalBarrett.php
@@ -55,7 +55,7 @@ abstract class EvalBarrett extends Base
             $code = 'return self::BCMOD_THREE_PARAMS ? bcmod($x, $n, 0) : bcmod($x, $n);';
             eval('$func = function ($n) { ' . $code . '};');
             self::$custom_reduction = $func;
-            return;
+            return $func;
         }
 
         $lhs = '1' . str_repeat('0', $m_length + ($m_length >> 1));

--- a/phpseclib/Net/SCP.php
+++ b/phpseclib/Net/SCP.php
@@ -32,6 +32,7 @@
 namespace phpseclib4\Net;
 
 use phpseclib4\Common\Functions\Strings;
+use phpseclib4\Exception\RuntimeException;
 use phpseclib4\Exception\FileNotFoundException;
 
 /**
@@ -60,14 +61,6 @@ class SCP extends SSH2
     //const SOURCE_CALLBACK = 16;
 
     /**
-     * Error information
-     *
-     * @see self::getSCPErrors()
-     * @see self::getLastSCPError()
-     */
-    private array $scp_errors = [];
-
-    /**
      * Uploads a file to the SCP server.
      *
      * By default, \phpseclib\Net\SCP::put() does not read from the local filesystem.  $data is dumped directly into $remote_file.
@@ -83,25 +76,22 @@ class SCP extends SSH2
      * 
      * @param string|resource $data
      */
-    public function put(string $remote_file, mixed $data, int $mode = self::SOURCE_STRING, ?callable $callback = null): bool
+    public function put(string $remote_file, mixed $data, int $mode = self::SOURCE_STRING, ?\Closure $callback = null): void
     {
-        if (!($this->bitmap & self::MASK_LOGIN)) {
-            return false;
+        if (!$this->isAuthenticated()) {
+            throw new RuntimeException('Unable to upload file. Not connected.');
         }
 
         if (empty($remote_file)) {
-            // remote file cannot be blank
-            return false;
+            throw new RuntimeException('Remote Filename cannot be blank');
         }
 
-        if (!$this->exec('scp -t ' . escapeshellarg($remote_file), false)) { // -t = to
-            return false;
-        }
+        $this->initExec('scp -t ' . escapeshellarg($remote_file)); // -t = to
 
         $temp = $this->get_channel_packet(self::CHANNEL_EXEC, true);
         if ($temp !== chr(0)) {
             $this->close_channel(self::CHANNEL_EXEC, true);
-            return false;
+            throw new RuntimeException('Expected but did not receive a null packet');
         }
 
         $packet_size = $this->packet_size_client_to_server[self::CHANNEL_EXEC] - 4;
@@ -128,7 +118,7 @@ class SCP extends SSH2
                 $fp = @fopen($data, 'rb');
                 if (!$fp) {
                     $this->close_channel(self::CHANNEL_EXEC, true);
-                    return false;
+                    throw new RuntimeException("Error opening $data");
                 }
         }
 
@@ -148,7 +138,7 @@ class SCP extends SSH2
         $temp = $this->get_channel_packet(self::CHANNEL_EXEC, true);
         if ($temp !== chr(0)) {
             $this->close_channel(self::CHANNEL_EXEC, true);
-            return false;
+            throw new RuntimeException('Expected but did not receive a null packet');
         }
 
         $sent = 0;
@@ -157,8 +147,8 @@ class SCP extends SSH2
             $this->send_channel_packet(self::CHANNEL_EXEC, $temp);
             $sent += strlen($temp);
 
-            if (is_callable($callback)) {
-                call_user_func($callback, $sent);
+            if (isset($callback)) {
+                $callback($sent);
             }
         }
         $this->close_channel(self::CHANNEL_EXEC, true);
@@ -166,8 +156,6 @@ class SCP extends SSH2
         if ($mode != self::SOURCE_STRING) {
             fclose($fp);
         }
-
-        return true;
     }
 
     /**
@@ -179,15 +167,13 @@ class SCP extends SSH2
      *
      * @param string|resource|null $local_file
      */
-    public function get(string $remote_file, mixed $local_file = null, ?callable $progressCallback = null): bool|string
+    public function get(string $remote_file, mixed $local_file = null, ?\Closure $progressCallback = null): ?string
     {
-        if (!($this->bitmap & self::MASK_LOGIN)) {
-            return false;
+        if (!$this->isAuthenticated()) {
+            throw new RuntimeException('Unable to download file. Not connected.');
         }
 
-        if (!$this->exec('scp -f ' . escapeshellarg($remote_file), false)) { // -f = from
-            return false;
-        }
+        $this->initExec('scp -f ' . escapeshellarg($remote_file)); // -f = from
 
         $this->send_channel_packet(self::CHANNEL_EXEC, chr(0));
 
@@ -195,28 +181,28 @@ class SCP extends SSH2
         // per https://goteleport.com/blog/scp-familiar-simple-insecure-slow/ non-zero responses mean there are errors
         if ($info[0] === chr(1) || $info[0] == chr(2)) {
             $type = $info[0] === chr(1) ? 'warning' : 'error';
-            $this->scp_errors[] = "$type: " . substr($info, 1);
             $this->close_channel(self::CHANNEL_EXEC, true);
-            return false;
+            throw new RuntimeException("Received a $type from server: " . substr($info, 1));
         }
 
         $this->send_channel_packet(self::CHANNEL_EXEC, chr(0));
 
         if (!preg_match('#(?<perms>[^ ]+) (?<size>\d+) (?<name>.+)#', rtrim($info), $info)) {
             $this->close_channel(self::CHANNEL_EXEC, true);
-            return false;
+            throw new RuntimeException('Response did not meet expected format');
         }
 
         $fclose_check = false;
         if (is_resource($local_file)) {
             $fp = $local_file;
-        } elseif (!is_null($local_file)) {
+        } elseif (isset($local_file)) {
             $fp = @fopen($local_file, 'wb');
             if (!$fp) {
                 $this->close_channel(self::CHANNEL_EXEC, true);
-                return false;
+                throw new RuntimeException("Unable to open local_file ($local_file)");
             }
             $fclose_check = true;
+            $content = null;
         } else {
             $content = '';
         }
@@ -224,12 +210,6 @@ class SCP extends SSH2
         $size = 0;
         while (true) {
             $data = $this->get_channel_packet(self::CHANNEL_EXEC, true);
-            // Terminate the loop in case the server repeatedly sends an empty response
-            if ($data === false) {
-                $this->close_channel(self::CHANNEL_EXEC, true);
-                // no data received from server
-                return false;
-            }
             // SCP usually seems to split stuff out into 16k chunks
             $length = strlen($data);
             $size += $length;
@@ -241,9 +221,8 @@ class SCP extends SSH2
                     $data = substr($data, 0, -$diff);
                 } else {
                     $type = $data[$offset] === chr(1) ? 'warning' : 'error';
-                    $this->scp_errors[] = "$type: " . substr($data, 1);
                     $this->close_channel(self::CHANNEL_EXEC, true);
-                    return false;
+                    throw new RuntimeException("Received a $type from server: " . substr($info, 1));
                 }
             }
 
@@ -253,8 +232,8 @@ class SCP extends SSH2
                 fputs($fp, $data);
             }
 
-            if (is_callable($progressCallback)) {
-                call_user_func($progressCallback, $size);
+            if (isset($progressCallback)) {
+                $progressCallback($size);
             }
 
             if ($end) {
@@ -269,22 +248,6 @@ class SCP extends SSH2
         }
 
         // if $content isn't set that means a file was written to
-        return $content ?? true;
-    }
-
-    /**
-     * Returns all errors on the SCP layer
-     */
-    public function getSCPErrors(): array
-    {
-        return $this->scp_errors;
-    }
-
-    /**
-     * Returns the last error on the SCP layer
-     */
-    public function getLastSCPError(): string
-    {
-        return count($this->scp_errors) ? $this->scp_errors[count($this->scp_errors) - 1] : '';
+        return $content;
     }
 }

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -157,6 +157,10 @@ class SFTP extends SSH2
     /**
      * Current working directory
      *
+     * bool(false) means we need to initiate the connection
+     * bool(true) means we don't have a string value but no connection initialization is needed
+     * otherwise it's a string
+     *
      * @see self::realpath()
      * @see self::chdir()
      */
@@ -182,28 +186,28 @@ class SFTP extends SSH2
      * @see self::_append_log()
      * @var resource|closed-resource
      */
-    private $realtime_log_file;
+    private mixed $realtime_log_file;
 
     /**
      * Real-time log file size
      *
      * @see self::_append_log()
      */
-    private int $realtime_log_size;
+    private ?int $realtime_log_size;
 
     /**
      * Real-time log file wrap boolean
      *
      * @see self::_append_log()
      */
-    private bool $realtime_log_wrap;
+    private ?bool $realtime_log_wrap;
 
     /**
      * Current log size
      *
      * Should never exceed self::LOG_MAX_SIZE
      */
-    private int $log_size;
+    private ?int $log_size;
 
     /**
      * Error information
@@ -305,12 +309,16 @@ class SFTP extends SSH2
     private int $queueSize = 32;
     private int $uploadQueueSize = 1024;
 
+    private string $lastErrorResponse;
+
     /**
      * Default Constructor.
      *
      * Connects to an SFTP server
+     *
+     * @param string|resource $host
      */
-    public function __construct($host, int $port = 22, int $timeout = 10)
+    public function __construct(mixed $host, int $port = 22, int $timeout = 10)
     {
         parent::__construct($host, $port, $timeout);
 
@@ -327,17 +335,15 @@ class SFTP extends SSH2
     /**
      * Check a few things before SFTP functions are called
      */
-    private function precheck(): bool
+    private function precheck(): void
     {
         if (!($this->bitmap & SSH2::MASK_LOGIN)) {
-            return false;
+            throw new RuntimeException("Function should not be called before you've logged in");
         }
 
         if ($this->pwd === false) {
-            return $this->init_sftp_connection();
+            $this->init_sftp_connection();
         }
-
-        return true;
     }
 
     /**
@@ -345,11 +351,11 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function partial_init_sftp_connection(): bool
+    private function partial_init_sftp_connection(): void
     {
         $response = $this->open_channel(self::CHANNEL, true);
         if ($response === true && $this->isTimeout()) {
-            return false;
+            throw new RuntimeException('Attempt to (re)connect timed out');
         }
 
         $packet = Strings::packSSH2(
@@ -386,10 +392,10 @@ class SFTP extends SSH2
 
             $response = $this->get_channel_packet(self::CHANNEL, true);
             if ($response === false) {
-                return false;
+                throw new RuntimeException('Received failure message when trying to open SFTP channel');
             }
         } elseif ($response === true && $this->isTimeout()) {
-            return false;
+            throw new RuntimeException('Attempt to (re)connect timed out');
         }
 
         $this->channel_status[self::CHANNEL] = SSH2MessageType::CHANNEL_DATA;
@@ -399,7 +405,7 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::VERSION) {
             throw new UnexpectedValueException(
                 'Expected PacketType::VERSION. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
@@ -412,17 +418,15 @@ class SFTP extends SSH2
         }
 
         $this->partial_init = true;
-
-        return true;
     }
 
     /**
      * (Re)initializes the SFTP channel
      */
-    private function init_sftp_connection(): bool
+    private function init_sftp_connection(): void
     {
-        if (!$this->partial_init && !$this->partial_init_sftp_connection()) {
-            return false;
+        if (!$this->partial_init) {
+            $this->partial_init_sftp_connection();
         }
 
         /*
@@ -468,7 +472,7 @@ class SFTP extends SSH2
                     if ($this->packet_type != SFTPPacketType::STATUS) {
                         throw new UnexpectedValueException(
                             'Expected PacketType::STATUS. '
-                            . 'Got packet type: ' . $this->packet_type
+                            . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                         );
                     }
                     [$status] = Strings::unpackSSH2('N', $response);
@@ -498,7 +502,7 @@ class SFTP extends SSH2
         }
         */
         if ($this->version < 2 || $this->version > 6) {
-            return false;
+            throw new RuntimeException('The only SFTP versions phpseclib supports are >= 2 and <= 6 - not ' . $this->version);
         }
 
         $this->pwd = true;
@@ -510,12 +514,11 @@ class SFTP extends SSH2
             }
             $this->canonicalize_paths = false;
             $this->reset_sftp();
-            return $this->init_sftp_connection();
+            $this->init_sftp_connection();
+            return;
         }
 
         $this->update_stat_cache($this->pwd, []);
-
-        return true;
     }
 
     /**
@@ -578,22 +581,39 @@ class SFTP extends SSH2
 
     /**
      * Returns the current directory name
-     *
-     * @return string|bool
      */
-    public function pwd()
+    public function pwd(): string
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         return $this->pwd;
+    }
+
+    private function throwStatusError(string $response, int $status = -1): RuntimeException
+    {
+        if ($status == -1) {
+            [$status] = Strings::unpackSSH2('N', $response);
+        }
+
+        $this->lastErrorResponse = $response;
+
+        $error = StatusCode::getConstantNameByValue($status);
+
+        if ($this->version > 2) {
+            [$message] = Strings::unpackSSH2('s', $response);
+            $output = "Error from server ($error)";
+            if (strlen($message)) {
+                $output.= ": $message";
+            }
+            return new RuntimeException($output, $status);
+        }
+        return new RuntimeException("Error from server ($error)", $status);
     }
 
     /**
      * Logs errors
      */
-    private function logError(string $response, int $status = -1): void
+    private function logError(string $response, int $status = -1, ?string $filename = null): void
     {
         if ($status == -1) {
             [$status] = Strings::unpackSSH2('N', $response);
@@ -603,9 +623,9 @@ class SFTP extends SSH2
 
         if ($this->version > 2) {
             [$message] = Strings::unpackSSH2('s', $response);
-            $this->sftp_errors[] = "$error: $message";
+            $this->sftp_errors[] = isset($filename) ? "$filename ($error): $message" : "$error: $message";
         } else {
-            $this->sftp_errors[] = $error;
+            $this->sftp_errors[] = isset($filename) ? "$filename ($error)" : $error;
         }
     }
 
@@ -621,11 +641,9 @@ class SFTP extends SSH2
      * @see    self::chdir()
      * @see    self::disablePathCanonicalization()
      */
-    public function realpath(string $path)
+    public function realpath(string $path): string
     {
-        if ($this->precheck() === false) {
-            return false;
-        }
+        $this->precheck();
 
         $path = (string) $path;
 
@@ -671,12 +689,11 @@ class SFTP extends SSH2
                     [, $filename] = Strings::unpackSSH2('Ns', $response);
                     return $filename;
                 case SFTPPacketType::STATUS:
-                    $this->logError($response);
-                    return false;
+                    throw $this->throwStatusError($response);
                 default:
                     throw new UnexpectedValueException(
                         'Expected PacketType::NAME or PacketType::STATUS. '
-                        . 'Got packet type: ' . $this->packet_type
+                        . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                     );
             }
         }
@@ -710,11 +727,9 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function chdir(string $dir): bool
+    public function chdir(string $dir): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $dir = (string) $dir;
 
@@ -727,14 +742,11 @@ class SFTP extends SSH2
         }
 
         $dir = $this->realpath($dir);
-        if ($dir === false) {
-            return false;
-        }
 
         // confirm that $dir is, in fact, a valid directory
         if ($this->use_stat_cache && is_array($this->query_stat_cache($dir))) {
             $this->pwd = $dir;
-            return true;
+            return;
         }
 
         // we could do a stat on the alleged $dir to see if it's a directory but that doesn't tell us
@@ -751,51 +763,37 @@ class SFTP extends SSH2
                 $handle = substr($response, 4);
                 break;
             case SFTPPacketType::STATUS:
-                $this->logError($response);
-                return false;
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS' .
-                    'Got packet type: ' . $this->packet_type
+                    'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
-        if (!$this->close_handle($handle)) {
-            return false;
-        }
+        $this->close_handle($handle);
 
         $this->update_stat_cache($dir, []);
 
         $this->pwd = $dir;
-        return true;
     }
 
     /**
      * Returns a list of files in the given directory
-     *
-     * @return array|false
      */
-    public function nlist(string $dir = '.', bool $recursive = false)
+    public function nlist(string $dir = '.', bool $recursive = false): array
     {
         return $this->nlist_helper($dir, $recursive, '');
     }
 
     /**
      * Helper method for nlist
-     *
-     * @return array|false
      */
-    private function nlist_helper(string $dir, bool $recursive, string $relativeDir)
+    private function nlist_helper(string $dir, bool $recursive, string $relativeDir): array
     {
         $files = $this->readlist($dir, false);
 
-        // If we get an int back, then that is an "unexpected" status.
-        // We do not have a file list, so return false.
-        if (is_int($files)) {
-            return false;
-        }
-
-        if (!$recursive || $files === false) {
+        if (!$recursive) {
             return $files;
         }
 
@@ -805,9 +803,16 @@ class SFTP extends SSH2
                 $result[] = $relativeDir . $value;
                 continue;
             }
-            if (is_array($this->query_stat_cache($this->realpath($dir . '/' . $value)))) {
-                $temp = $this->nlist_helper($dir . '/' . $value, true, $relativeDir . $value . '/');
-                $temp = is_array($temp) ? $temp : [];
+
+            $path = $this->realpath($dir . '/' . $value);
+            if (is_array($this->query_stat_cache($path))) {
+                try {
+                    $temp = $this->nlist_helper($dir . '/' . $value, true, $relativeDir . $value . '/');
+                } catch (\Exception $e) {
+                    $this->logError($this->lastErrorResponse, $e->getCode(), "OPENDIR $path");
+                    $temp = [];
+                }
+
                 $result = array_merge($result, $temp);
             } else {
                 $result[] = $relativeDir . $value;
@@ -820,20 +825,20 @@ class SFTP extends SSH2
     /**
      * Returns a detailed list of files in the given directory
      *
-     * @param null|\Closure(string, string, array):void $onFile Callback invoked for each file found. The parameters are: directory, filename, attributes.
-     * @return array|false
+     * @param ?\Closure(string, string, array):void $onFile Callback invoked for each file found. The parameters are: directory, filename, attributes.
      */
-    public function rawlist(string $dir = '.', bool $recursive = false, ?\Closure $onFile = null)
+    public function rawlist(string $dir = '.', bool $recursive = false, ?\Closure $onFile = null): array
     {
-        $files = $this->readlist($dir, true, $onFile);
-
-        // If we get an int back, then that is an "unexpected" status.
-        // We do not have a file list, so return false.
-        if (is_int($files)) {
-            return false;
+        try {
+            $files = $this->readlist($dir, true, $onFile);
+        } catch (\Exception $e) {
+            if (!$recursive) {
+                throw $e;
+            }
+            $files = [];
+            $this->logError($this->lastErrorResponse, $e->getCode(), "OPENDIR $dir");
         }
-
-        if (!$recursive || $files === false) {
+        if (!$recursive) {
             return $files;
         }
 
@@ -870,19 +875,13 @@ class SFTP extends SSH2
      * Reads a list, be it detailed or not, of files in the given directory
      *
      * @param null|\Closure(string, string, array):void $onFile Callback invoked for each file found. The parameters are: directory, filename, attributes.
-     * @return array|int|false array of files, integer status (if known) or false if something else is wrong
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function readlist(string $dir, bool $raw = true, ?\Closure $onFile = null): array|int|false
+    private function readlist(string $dir, bool $raw = true, ?\Closure $onFile = null): array
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $dir = $this->realpath($dir . '/');
-        if ($dir === false) {
-            return false;
-        }
 
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-8.1.2
         $this->send_sftp_packet(SFTPPacketType::OPENDIR, Strings::packSSH2('s', $dir));
@@ -896,14 +895,12 @@ class SFTP extends SSH2
                 $handle = substr($response, 4);
                 break;
             case SFTPPacketType::STATUS:
-                // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-                [$status] = Strings::unpackSSH2('N', $response);
-                $this->logError($response, $status);
-                return $status;
+                // presumably the status code is either SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
@@ -927,9 +924,9 @@ class SFTP extends SSH2
                         if ($this->version < 4) {
                             [$longname] = Strings::unpackSSH2('s', $response);
                         }
-                        $attributes = $this->parseAttributes($response);
+                        $attributes = self::parseAttributes($this->version, $response);
                         if (!isset($attributes['type']) && $this->version < 4) {
-                            $fileType = $this->parseLongname($longname);
+                            $fileType = self::parseLongname($longname);
                             if ($fileType) {
                                 $attributes['type'] = $fileType;
                             }
@@ -949,7 +946,7 @@ class SFTP extends SSH2
                         // SFTPv6 has an optional boolean end-of-list field, but we'll ignore that, since the
                         // final SSH_FXP_STATUS packet should tell us that, already.
 
-                        if ($onFile !== null) {
+                        if ($onFile) {
                             $onFile($dir, $shortname, $attributes);
                         }
                     }
@@ -957,21 +954,18 @@ class SFTP extends SSH2
                 case SFTPPacketType::STATUS:
                     [$status] = Strings::unpackSSH2('N', $response);
                     if ($status != StatusCode::EOF) {
-                        $this->logError($response, $status);
-                        return $status;
+                        throw $this->throwStatusError($response, $status);
                     }
                     break 2;
                 default:
                     throw new UnexpectedValueException(
                         'Expected PacketType::NAME or PacketType::STATUS. '
-                        . 'Got packet type: ' . $this->packet_type
+                        . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                     );
             }
         }
 
-        if (!$this->close_handle($handle)) {
-            return false;
-        }
+        $this->close_handle($handle);
 
         if (count($this->sortOptions)) {
             uasort($contents, [&$this, 'comparator']);
@@ -1060,7 +1054,7 @@ class SFTP extends SSH2
      *
      * @param string ...$args
      */
-    public function setListOrder(...$args): void
+    public function setListOrder(string|int ...$args): void
     {
         $this->sortOptions = [];
         if (empty($args)) {
@@ -1078,7 +1072,7 @@ class SFTP extends SSH2
     /**
      * Save files / directories to cache
      */
-    private function update_stat_cache(string $path, $value): void
+    private function update_stat_cache(string $path, object|array $value): void
     {
         if ($this->use_stat_cache === false) {
             return;
@@ -1118,7 +1112,7 @@ class SFTP extends SSH2
     /**
      * Remove files / directories from cache
      */
-    private function remove_from_stat_cache(string $path): bool
+    private function remove_from_stat_cache(string $path): void
     {
         $dirs = explode('/', preg_replace('#^/|/(?=/)|/$#', '', $path));
 
@@ -1126,14 +1120,14 @@ class SFTP extends SSH2
         $max = count($dirs) - 1;
         foreach ($dirs as $i => $dir) {
             if (!is_array($temp)) {
-                return false;
+                return;
             }
             if ($i === $max) {
                 unset($temp[$dir]);
-                return true;
+                return;
             }
             if (!isset($temp[$dir])) {
-                return false;
+                return;
             }
             $temp = &$temp[$dir];
         }
@@ -1142,9 +1136,9 @@ class SFTP extends SSH2
     /**
      * Checks cache for path
      *
-     * Mainly used by file_exists
+     * Returns object for files, array for directories and null if it's neither
      */
-    private function query_stat_cache(string $path)
+    private function query_stat_cache(string $path): object|array|null
     {
         $dirs = explode('/', preg_replace('#^/|/(?=/)|/$#', '', $path));
 
@@ -1165,19 +1159,12 @@ class SFTP extends SSH2
      * Returns general information about a file.
      *
      * Returns an array on success and false otherwise.
-     *
-     * @return array|false
      */
-    public function stat(string $filename)
+    public function stat(string $filename): array
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $filename = $this->realpath($filename);
-        if ($filename === false) {
-            return false;
-        }
 
         if ($this->use_stat_cache) {
             $result = $this->query_stat_cache($filename);
@@ -1189,10 +1176,11 @@ class SFTP extends SSH2
             }
         }
 
-        $stat = $this->stat_helper($filename, SFTPPacketType::STAT);
-        if ($stat === false) {
+        try {
+            $stat = $this->stat_helper($filename, SFTPPacketType::STAT);
+        } catch (\Exception $e) {
             $this->remove_from_stat_cache($filename);
-            return false;
+            throw $e;
         }
         if (isset($stat['type'])) {
             if ($stat['type'] == FileType::DIRECTORY) {
@@ -1220,19 +1208,12 @@ class SFTP extends SSH2
      * Returns general information about a file or symbolic link.
      *
      * Returns an array on success and false otherwise.
-     *
-     * @return array|false
      */
-    public function lstat(string $filename)
+    public function lstat(string $filename): array
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
-        $filename = $this->realpath($filename);
-        if ($filename === false) {
-            return false;
-        }
+        $this->realpath($filename);
 
         if ($this->use_stat_cache) {
             $result = $this->query_stat_cache($filename);
@@ -1244,10 +1225,11 @@ class SFTP extends SSH2
             }
         }
 
-        $lstat = $this->stat_helper($filename, SFTPPacketType::LSTAT);
-        if ($lstat === false) {
+        try {
+            $lstat = $this->stat_helper($filename, SFTPPacketType::LSTAT);
+        } catch (\Exception $e) {
             $this->remove_from_stat_cache($filename);
-            return false;
+            throw $e;
         }
         if (isset($lstat['type'])) {
             if ($lstat['type'] == FileType::DIRECTORY) {
@@ -1285,10 +1267,9 @@ class SFTP extends SSH2
      * Determines information without calling \phpseclib4\Net\SFTP::realpath().
      * The second parameter can be either PacketType::STAT or PacketType::LSTAT.
      *
-     * @return array|false
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function stat_helper(string $filename, int $type)
+    private function stat_helper(string $filename, int $type): array
     {
         // SFTPv4+ adds an additional 32-bit integer field - flags - to the following:
         $packet = Strings::packSSH2('s', $filename);
@@ -1297,26 +1278,27 @@ class SFTP extends SSH2
         $response = $this->get_sftp_packet();
         switch ($this->packet_type) {
             case SFTPPacketType::ATTRS:
-                return $this->parseAttributes($response);
+                return self::parseAttributes($this->version, $response);
             case SFTPPacketType::STATUS:
-                $this->logError($response);
-                return false;
+                throw $this->throwStatusError($response);
         }
 
         throw new UnexpectedValueException(
             'Expected PacketType::ATTRS or PacketType::STATUS. '
-            . 'Got packet type: ' . $this->packet_type
+            . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
         );
     }
 
     /**
      * Truncates a file to a given length
      */
-    public function truncate(string $filename, int $new_size): bool
+    public function truncate(string $filename, int $new_size): void
     {
+        $this->precheck();
+
         $attr = Strings::packSSH2('NQ', Attribute::SIZE, $new_size);
 
-        return $this->setstat($filename, $attr, false);
+        $this->setstat($filename, $attr, false);
     }
 
     /**
@@ -1326,16 +1308,11 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function touch(string $filename, ?int $time = null, ?int $atime = null): bool
+    public function touch(string $filename, ?int $time = null, ?int $atime = null): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $filename = $this->realpath($filename);
-        if ($filename === false) {
-            return false;
-        }
 
         if (!isset($time)) {
             $time = time();
@@ -1359,18 +1336,18 @@ class SFTP extends SSH2
         $response = $this->get_sftp_packet();
         switch ($this->packet_type) {
             case SFTPPacketType::HANDLE:
-                return $this->close_handle(substr($response, 4));
+                $this->close_handle(substr($response, 4));
+                return;
             case SFTPPacketType::STATUS:
-                $this->logError($response);
-                break;
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
-        return $this->setstat($filename, $attr, false);
+        $this->setstat($filename, $attr, false);
     }
 
     /**
@@ -1380,13 +1357,11 @@ class SFTP extends SSH2
      * would be of the form "user@dns_domain" but it does not need to be.
      * `$sftp->getSupportedVersions()['version']` will return the specific version
      * that's being used.
-     *
-     * Returns true on success or false on error.
-     *
-     * @param int|string $uid
      */
-    public function chown(string $filename, $uid, bool $recursive = false): bool
+    public function chown(string $filename, int|string $uid, bool $recursive = false): void
     {
+        $this->precheck();
+
         /*
          quoting <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-7.5>,
 
@@ -1414,7 +1389,7 @@ class SFTP extends SSH2
             //  during a modification operation"
             Strings::packSSH2('Nss', Attribute::OWNERGROUP, $uid, '');
 
-        return $this->setstat($filename, $attr, $recursive);
+        $this->setstat($filename, $attr, $recursive);
     }
 
     /**
@@ -1426,63 +1401,29 @@ class SFTP extends SSH2
      * that's being used.
      *
      * Returns true on success or false on error.
-     *
-     * @param int|string $gid
      */
-    public function chgrp(string $filename, $gid, bool $recursive = false): bool
+    public function chgrp(string $filename, int|string $gid, bool $recursive = false): void
     {
+        $this->precheck();
+
         $attr = $this->version < 4 ?
             pack('N3', Attribute::UIDGID, -1, $gid) :
             Strings::packSSH2('Nss', Attribute::OWNERGROUP, '', $gid);
 
-        return $this->setstat($filename, $attr, $recursive);
+        $this->setstat($filename, $attr, $recursive);
     }
 
     /**
-     * Set permissions on a file.
-     *
-     * Returns the new file permissions on success or false on error.
-     * If $recursive is true than this just returns true or false.
+     * Set permissions on a file
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function chmod(int $mode, string $filename, bool $recursive = false)
+    public function chmod(string $filename, int $mode, bool $recursive = false): void
     {
-        if (is_string($mode) && is_int($filename)) {
-            $temp = $mode;
-            $mode = $filename;
-            $filename = $temp;
-        }
+        $this->precheck();
 
         $attr = pack('N2', Attribute::PERMISSIONS, $mode & 0o7777);
-        if (!$this->setstat($filename, $attr, $recursive)) {
-            return false;
-        }
-        if ($recursive) {
-            return true;
-        }
-
-        $filename = $this->realpath($filename);
-        // rather than return what the permissions *should* be, we'll return what they actually are.  this will also
-        // tell us if the file actually exists.
-        // incidentally, SFTPv4+ adds an additional 32-bit integer field - flags - to the following:
-        $packet = pack('Na*', strlen($filename), $filename);
-        $this->send_sftp_packet(SFTPPacketType::STAT, $packet);
-
-        $response = $this->get_sftp_packet();
-        switch ($this->packet_type) {
-            case SFTPPacketType::ATTRS:
-                $attrs = $this->parseAttributes($response);
-                return $attrs['mode'];
-            case SFTPPacketType::STATUS:
-                $this->logError($response);
-                return false;
-        }
-
-        throw new UnexpectedValueException(
-            'Expected PacketType::ATTRS or PacketType::STATUS. '
-            . 'Got packet type: ' . $this->packet_type
-        );
+        $this->setstat($filename, $attr, $recursive);
     }
 
     /**
@@ -1490,24 +1431,17 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function setstat(string $filename, string $attr, bool $recursive): bool
+    private function setstat(string $filename, string $attr, bool $recursive): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
-
         $filename = $this->realpath($filename);
-        if ($filename === false) {
-            return false;
-        }
 
         $this->remove_from_stat_cache($filename);
 
         if ($recursive) {
-            $i = 0;
-            $result = $this->setstat_recursive($filename, $attr, $i);
-            $this->read_put_responses($i);
-            return $result;
+            $files = [];
+            $this->setstat_recursive($filename, $attr, $files);
+            $this->read_put_responses($files);
+            return;
         }
 
         $packet = Strings::packSSH2('s', $filename);
@@ -1527,17 +1461,14 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response, $status);
         }
-
-        return true;
     }
 
     /**
@@ -1545,35 +1476,39 @@ class SFTP extends SSH2
      *
      * Minimizes directory lookups and SSH_FXP_STATUS requests for speed.
      */
-    private function setstat_recursive(string $path, string $attr, int &$i): bool
+    private function setstat_recursive(string $path, string $attr, array &$files): void
     {
-        if (!$this->read_put_responses($i)) {
-            return false;
-        }
-        $i = 0;
-        $entries = $this->readlist($path, true);
+        $this->read_put_responses($files);
 
-        if ($entries === false || is_int($entries)) {
-            return $this->setstat($path, $attr, false);
+        try {
+            // try to open $path as a directory
+            $entries = $this->readlist($path, true);
+        } catch (\Exception $e) {
+            $this->logError($this->lastErrorResponse, $e->getCode(), "OPENDIR $path");
+            // if it can't be opened assume it's a file
+            try {
+                $this->setstat($path, $attr, false);
+            } catch (\Exception $e) {
+                $this->logError($this->lastErrorResponse, $e->getCode(), "SETSTAT $path");
+            }
+            return;
         }
 
         // normally $entries would have at least . and .. but it might not if the directories
         // permissions didn't allow reading
         if (empty($entries)) {
-            return false;
+            throw new RuntimeException('Directory has zero entries - it should have at least . and ..');
         }
 
         unset($entries['.'], $entries['..']);
         foreach ($entries as $filename => $props) {
             if (!isset($props['type'])) {
-                return false;
+                throw new RuntimeException('Unable to determine the "type');
             }
 
             $temp = $path . '/' . $filename;
             if ($props['type'] == FileType::DIRECTORY) {
-                if (!$this->setstat_recursive($temp, $attr, $i)) {
-                    return false;
-                }
+                $this->setstat_recursive($temp, $attr, $files);
             } else {
                 $packet = Strings::packSSH2('s', $temp);
                 $packet .= $this->version >= 4 ?
@@ -1581,13 +1516,9 @@ class SFTP extends SSH2
                     $attr;
                 $this->send_sftp_packet(SFTPPacketType::SETSTAT, $packet);
 
-                $i++;
-
-                if ($i >= $this->queueSize) {
-                    if (!$this->read_put_responses($i)) {
-                        return false;
-                    }
-                    $i = 0;
+                $files[] = $filename;
+                if (count($files) >= $this->queueSize) {
+                    $this->read_put_responses($files);
                 }
             }
         }
@@ -1598,16 +1529,10 @@ class SFTP extends SSH2
             $attr;
         $this->send_sftp_packet(SFTPPacketType::SETSTAT, $packet);
 
-        $i++;
-
-        if ($i >= $this->queueSize) {
-            if (!$this->read_put_responses($i)) {
-                return false;
-            }
-            $i = 0;
+        $files[] = $filename;
+        if (count($files) >= $this->queueSize) {
+            $this->read_put_responses($files);
         }
-
-        return true;
     }
 
     /**
@@ -1615,11 +1540,9 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function readlink(string $link)
+    public function readlink(string $link): string
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $link = $this->realpath($link);
 
@@ -1630,19 +1553,17 @@ class SFTP extends SSH2
             case SFTPPacketType::NAME:
                 break;
             case SFTPPacketType::STATUS:
-                $this->logError($response);
-                return false;
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::NAME or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
         [$count] = Strings::unpackSSH2('N', $response);
-        // the file isn't a symlink
         if (!$count) {
-            return false;
+            throw new RuntimException('The file in question is not a symlink');
         }
 
         [$filename] = Strings::unpackSSH2('s', $response);
@@ -1653,15 +1574,13 @@ class SFTP extends SSH2
     /**
      * Create a symlink
      *
-     * symlink() creates a symbolic link to the existing target with the specified name link.
+     * symlink() creates a symbolic link to the existing $target with the specified name $link.
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function symlink(string $target, string $link): bool
+    public function symlink(string $target, string $link): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         //$target = $this->realpath($target);
         $link = $this->realpath($link);
@@ -1702,29 +1621,30 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response, $status);
         }
-
-        return true;
     }
 
     /**
      * Creates a directory.
      */
-    public function mkdir(string $dir, int $mode = -1, bool $recursive = false): bool
+    public function mkdir(string $dir, int $mode = -1, bool $recursive = false): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $dir = $this->realpath($dir);
+        // if the fully expanded directory is already a directory then trying to
+        // create it anew would result in an exception being thrown. at least if
+        // it weren't for the following line
+        if ($this->is_dir($dir)) {
+            return;
+        }
 
         if ($recursive) {
             $dirs = explode('/', preg_replace('#/(?=/)|/$#', '', $dir));
@@ -1735,18 +1655,27 @@ class SFTP extends SSH2
             for ($i = 0; $i < count($dirs); $i++) {
                 $temp = array_slice($dirs, 0, $i + 1);
                 $temp = implode('/', $temp);
-                $result = $this->mkdir_helper($temp, $mode);
+                try {
+                    $this->mkdir_helper($temp, $mode);
+                } catch (\Exception $e) {
+                    // if we're trying to create /home/user/path/to/whatever and /home/user already exists,
+                    // exceptions will be thrown, but that doesn't mean we can't try successive directories
+                    // until we succeed
+                    if ($i === count($dirs) - 1) {
+                        throw $e;
+                    }
+                }
             }
-            return $result;
+            return;
         }
 
-        return $this->mkdir_helper($dir, $mode);
+        $this->mkdir_helper($dir, $mode);
     }
 
     /**
      * Helper function for directory creation
      */
-    private function mkdir_helper(string $dir, int $mode): bool
+    private function mkdir_helper(string $dir, int $mode): void
     {
         // send SSH_FXP_MKDIR without any attributes (that's what the \0\0\0\0 is doing)
         $this->send_sftp_packet(SFTPPacketType::MKDIR, Strings::packSSH2('s', $dir) . "\0\0\0\0");
@@ -1755,21 +1684,18 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response, $status);
         }
 
         if ($mode !== -1) {
             $this->chmod($mode, $dir);
         }
-
-        return true;
     }
 
     /**
@@ -1777,16 +1703,11 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function rmdir(string $dir): bool
+    public function rmdir(string $dir): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $dir = $this->realpath($dir);
-        if ($dir === false) {
-            return false;
-        }
 
         $this->send_sftp_packet(SFTPPacketType::RMDIR, Strings::packSSH2('s', $dir));
 
@@ -1794,24 +1715,21 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
             // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED?
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response);
         }
 
         $this->remove_from_stat_cache($dir);
         // the following will do a soft delete, which would be useful if you deleted a file
         // and then tried to do a stat on the deleted file. the above, in contrast, does
         // a hard delete
-        //$this->update_stat_cache($dir, false);
-
-        return true;
+        //$this->update_stat_cache($dir, null);
     }
 
     /**
@@ -1852,21 +1770,16 @@ class SFTP extends SSH2
      *
      * {@internal ASCII mode for SFTPv4/5/6 can be supported by adding a new function - \phpseclib4\Net\SFTP::setMode().}
      *
-     * @param  resource|array|string $data
+     * @param  resource|string $data
      * @throws UnexpectedValueException on receipt of unexpected packets
      * @throws BadFunctionCallException if you're uploading via a callback and the callback function is invalid
      * @throws FileNotFoundException if you're uploading via a file and the file doesn't exist
      */
-    public function put(string $remote_file, $data, int $mode = self::SOURCE_STRING, int $start = -1, int $local_start = -1, ?callable $progressCallback = null): bool
+    public function put(string $remote_file, mixed $data, int $mode = self::SOURCE_STRING, int $start = -1, int $local_start = -1, ?\Closure $progressCallback = null): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $remote_file = $this->realpath($remote_file);
-        if ($remote_file === false) {
-            return false;
-        }
 
         $this->remove_from_stat_cache($remote_file);
 
@@ -1907,13 +1820,12 @@ class SFTP extends SSH2
             case SFTPPacketType::HANDLE:
                 $handle = substr($response, 4);
                 break;
-            case SFTPPacketType::STATUS:
-                $this->logError($response);
-                return false;
+            case SFTPPacketType::STATUS:break;
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
@@ -1921,8 +1833,8 @@ class SFTP extends SSH2
         $dataCallback = false;
         switch (true) {
             case $mode & self::SOURCE_CALLBACK:
-                if (!is_callable($data)) {
-                    throw new BadFunctionCallException("\$data should be is_callable() if you specify SOURCE_CALLBACK flag");
+                if (!$data instanceof \Closure) {
+                    throw new BadFunctionCallException("\$data should be a Closure if you specify SOURCE_CALLBACK flag");
                 }
                 $dataCallback = $data;
                 // do nothing
@@ -1944,7 +1856,7 @@ class SFTP extends SSH2
                 }
                 $fp = @fopen($data, 'rb');
                 if (!$fp) {
-                    return false;
+                    throw new RuntimeException("Error opening $data");
                 }
         }
 
@@ -1996,48 +1908,35 @@ class SFTP extends SSH2
                 throw $e;
             }
             $sent += strlen($temp);
-            if (is_callable($progressCallback)) {
+            if ($progressCallback) {
                 $progressCallback($sent);
             }
 
             $i++;
             $j++;
             if ($i == $this->uploadQueueSize) {
-                if (!$this->read_put_responses($i)) {
-                    $i = 0;
-                    break;
-                }
-                $i = 0;
+                $this->read_put_responses($i);
             }
         }
 
-        $result = $this->close_handle($handle);
-
-        if (!$this->read_put_responses($i)) {
-            if ($mode & self::SOURCE_LOCAL_FILE) {
+        try {
+            $this->read_put_responses($i);
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            if (($mode & self::SOURCE_LOCAL_FILE) && isset($fp) && is_resource($fp)) {
                 fclose($fp);
             }
             $this->close_handle($handle);
-            return false;
         }
 
-        if ($mode & SFTP::SOURCE_LOCAL_FILE) {
-            if (isset($fp) && is_resource($fp)) {
-                fclose($fp);
-            }
-
-            if ($this->preserveTime) {
-                $stat = stat($data);
-                $attr = $this->version < 4 ?
-                    pack('N3', Attribute::ACCESSTIME, $stat['atime'], $stat['mtime']) :
-                    Strings::packSSH2('NQ2', Attribute::ACCESSTIME | Attribute::MODIFYTIME, $stat['atime'], $stat['mtime']);
-                if (!$this->setstat($remote_file, $attr, false)) {
-                    throw new RuntimeException('Error setting file time');
-                }
-            }
+        if (($mode & SFTP::SOURCE_LOCAL_FILE) && $this->preserveTime) {
+            $stat = stat($data);
+            $attr = $this->version < 4 ?
+                pack('N3', Attribute::ACCESSTIME, $stat['atime'], $stat['mtime']) :
+                Strings::packSSH2('NQ2', Attribute::ACCESSTIME | Attribute::MODIFYTIME, $stat['atime'], $stat['mtime']);
+            $this->setstat($remote_file, $attr, false);
         }
-
-        return $result;
     }
 
     /**
@@ -2048,25 +1947,39 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function read_put_responses(int $i): bool
+    private function read_put_responses(int|array &$count): void
     {
+        if (is_array($count)) {
+            $files = &$count;
+            $i = $size = count($count);
+            $size--;
+        } else {
+            $i = $count;
+        }
         while ($i--) {
             $response = $this->get_sftp_packet();
             if ($this->packet_type != SFTPPacketType::STATUS) {
                 throw new UnexpectedValueException(
                     'Expected PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
             }
 
             [$status] = Strings::unpackSSH2('N', $response);
             if ($status != StatusCode::OK) {
-                $this->logError($response, $status);
-                break;
+                if (!isset($files)) {
+                    throw $this->throwStatusError($response, $status);
+                }
+                $this->logError($response, $status, $files[$size - $i]);
             }
         }
 
-        return $i < 0;
+        if (isset($files)) {
+            $files = [];
+        } else {
+            $count = 0;
+        }
+        //return $i < 0;
     }
 
     /**
@@ -2074,7 +1987,7 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    private function close_handle(string $handle): bool
+    private function close_handle(string $handle): void
     {
         $this->send_sftp_packet(SFTPPacketType::CLOSE, pack('Na*', strlen($handle), $handle));
 
@@ -2084,17 +1997,14 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw throw $this->throwStatusError($response, $status);
         }
-
-        return true;
     }
 
     /**
@@ -2105,22 +2015,17 @@ class SFTP extends SSH2
      *
      * $offset and $length can be used to download files in chunks.
      *
-     * @param  string|bool|resource|callable $local_file
+     * @param  string|bool|resource|\Closure $local_file
      * @return string|true
      * @throws RuntimeException if unable to download file (not connected, file not found, permission denied, etc.)
      * @throws FileNotFoundException if remote file path cannot be resolved
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function get(string $remote_file, $local_file = false, int $offset = 0, int $length = -1, ?callable $progressCallback = null)
+    public function get(string $remote_file, mixed $local_file = null, int $offset = 0, int $length = -1, ?\Closure $progressCallback = null): ?string
     {
-        if (!$this->precheck()) {
-            throw new RuntimeException('Unable to download file. Not connected or SFTP connection not initialized');
-        }
+        $this->precheck();
 
         $remote_file = $this->realpath($remote_file);
-        if ($remote_file === false) {
-            throw new FileNotFoundException("Cannot resolve remote file path: $remote_file");
-        }
 
         $packet = Strings::packSSH2('s', $remote_file);
         $packet .= $this->version >= 5 ?
@@ -2134,12 +2039,11 @@ class SFTP extends SSH2
                 $handle = substr($response, 4);
                 break;
             case SFTPPacketType::STATUS: // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-                $this->logError($response);
-                throw new RuntimeException("Unable to open remote file \"$remote_file\": " . $this->getLastSFTPError());
+                throw $this->throwStatusError($response);
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
 
@@ -2149,8 +2053,8 @@ class SFTP extends SSH2
             $res_offset = $stat['size'];
         } else {
             $res_offset = 0;
-            if ($local_file !== false && !is_callable($local_file)) {
-                $fp = fopen($local_file, 'wb');
+            if (is_string($local_file)) {
+                $fp = @fopen($local_file, 'wb');
                 if (!$fp) {
                     throw new RuntimeException("Unable to open local file \"$local_file\" for writing");
                 }
@@ -2159,7 +2063,7 @@ class SFTP extends SSH2
             }
         }
 
-        $fclose_check = $local_file !== false && !is_callable($local_file) && !is_resource($local_file);
+        $fclose_check = isset($local_file) && (!$local_file instanceof \Closure) && !is_resource($local_file);
 
         $start = $offset;
         $read = 0;
@@ -2206,21 +2110,21 @@ class SFTP extends SSH2
                     case SFTPPacketType::DATA:
                         $temp = substr($response, 4);
                         $offset += strlen($temp);
-                        if ($local_file === false) {
+                        if (!isset($local_file)) {
                             $content .= $temp;
                         } elseif (is_callable($local_file)) {
                             $local_file($temp);
                         } else {
                             fwrite($fp, $temp);
                         }
-                        if (is_callable($progressCallback)) {
-                            call_user_func($progressCallback, $offset);
+                        if ($progressCallback) {
+                            $progressCallback($offset);
                         }
                         $temp = null;
                         break;
                     case SFTPPacketType::STATUS:
                         // could, in theory, return false if !strlen($content) but we'll hold off for the time being
-                        $this->logError($response);
+                        //$this->logError($response);
                         $clear_responses = true; // don't break out of the loop yet, so we can read the remaining responses
                         break;
                     default:
@@ -2234,7 +2138,7 @@ class SFTP extends SSH2
                         } else {
                             throw new UnexpectedValueException(
                                 'Expected PacketType::DATA or PacketType::STATUS. '
-                                                          . 'Got packet type: ' . $this->packet_type
+                                                          . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                             );
                         }
                 }
@@ -2255,12 +2159,10 @@ class SFTP extends SSH2
             }
         }
 
-        if (!$this->close_handle($handle)) {
-            throw new RuntimeException('Failed to close remote file handle');
-        }
+        $this->close_handle($handle);
 
         // if $content isn't set that means a file was written to
-        return $content ?? true;
+        return $content ?? null;
     }
 
     /**
@@ -2268,25 +2170,15 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function delete(string $path, bool $recursive = true): bool
+    public function delete(string $path, bool $recursive = true): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
-        if (is_object($path)) {
-            // It's an object. Cast it as string before we check anything else.
-            $path = (string) $path;
-        }
-
-        if (!is_string($path) || $path == '') {
-            return false;
+        if (!strlen($path)) {
+            throw new RuntimeException('strlen($path) should be > 0');
         }
 
         $path = $this->realpath($path);
-        if ($path === false) {
-            return false;
-        }
 
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-8.3
         $this->send_sftp_packet(SFTPPacketType::REMOVE, pack('Na*', strlen($path), $path));
@@ -2295,27 +2187,30 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            if (!$recursive) {
-                return false;
+            if ($recursive) {
+                // if you're trying to delete a directory you'll have 1x entry in getSFTPErrors() as it'll
+                // first try to delete it as a file. if the file you're deleting doesn't exist you'll have
+                // 2x entries - the first one being for your attempt to delete the "file" as a directory
+                // and the second attempting to delete the "file" as a file
+                $this->logError($response, $status, "REMOVE $path");
+            } else {
+                throw $this->throwStatusError($response, $status);
             }
 
-            $i = 0;
-            $result = $this->delete_recursive($path, $i);
-            $this->read_put_responses($i);
-            return $result;
+            $files = [];
+            $this->delete_recursive($path, $files);
+            $this->read_put_responses($files);
+            return;
         }
 
         $this->remove_from_stat_cache($path);
-
-        return true;
     }
 
     /**
@@ -2323,47 +2218,37 @@ class SFTP extends SSH2
      *
      * Minimizes directory lookups and SSH_FXP_STATUS requests for speed.
      */
-    private function delete_recursive(string $path, int &$i): bool
+    private function delete_recursive(string $path, array &$files): void
     {
-        if (!$this->read_put_responses($i)) {
-            return false;
-        }
-        $i = 0;
-        $entries = $this->readlist($path, true);
-
-        // The folder does not exist at all, so we cannot delete it.
-        if ($entries === StatusCode::NO_SUCH_FILE) {
-            return false;
-        }
-
-        // Normally $entries would have at least . and .. but it might not if the directories
-        // permissions didn't allow reading. If this happens then default to an empty list of files.
-        if ($entries === false || is_int($entries)) {
+        $this->read_put_responses($files, true);
+        try {
+            $entries = $this->readlist($path, true);
+        } catch (\Exception $e) {
+            $this->logError($this->lastErrorResponse, $e->getCode(), "OPENDIR $path");
+            if ($e->getCode() == StatusCode::NO_SUCH_FILE) {
+                return;
+            }
+            // it's possible that the permissions just don't allow reading. in this scenario
+            // default to an empty list of files
             $entries = [];
         }
 
         unset($entries['.'], $entries['..']);
         foreach ($entries as $filename => $props) {
             if (!isset($props['type'])) {
-                return false;
+                throw new RuntimeException('Unable to determine resource type');
             }
 
             $temp = $path . '/' . $filename;
             if ($props['type'] == FileType::DIRECTORY) {
-                if (!$this->delete_recursive($temp, $i)) {
-                    return false;
-                }
+                $this->delete_recursive($temp, $files);
             } else {
                 $this->send_sftp_packet(SFTPPacketType::REMOVE, Strings::packSSH2('s', $temp));
                 $this->remove_from_stat_cache($temp);
 
-                $i++;
-
-                if ($i >= $this->queueSize) {
-                    if (!$this->read_put_responses($i)) {
-                        return false;
-                    }
-                    $i = 0;
+                $files[] = "REMOVE $temp";
+                if (count($files) >= $this->queueSize) {
+                    $this->read_put_responses($files);
                 }
             }
         }
@@ -2371,16 +2256,10 @@ class SFTP extends SSH2
         $this->send_sftp_packet(SFTPPacketType::RMDIR, Strings::packSSH2('s', $path));
         $this->remove_from_stat_cache($path);
 
-        $i++;
-
-        if ($i >= $this->queueSize) {
-            if (!$this->read_put_responses($i)) {
-                return false;
-            }
-            $i = 0;
+        $files[] = "RMDIR $path";
+        if (count($files) >= $this->queueSize) {
+            $this->read_put_responses($files);
         }
-
-        return true;
     }
 
     /**
@@ -2389,10 +2268,6 @@ class SFTP extends SSH2
     public function file_exists(string $path): bool
     {
         if ($this->use_stat_cache) {
-            if (!$this->precheck()) {
-                return false;
-            }
-
             $path = $this->realpath($path);
 
             $result = $this->query_stat_cache($path);
@@ -2403,7 +2278,12 @@ class SFTP extends SSH2
             }
         }
 
-        return $this->stat($path) !== false;
+        try {
+            $this->stat($path);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**
@@ -2411,11 +2291,11 @@ class SFTP extends SSH2
      */
     public function is_dir(string $path): bool
     {
-        $result = $this->get_stat_cache_prop($path, 'type');
-        if ($result === false) {
+        try {
+            return $this->get_stat_cache_prop($path, 'type') === FileType::DIRECTORY;
+        } catch (\Exception $e) {
             return false;
         }
-        return $result === FileType::DIRECTORY;
     }
 
     /**
@@ -2423,11 +2303,11 @@ class SFTP extends SSH2
      */
     public function is_file(string $path): bool
     {
-        $result = $this->get_stat_cache_prop($path, 'type');
-        if ($result === false) {
+        try {
+            return $this->get_stat_cache_prop($path, 'type') === FileType::REGULAR;
+        } catch (\Exception $e) {
             return false;
         }
-        return $result === FileType::REGULAR;
     }
 
     /**
@@ -2435,11 +2315,11 @@ class SFTP extends SSH2
      */
     public function is_link(string $path): bool
     {
-        $result = $this->get_lstat_cache_prop($path, 'type');
-        if ($result === false) {
+        try {
+            return $this->get_lstat_cache_prop($path, 'type') === FileType::SYMLINK;
+        } catch (\Exception $e) {
             return false;
         }
-        return $result === FileType::SYMLINK;
     }
 
     /**
@@ -2447,9 +2327,7 @@ class SFTP extends SSH2
      */
     public function is_readable(string $path): bool
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $packet = Strings::packSSH2('sNN', $this->realpath($path), OpenFlag::READ, 0);
         $this->send_sftp_packet(SFTPPacketType::OPEN, $packet);
@@ -2463,7 +2341,7 @@ class SFTP extends SSH2
             default:
                 throw new UnexpectedValueException(
                     'Expected PacketType::HANDLE or PacketType::STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
     }
@@ -2473,9 +2351,7 @@ class SFTP extends SSH2
      */
     public function is_writable(string $path): bool
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $packet = Strings::packSSH2('sNN', $this->realpath($path), OpenFlag::WRITE, 0);
         $this->send_sftp_packet(SFTPPacketType::OPEN, $packet);
@@ -2489,7 +2365,7 @@ class SFTP extends SSH2
             default:
                 throw new UnexpectedValueException(
                     'Expected SSH_FXP_HANDLE or SSH_FXP_STATUS. '
-                    . 'Got packet type: ' . $this->packet_type
+                    . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
                 );
         }
     }
@@ -2507,7 +2383,7 @@ class SFTP extends SSH2
     /**
      * Gets last access time of file
      */
-    public function fileatime(string $path)
+    public function fileatime(string $path): int
     {
         return $this->get_stat_cache_prop($path, 'atime');
     }
@@ -2515,7 +2391,7 @@ class SFTP extends SSH2
     /**
      * Gets file modification time
      */
-    public function filemtime(string $path)
+    public function filemtime(string $path): int
     {
         return $this->get_stat_cache_prop($path, 'mtime');
     }
@@ -2523,7 +2399,7 @@ class SFTP extends SSH2
     /**
      * Gets file permissions
      */
-    public function fileperms(string $path)
+    public function fileperms(string $path): int
     {
         return $this->get_stat_cache_prop($path, 'mode');
     }
@@ -2531,17 +2407,21 @@ class SFTP extends SSH2
     /**
      * Gets file owner
      */
-    public function fileowner(string $path)
+    public function fileowner(string $path): int|string
     {
-        return $this->get_stat_cache_prop($path, 'uid');
+        $this->precheck();
+
+        return $this->get_stat_cache_prop($path, $this->version > 3 ? 'owner' : 'uid');
     }
 
     /**
      * Gets file group
      */
-    public function filegroup(string $path)
+    public function filegroup(string $path): int|string
     {
-        return $this->get_stat_cache_prop($path, 'gid');
+        $this->precheck();
+
+        return $this->get_stat_cache_prop($path, $this->version > 3 ? 'group' : 'gid');
     }
 
     /**
@@ -2564,7 +2444,7 @@ class SFTP extends SSH2
     /**
      * Gets file size
      */
-    public function filesize(string $path, bool $recursive = false)
+    public function filesize(string $path, bool $recursive = false): int
     {
         return !$recursive || $this->filetype($path) != 'dir' ?
             $this->get_stat_cache_prop($path, 'size') :
@@ -2573,32 +2453,19 @@ class SFTP extends SSH2
 
     /**
      * Gets file type
-     *
-     * @return string|false
      */
-    public function filetype(string $path)
+    public function filetype(string $path): string
     {
         $type = $this->get_stat_cache_prop($path, 'type');
-        if ($type === false) {
-            return false;
-        }
 
-        switch ($type) {
-            case FileType::BLOCK_DEVICE:
-                return 'block';
-            case FileType::CHAR_DEVICE:
-                return 'char';
-            case FileType::DIRECTORY:
-                return 'dir';
-            case FileType::FIFO:
-                return 'fifo';
-            case FileType::REGULAR:
-                return 'file';
-            case FileType::SYMLINK:
-                return 'link';
-            default:
-                return false;
-        }
+        return match ($type) {
+            FileType::BLOCK_DEVICE => 'block',
+            FileType::CHAR_DEVICE => 'char',
+            FileType::DIRECTORY => 'dir',
+            FileType::FIFO => 'fifo',
+            FileType::REGULAR => 'link',
+            default => throw new RuntimeException("Unable to map file type ($type) to a known type")
+        };
     }
 
     /**
@@ -2606,7 +2473,7 @@ class SFTP extends SSH2
      *
      * Uses cache if appropriate.
      */
-    private function get_stat_cache_prop(string $path, string $prop)
+    private function get_stat_cache_prop(string $path, string $prop): int|string
     {
         return $this->get_xstat_cache_prop($path, $prop, 'stat');
     }
@@ -2616,7 +2483,7 @@ class SFTP extends SSH2
      *
      * Uses cache if appropriate.
      */
-    private function get_lstat_cache_prop(string $path, string $prop)
+    private function get_lstat_cache_prop(string $path, string $prop): int|string
     {
         return $this->get_xstat_cache_prop($path, $prop, 'lstat');
     }
@@ -2626,11 +2493,9 @@ class SFTP extends SSH2
      *
      * Uses cache if appropriate.
      */
-    private function get_xstat_cache_prop(string $path, string $prop, string $type)
+    private function get_xstat_cache_prop(string $path, string $prop, string $type): int|string
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         if ($this->use_stat_cache) {
             $path = $this->realpath($path);
@@ -2644,8 +2509,8 @@ class SFTP extends SSH2
 
         $result = $this->$type($path);
 
-        if ($result === false || !isset($result[$prop])) {
-            return false;
+        if (!isset($result[$prop])) {
+            throw new RuntimeException("Property $prop is not available for $path");
         }
 
         return $result[$prop];
@@ -2658,17 +2523,12 @@ class SFTP extends SSH2
      *
      * @throws UnexpectedValueException on receipt of unexpected packets
      */
-    public function rename(string $oldname, string $newname): bool
+    public function rename(string $oldname, string $newname): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $oldname = $this->realpath($oldname);
         $newname = $this->realpath($newname);
-        if ($oldname === false || $newname === false) {
-            return false;
-        }
 
         // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-8.3
         $packet = Strings::packSSH2('ss', $oldname, $newname);
@@ -2690,7 +2550,7 @@ class SFTP extends SSH2
         if ($this->packet_type != SFTPPacketType::STATUS) {
             throw new UnexpectedValueException(
                 'Expected PacketType::STATUS. '
-                . 'Got packet type: ' . $this->packet_type
+                . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 
@@ -2700,8 +2560,7 @@ class SFTP extends SSH2
          */
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response, $status);
         }
 
         // don't move the stat cache entry over since this operation could very well change the
@@ -2709,8 +2568,6 @@ class SFTP extends SSH2
         //$this->update_stat_cache($newname, $this->query_stat_cache($oldname));
         $this->remove_from_stat_cache($oldname);
         $this->remove_from_stat_cache($newname);
-
-        return true;
     }
 
     /**
@@ -2718,7 +2575,7 @@ class SFTP extends SSH2
      *
      * See '7.7.  Times' of draft-ietf-secsh-filexfer-13 for more info.
      */
-    private function parseTime(string $key, int $flags, string &$response): array
+    private static function parseTime(string $key, int $flags, string &$response): array
     {
         $attr = [];
         [$attr[$key]] = Strings::unpackSSH2('Q', $response);
@@ -2733,11 +2590,11 @@ class SFTP extends SSH2
      *
      * See '7.  File Attributes' of draft-ietf-secsh-filexfer-13 for more info.
      */
-    protected function parseAttributes(string &$response): array
+    protected static function parseAttributes(int $version, string &$response): array
     {
         $attr = [];
 
-        if ($this->version >= 4) {
+        if ($version >= 4) {
             [$flags, $attr['type']] = Strings::unpackSSH2('NC', $response);
         } else {
             [$flags] = Strings::unpackSSH2('N', $response);
@@ -2746,7 +2603,7 @@ class SFTP extends SSH2
         foreach (Attribute::getConstants() as $value => $key) {
             switch ($flags & $key) {
                 case Attribute::UIDGID:
-                    if ($this->version > 3) {
+                    if ($version > 3) {
                         continue 2;
                     }
                     break;
@@ -2755,12 +2612,12 @@ class SFTP extends SSH2
                 case Attribute::ACL:
                 case Attribute::OWNERGROUP:
                 case Attribute::SUBSECOND_TIMES:
-                    if ($this->version < 4) {
+                    if ($version < 4) {
                         continue 2;
                     }
                     break;
                 case Attribute::BITS:
-                    if ($this->version < 5) {
+                    if ($version < 5) {
                         continue 2;
                     }
                     break;
@@ -2770,7 +2627,7 @@ class SFTP extends SSH2
                 case Attribute::LINK_COUNT:
                 case Attribute::UNTRANSLATED_NAME:
                 case Attribute::CTIME:
-                    if ($this->version < 6) {
+                    if ($version < 6) {
                         continue 2;
                     }
             }
@@ -2789,23 +2646,23 @@ class SFTP extends SSH2
                     break;
                 case Attribute::PERMISSIONS: // 0x00000004
                     [$attr['mode']] = Strings::unpackSSH2('N', $response);
-                    $fileType = $this->parseMode($attr['mode']);
-                    if ($this->version < 4 && $fileType !== false) {
+                    $fileType = self::parseMode($attr['mode']);
+                    if ($version < 4 && isset($fileType)) {
                         $attr += ['type' => $fileType];
                     }
                     break;
                 case Attribute::ACCESSTIME: // 0x00000008
-                    if ($this->version >= 4) {
-                        $attr += $this->parseTime('atime', $flags, $response);
+                    if ($version >= 4) {
+                        $attr += self::parseTime('atime', $flags, $response);
                         break;
                     }
                     [$attr['atime'], $attr['mtime']] = Strings::unpackSSH2('NN', $response);
                     break;
                 case Attribute::CREATETIME:       // 0x00000010 (SFTPv4+)
-                    $attr += $this->parseTime('createtime', $flags, $response);
+                    $attr += self::parseTime('createtime', $flags, $response);
                     break;
                 case Attribute::MODIFYTIME:       // 0x00000020
-                    $attr += $this->parseTime('mtime', $flags, $response);
+                    $attr += self::parseTime('mtime', $flags, $response);
                     break;
                 case Attribute::ACL:              // 0x00000040
                     // access control list
@@ -2817,7 +2674,7 @@ class SFTP extends SSH2
                     }
                     break;
                 case Attribute::OWNERGROUP:       // 0x00000080
-                    [$attr['owner'], $attr['$group']] = Strings::unpackSSH2('ss', $response);
+                    [$attr['owner'], $attr['group']] = Strings::unpackSSH2('ss', $response);
                     break;
                 case Attribute::SUBSECOND_TIMES:  // 0x00000100
                     break;
@@ -2860,7 +2717,7 @@ class SFTP extends SSH2
                 case Attribute::CTIME:            // 0x00008000
                     // 'ctime' contains the last time the file attributes were changed.  The
                     // exact meaning of this field depends on the server.
-                    $attr += $this->parseTime('ctime', $flags, $response);
+                    $attr += self::parseTime('ctime', $flags, $response);
                     break;
                 case Attribute::EXTENDED: // 0x80000000
                     [$count] = Strings::unpackSSH2('N', $response);
@@ -2877,39 +2734,27 @@ class SFTP extends SSH2
      * Attempt to identify the file type
      *
      * Quoting the SFTP RFC, "Implementations MUST NOT send bits that are not defined" but they seem to anyway
-     *
-     * @return int
      */
-    private function parseMode(int $mode)
+    private static function parseMode(int $mode): ?int
     {
         // values come from http://lxr.free-electrons.com/source/include/uapi/linux/stat.h#L12
         // see, also, http://linux.die.net/man/2/stat
-        switch ($mode & 0o170000) {// ie. 1111 0000 0000 0000
-            case 0: // no file type specified - figure out the file type using alternative means
-                return false;
-            case 0o040000:
-                return FileType::DIRECTORY;
-            case 0o100000:
-                return FileType::REGULAR;
-            case 0o120000:
-                return FileType::SYMLINK;
+        return match ($mode & 0o170000) {// ie. 1111 0000 0000 0000
+            0 => null, // no file type specified - figure out the file type using alternative means
+            0o040000 => FileType::DIRECTORY,
+            0o100000 => FileType::REGULAR,
+            0o120000 => FileType::SYMLINK,
             // new types introduced in SFTPv5+
             // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-05#section-5.2
-            case 0o010000: // named pipe (fifo)
-                return FileType::FIFO;
-            case 0o020000: // character special
-                return FileType::CHAR_DEVICE;
-            case 0o060000: // block special
-                return FileType::BLOCK_DEVICE;
-            case 0o140000: // socket
-                return FileType::SOCKET;
-            case 0o160000: // whiteout
-                // "SPECIAL should be used for files that are of
-                //  a known type which cannot be expressed in the protocol"
-                return FileType::SPECIAL;
-            default:
-                return FileType::UNKNOWN;
-        }
+            0o010000 => FileType::FIFO, // named pipe (fifo)
+            0o020000 => FileType::CHAR_DEVICE, // character special
+            0o060000 => FileType::BLOCK_DEVICE, // block special
+            0o140000 => FileType::SOCKET, // socket
+            // "SPECIAL should be used for files that are of
+            //  a known type which cannot be expressed in the protocol"
+            0o160000 => FileType::SPECIAL, // whiteout
+            default => FileType::UNKNOWN
+        };
     }
 
     /**
@@ -2923,24 +2768,20 @@ class SFTP extends SSH2
      *
      * If the longname is in an unrecognized format bool(false) is returned.
      */
-    private function parseLongname(string $longname)
+    private static function parseLongname(string $longname): ?int
     {
         // http://en.wikipedia.org/wiki/Unix_file_types
         // http://en.wikipedia.org/wiki/Filesystem_permissions#Notation_of_traditional_Unix_permissions
         if (preg_match('#^[^/]([r-][w-][xstST-]){3}#', $longname)) {
-            switch ($longname[0]) {
-                case '-':
-                    return FileType::REGULAR;
-                case 'd':
-                    return FileType::DIRECTORY;
-                case 'l':
-                    return FileType::SYMLINK;
-                default:
-                    return FileType::SPECIAL;
-            }
+            return match ($longname[0]) {
+                '-' => FileType::REGULAR,
+                'd' => FileType::DIRECTORY,
+                'l' => FileType::SYMLINK,
+                default => FileType::SPECIAL
+            };
         }
 
-        return false;
+        return null;
     }
 
     /**
@@ -2965,9 +2806,8 @@ class SFTP extends SSH2
         $start = microtime(true);
         $this->send_channel_packet(self::CHANNEL, $packet);
         $stop = microtime(true);
-
         if (defined('NET_SFTP_LOGGING')) {
-            $packet_type = '-> ' . $this->packet_types[$type] .
+            $packet_type = '-> SSH_FXP_' . SFTPPacketType::getConstantNameByValue($type) .
                            ' (' . round($stop - $start, 4) . 's)';
             $this->append_log($packet_type, $data);
         }
@@ -3002,10 +2842,11 @@ class SFTP extends SSH2
      * There can be one SSH_MSG_CHANNEL_DATA messages containing two SFTP packets or there can be two SSH_MSG_CHANNEL_DATA
      * messages containing one SFTP packet.
      *
+     * By the time this function is called the channel_status is SSH2MessageType::CHANNEL_DATA.
+     *
      * @see    self::_send_sftp_packet()
-     * @return string
      */
-    private function get_sftp_packet($request_id = null)
+    private function get_sftp_packet(?int $request_id = null): string
     {
         $this->channel_close = false;
 
@@ -3032,7 +2873,7 @@ class SFTP extends SSH2
                 }
                 $this->packet_type = -1;
                 $this->packet_buffer = '';
-                return false;
+                throw new RuntimeException('Error reading next SFTP packet');
             }
             $this->packet_buffer .= $temp;
         }
@@ -3058,7 +2899,7 @@ class SFTP extends SSH2
                 }
                 $this->packet_type = -1;
                 $this->packet_buffer = '';
-                return false;
+                throw new RuntimeException('Error reading next SFTP packet');
             }
             $this->packet_buffer .= $temp;
             $tempLength -= strlen($temp);
@@ -3078,7 +2919,7 @@ class SFTP extends SSH2
         $packet = Strings::shift($this->packet_buffer, $length);
 
         if (defined('NET_SFTP_LOGGING')) {
-            $packet_type = '<- ' . $this->packet_types[$this->packet_type] .
+            $packet_type = '<- SSH_FXP_' . SFTPPacketType::getConstantNameByValue($this->packet_type) .
                            ' (' . round($stop - $start, 4) . 's)';
             $this->append_log($packet_type, $packet);
         }
@@ -3118,49 +2959,36 @@ class SFTP extends SSH2
      * Returns a log of the packets that have been sent and received.
      *
      * Returns a string if PacketType::LOGGING == self::LOG_COMPLEX, an array if PacketType::LOGGING == self::LOG_SIMPLE and false if !defined('NET_SFTP_LOGGING')
-     *
-     * @return array|string|false
      */
-    public function getSFTPLog()
+    public function getSFTPLog(): array|string|null
     {
         if (!defined('NET_SFTP_LOGGING')) {
-            return false;
+            return null;
         }
 
-        switch (NET_SFTP_LOGGING) {
-            case self::LOG_COMPLEX:
-                return $this->format_log($this->packet_log, $this->packet_type_log);
-                break;
-            //case self::LOG_SIMPLE:
-            default:
-                return $this->packet_type_log;
-        }
-    }
-    /**
-     * Returns all errors on the SFTP layer
-     */
-    public function getSFTPErrors(): array
-    {
-        return $this->sftp_errors;
+        return match (NET_SFTP_LOGGING ?? -1) {
+            self::LOG_COMPLEX => $this->format_log($this->packet_log, $this->packet_type_log),
+            default => $this->packet_type_log
+        };
     }
 
     /**
-     * Returns the last error on the SFTP layer
+     * Returns all errors on the SFTP layer and resets internal error array
      */
-    public function getLastSFTPError(): string
+    public function getErrors(): array
     {
-        return count($this->sftp_errors) ? $this->sftp_errors[count($this->sftp_errors) - 1] : '';
+        $copy = $this->sftp_errors;
+        $this->sftp_errors = [];
+        return $copy;
     }
 
     /**
      * Get supported SFTP versions
-     *
-     * @return array
      */
-    public function getSupportedVersions()
+    public function getSupportedVersions(): array
     {
         if (!($this->bitmap & SSH2::MASK_LOGIN)) {
-            return false;
+            throw new RuntimeException("Function should not be called before you've logged in");
         }
 
         if (!$this->partial_init) {
@@ -3176,13 +3004,11 @@ class SFTP extends SSH2
 
     /**
      * Get supported SFTP extensions
-     *
-     * @return array
      */
-    public function getSupportedExtensions()
+    public function getSupportedExtensions(): array
     {
         if (!($this->bitmap & SSH2::MASK_LOGIN)) {
-            return false;
+            throw new RuntimeException("Function should not be called before you've logged in");
         }
 
         if (!$this->partial_init) {
@@ -3194,14 +3020,10 @@ class SFTP extends SSH2
 
     /**
      * Get supported SFTP versions
-     *
-     * @return int|false
      */
-    public function getNegotiatedVersion()
+    public function getNegotiatedVersion(): int
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         return $this->version;
     }
@@ -3249,22 +3071,13 @@ class SFTP extends SSH2
      * Copy
      *
      * This method (currently) only works if the copy-data extension is available
-     *
-     * @param string $oldname
-     * @param string $newname
-     * @return bool
      */
-    public function copy(string $oldname, string $newname): bool
+    public function copy(string $oldname, string $newname): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $oldname = $this->realpath($oldname);
         $newname = $this->realpath($newname);
-        if ($oldname === false || $newname === false) {
-            return false;
-        }
 
         if (!isset($this->extensions['copy-data']) || $this->extensions['copy-data'] !== '1') {
             throw new \RuntimeException(
@@ -3287,18 +3100,15 @@ class SFTP extends SSH2
                 $oldhandle = substr($response, 4);
                 break;
             case PacketType::STATUS: // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-                $this->logError($response);
-                return false;
+                throw $this->throwStatusError($response);
             default:
                 throw new \UnexpectedValueException('Expected NET_SFTP_HANDLE or NET_SFTP_STATUS. '
-                                                  . 'Got packet type: ' . $this->packet_type);
+                                                  . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type));
         }
 
-        if ($this->version >= 5) {
-            $flags = OpenFlag5::OPEN_OR_CREATE;
-        } else {
-            $flags = OpenFlag::WRITE | OpenFlag::CREATE;
-        }
+        $flags = $this->version >= 5 ?
+            OpenFlag5::OPEN_OR_CREATE :
+            OpenFlag::WRITE | OpenFlag::CREATE;
 
         $packet = Strings::packSSH2('s', $newname);
         $packet .= $this->version >= 5 ?
@@ -3312,11 +3122,10 @@ class SFTP extends SSH2
                 $newhandle = substr($response, 4);
                 break;
             case PacketType::STATUS:
-                $this->logError($response);
-                return false;
+                throw $this->throwStatusError($response);
             default:
                 throw new \UnexpectedValueException('Expected NET_SFTP_HANDLE or NET_SFTP_STATUS. '
-                                                  . 'Got packet type: ' . $this->packet_type);
+                                                  . 'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type));
         }
 
         $packet = Strings::packSSH2('ssQQsQ', 'copy-data', $oldhandle, 0, $size, $newhandle, 0);
@@ -3330,8 +3139,6 @@ class SFTP extends SSH2
 
         $this->close_handle($oldhandle);
         $this->close_handle($newhandle);
-
-        return true;
     }
 
     /**
@@ -3342,17 +3149,12 @@ class SFTP extends SSH2
      * ie. "there is no observable instant in time where the name does not refer to either the old or the new file"
      * (draft-ietf-secsh-filexfer-13#page-39).
      */
-    public function posix_rename(string $oldname, string $newname): bool
+    public function posix_rename(string $oldname, string $newname): void
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         $oldname = $this->realpath($oldname);
         $newname = $this->realpath($newname);
-        if ($oldname === false || $newname === false) {
-            return false;
-        }
 
         if ($this->version >= 5) {
             $packet = Strings::packSSH2('ssN', $oldname, $newname, 2); // 2 = SSH_FXP_RENAME_ATOMIC
@@ -3378,8 +3180,7 @@ class SFTP extends SSH2
         // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
         [$status] = Strings::unpackSSH2('N', $response);
         if ($status != StatusCode::OK) {
-            $this->logError($response, $status);
-            return false;
+            throw $this->throwStatusError($response, $status);
         }
 
         // don't move the stat cache entry over since this operation could very well change the
@@ -3387,8 +3188,6 @@ class SFTP extends SSH2
         //$this->update_stat_cache($newname, $this->query_stat_cache($oldname));
         $this->remove_from_stat_cache($oldname);
         $this->remove_from_stat_cache($newname);
-
-        return true;
     }
 
     /**
@@ -3399,11 +3198,9 @@ class SFTP extends SSH2
      *
      * @return array{bsize: int, frsize: int, blocks: int, bfree: int, bavail: int, files: int, ffree: int, favail: int, fsid: int, flag: int, namemax: int}
      */
-    public function statvfs(string $path): array|bool
+    public function statvfs(string $path): array
     {
-        if (!$this->precheck()) {
-            return false;
-        }
+        $this->precheck();
 
         if (!isset($this->extensions['statvfs@openssh.com']) || $this->extensions['statvfs@openssh.com'] !== '2') {
             throw new RuntimeException(
@@ -3413,9 +3210,6 @@ class SFTP extends SSH2
         }
 
         $realpath = $this->realpath($path);
-        if ($realpath === false) {
-            return false;
-        }
 
         $packet = Strings::packSSH2('ss', 'statvfs@openssh.com', $realpath);
         $this->send_sftp_packet(PacketType::EXTENDED, $packet);
@@ -3424,7 +3218,7 @@ class SFTP extends SSH2
         if ($this->packet_type !== PacketType::EXTENDED_REPLY) {
             throw new UnexpectedValueException(
                 'Expected SSH_FXP_EXTENDED_REPLY. ' .
-                'Got packet type: ' . $this->packet_type
+                'Got packet type: ' . SFTPPacketType::getConstantNameByValue($this->packet_type)
             );
         }
 

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -477,7 +477,6 @@ class SFTP extends SSH2
                     }
                     [$status] = Strings::unpackSSH2('N', $response);
                     if ($status != StatusCode::OK) {
-                        $this->logError($response, $status);
                         throw new UnexpectedValueException(
                             'Expected StatusCode::OK. '
                             . ' Got ' . $status
@@ -613,12 +612,8 @@ class SFTP extends SSH2
     /**
      * Logs errors
      */
-    private function logError(string $response, int $status = -1, ?string $filename = null): void
+    private function logError(string $response, int $status, string $filename): void
     {
-        if ($status == -1) {
-            [$status] = Strings::unpackSSH2('N', $response);
-        }
-
         $error = StatusCode::getConstantNameByValue($status);
 
         if ($this->version > 2) {

--- a/phpseclib/Net/SFTP/Stream.php
+++ b/phpseclib/Net/SFTP/Stream.php
@@ -59,7 +59,7 @@ class Stream
     /**
      * Size
      */
-    private int|false $size;
+    private ?int $size;
 
     /**
      * Directory entries
@@ -85,7 +85,7 @@ class Stream
      *
      * @var callable
      */
-    private $notification;
+    private \Closure|string|array $notification;
 
     /**
      * Registers this class as a URL wrapper.
@@ -118,10 +118,8 @@ class Stream
      *
      * If "notification" is set as a context parameter the message code for successful login is
      * SSHMsg::USERAUTH_SUCCESS. For a failed login it's SSHMsg::USERAUTH_FAILURE.
-     *
-     * @return string
      */
-    protected function parse_path(string $path)
+    protected function parse_path(string $path): ?string
     {
         $orig = $path;
         $url = parse_url($path) + ['port' => 22];
@@ -145,7 +143,7 @@ class Stream
         }
 
         if (!isset($host)) {
-            return false;
+            return null;
         }
 
         if (isset($this->context)) {
@@ -158,7 +156,7 @@ class Stream
         if (preg_match('/^{[a-z0-9]+}$/i', $host)) {
             $host = SSH2::getConnectionByResourceId($host);
             if ($host === null) {
-                return false;
+                return null;
             }
             $this->sftp = $host;
         } else {
@@ -186,7 +184,7 @@ class Stream
             }
 
             if (!isset($user) || !isset($pass)) {
-                return false;
+                return null;
             }
 
             // casting $pass to a string is necessary in the event that it's a \phpseclib4\Crypt\RSA object
@@ -209,12 +207,12 @@ class Stream
                     call_user_func($this->notification, STREAM_NOTIFY_AUTH_REQUIRED, STREAM_NOTIFY_SEVERITY_INFO, '', 0, 0, 0);
                     if (!$this->sftp->login($user, $pass)) {
                         call_user_func($this->notification, STREAM_NOTIFY_AUTH_RESULT, STREAM_NOTIFY_SEVERITY_ERR, 'Login Failure', SSH2MessageType::USERAUTH_FAILURE, 0, 0);
-                        return false;
+                        return null;
                     }
                     call_user_func($this->notification, STREAM_NOTIFY_AUTH_RESULT, STREAM_NOTIFY_SEVERITY_INFO, 'Login Success', SSH2MessageType::USERAUTH_SUCCESS, 0, 0);
                 } else {
                     if (!$this->sftp->login($user, $pass)) {
-                        return false;
+                        return null;
                     }
                 }
                 self::$instances[$host][$port][$user][(string) $pass] = $this->sftp;
@@ -231,20 +229,31 @@ class Stream
     {
         $path = $this->parse_path($path);
 
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
         $this->path = $path;
 
-        $this->size = $this->sftp->filesize($path);
+        try {
+            $this->size = $this->sftp->filesize($path);
+        } catch (\Exception) {
+            $this->size = null;
+        }
         $this->mode = preg_replace('#[bt]$#', '', $mode);
         $this->eof = false;
 
-        if ($this->size === false) {
+        if (!isset($this->size)) {
             if ($this->mode[0] == 'r') {
                 return false;
             } else {
-                $this->sftp->touch($path);
+                try {
+                    $this->sftp->touch($path);
+                } catch (\Exception $e) {
+                    if (isset($this->notification) && is_callable($this->notification)) {
+                        call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+                    }
+                    return false;
+                }
                 $this->size = 0;
             }
         } else {
@@ -252,7 +261,14 @@ class Stream
                 case 'x':
                     return false;
                 case 'w':
-                    $this->sftp->truncate($path, 0);
+                    try {
+                        $this->sftp->truncate($path, 0);
+                    } catch (\Exception $e) {
+                        if (isset($this->notification) && is_callable($this->notification)) {
+                            call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+                        }
+                        return false;
+                    }
                     $this->size = 0;
             }
         }
@@ -264,8 +280,10 @@ class Stream
 
     /**
      * Read from stream
+     *
+     * @return string|false
      */
-    private function _stream_read(int $count)
+    private function _stream_read(int $count): string|bool
     {
         switch ($this->mode) {
             case 'w':
@@ -281,20 +299,19 @@ class Stream
         //    return false;
         //}
 
-        $result = $this->sftp->get($this->path, false, $this->pos, $count);
-        if (isset($this->notification) && is_callable($this->notification)) {
-            if ($result === false) {
-                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $this->sftp->getLastSFTPError(), PacketType::OPEN, 0, 0);
-                return 0;
+        try {
+            $result = $this->sftp->get($this->path, false, $this->pos, $count);
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
             }
+            return false;
+        }
+        if (isset($this->notification) && is_callable($this->notification)) {
             // seems that PHP calls stream_read in 8k chunks
             call_user_func($this->notification, STREAM_NOTIFY_PROGRESS, STREAM_NOTIFY_SEVERITY_INFO, '', 0, strlen($result), $this->size);
         }
 
-        if (empty($result)) { // ie. false or empty string
-            $this->eof = true;
-            return false;
-        }
         $this->pos += strlen($result);
 
         return $result;
@@ -305,26 +322,26 @@ class Stream
      *
      * @return int|false
      */
-    private function _stream_write(string $data)
+    private function _stream_write(string $data): int|bool
     {
         switch ($this->mode) {
             case 'r':
                 return false;
         }
 
-        $result = $this->sftp->put($this->path, $data, SFTP::SOURCE_STRING, $this->pos);
-        if (isset($this->notification) && is_callable($this->notification)) {
-            if (!$result) {
-                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $this->sftp->getLastSFTPError(), PacketType::OPEN, 0, 0);
-                return 0;
+        try {
+            $result = $this->sftp->put($this->path, $data, SFTP::SOURCE_STRING, $this->pos);
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
             }
+            return false;
+        }
+        if (isset($this->notification) && is_callable($this->notification)) {
             // seems that PHP splits up strings into 8k blocks before calling stream_write
             call_user_func($this->notification, STREAM_NOTIFY_PROGRESS, STREAM_NOTIFY_SEVERITY_INFO, '', 0, strlen($data), strlen($data));
         }
 
-        if ($result === false) {
-            return false;
-        }
         $this->pos += strlen($data);
         if ($this->pos > $this->size) {
             $this->size = $this->pos;
@@ -382,30 +399,53 @@ class Stream
     /**
      * Change stream options
      */
-    private function _stream_metadata(string $path, int $option, $var): bool
+    private function _stream_metadata(string $path, int $option, int|string|array $var): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
 
-        // stream_metadata was introduced in PHP 5.4.0 but as of 5.4.11 the constants haven't been defined
-        // see http://www.php.net/streamwrapper.stream-metadata and https://bugs.php.net/64246
-        //     and https://github.com/php/php-src/blob/master/main/php_streams.h#L592
-        switch ($option) {
-            case 1: // PHP_STREAM_META_TOUCH
-                $time = $var[0] ?? null;
-                $atime = $var[1] ?? null;
-                return $this->sftp->touch($path, $time, $atime);
-            case 2: // PHP_STREAM_OWNER_NAME
-            case 3: // PHP_STREAM_GROUP_NAME
-                return false;
-            case 4: // PHP_STREAM_META_OWNER
-                return $this->sftp->chown($path, $var);
-            case 5: // PHP_STREAM_META_GROUP
-                return $this->sftp->chgrp($path, $var);
-            case 6: // PHP_STREAM_META_ACCESS
-                return $this->sftp->chmod($path, $var) !== false;
+        try {
+            switch ($option) {
+                case PHP_STREAM_META_TOUCH:
+                    $time = $var[0] ?? null;
+                    $atime = $var[1] ?? null;
+                    $this->sftp->touch($path, $time, $atime);
+                    return true;
+                case PHP_STREAM_OWNER_NAME:
+                    if ($this->getNegotiatedVersion() >= 4) {
+                        $this->sftp->chown($path, $var);
+                        return true;
+                    }
+                    return false;
+                case PHP_STREAM_GROUP_NAME:
+                    if ($this->getNegotiatedVersion() >= 4) {
+                        $this->sftp->chgrp($path, $var);
+                        return true;
+                    }
+                    return false;
+                case PHP_STREAM_META_OWNER:
+                    if ($this->getNegotiatedVersion() < 4) {
+                        $this->sftp->chown($path, $var);
+                        return true;
+                    }
+                    return false;
+                case PHP_STREAM_META_GROUP:
+                    if ($this->getNegotiatedVersion() < 4) {
+                        $this->sftp->chgrp($path, $var);
+                        return true;
+                    }
+                    return false;
+                case PHP_STREAM_META_ACCESS:
+                    $this->sftp->chmod($path, $var);
+                    return true;
+            }
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
+            return false;
         }
     }
 
@@ -445,18 +485,31 @@ class Stream
 
         $path_from = $this->parse_path($path_from);
         $path_to = parse_url($path_to);
-        if ($path_from === false) {
+        if (!isset($path_from)) {
             return false;
         }
 
-        $path_to = $path_to['path']; // the $component part of parse_url() was added in PHP 5.1.2
+        $path_to = $path_to['path'];
         // "It is an error if there already exists a file with the name specified by newpath."
         //  -- http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02#section-6.5
-        if (!$this->sftp->rename($path_from, $path_to)) {
-            if ($this->sftp->stat($path_to)) {
-                return $this->sftp->delete($path_to, true) && $this->sftp->rename($path_from, $path_to);
+        try {
+            $this->sftp->rename($path_from, $path_to);
+        } catch (\Exception $e) {
+            if (!$this->sftp->file_exists($path_to)) {
+                if (isset($this->notification) && is_callable($this->notification)) {
+                    call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+                }
+                return false;
             }
-            return false;
+            try {
+                $this->sftp->delete($path_to, true);
+                $this->sftp->rename($path_from, $path_to);
+            } catch (\Exception $e) {
+                if (isset($this->notification) && is_callable($this->notification)) {
+                    call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+                }
+                return false;
+            }
         }
 
         return true;
@@ -465,11 +518,8 @@ class Stream
     /**
      * Open directory handle
      *
-     * The only $options is "whether or not to enforce safe_mode (0x04)". Since safe mode was deprecated in 5.3 and
-     * removed in 5.4 I'm just going to ignore it.
-     *
-     * Also, nlist() is the best that this function is realistically going to be able to do. When an SFTP client
-     * sends a SSH_FXP_READDIR packet you don't generally get info on just one file but on multiple files. Quoting
+     * nlist() is the best that this function is realistically going to be able to do. When an SFTP client sends 
+     * a SSH_FXP_READDIR packet you don't generally get info on just one file but on multiple files. Quoting
      * the SFTP specs:
      *
      *    The SSH_FXP_NAME response has the following format:
@@ -484,12 +534,19 @@ class Stream
     private function _dir_opendir(string $path, int $options): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
         $this->pos = 0;
-        $this->entries = $this->sftp->nlist($path);
-        return $this->entries !== false;
+        try {
+            $this->entries = $this->sftp->nlist($path);
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -528,11 +585,19 @@ class Stream
     private function _mkdir(string $path, int $mode, int $options): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
 
-        return $this->sftp->mkdir($path, $mode, $options & STREAM_MKDIR_RECURSIVE);
+        try {
+            $this->sftp->mkdir($path, $mode, boolval($options & STREAM_MKDIR_RECURSIVE));
+            return true;
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
+            return false;
+        }
     }
 
     /**
@@ -546,11 +611,19 @@ class Stream
     private function _rmdir(string $path, int $options): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
 
-        return $this->sftp->rmdir($path);
+        try {
+            $this->sftp->rmdir($path);
+            return true;
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
+            return false;
+        }
     }
 
     /**
@@ -566,13 +639,16 @@ class Stream
     /**
      * Retrieve information about a file resource
      */
-    private function _stream_stat(): bool
+    private function _stream_stat(): array|bool
     {
-        $results = $this->sftp->stat($this->path);
-        if ($results === false) {
+        try {
+            return $this->sftp->stat($this->path);
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
             return false;
         }
-        return $results;
     }
 
     /**
@@ -581,11 +657,19 @@ class Stream
     private function _unlink(string $path): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
 
-        return $this->sftp->delete($path, false);
+        try {
+            $this->sftp->delete($path, false);
+            return true;
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
+            return false;
+        }
     }
 
     /**
@@ -598,16 +682,18 @@ class Stream
     private function _url_stat(string $path, int $flags): bool
     {
         $path = $this->parse_path($path);
-        if ($path === false) {
+        if (!isset($path)) {
             return false;
         }
 
-        $results = $flags & STREAM_URL_STAT_LINK ? $this->sftp->lstat($path) : $this->sftp->stat($path);
-        if ($results === false) {
+        try {
+            return $flags & STREAM_URL_STAT_LINK ? $this->sftp->lstat($path) : $this->sftp->stat($path);
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
             return false;
         }
-
-        return $results;
     }
 
     /**
@@ -615,14 +701,16 @@ class Stream
      */
     private function _stream_truncate(int $new_size): bool
     {
-        if (!$this->sftp->truncate($this->path, $new_size)) {
+        try {
+            $this->sftp->truncate($this->path, $new_size);
+            $this->eof = false;
+            $this->size = $new_size;
+        } catch (\Exception $e) {
+            if (isset($this->notification) && is_callable($this->notification)) {
+                call_user_func($this->notification, STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, $e->getMessage(), $e->getCode(), 0, 0);
+            }
             return false;
         }
-
-        $this->eof = false;
-        $this->size = $new_size;
-
-        return true;
     }
 
     /**

--- a/phpseclib/Net/SSH2.php
+++ b/phpseclib/Net/SSH2.php
@@ -205,7 +205,7 @@ class SSH2
      *
      * @var resource|closed-resource|null
      */
-    public $fsock;
+    public mixed $fsock = null;
 
     /**
      * Execution Bitmap
@@ -228,21 +228,21 @@ class SSH2
      *
      * @see self::getServerIdentification()
      */
-    protected string|false $server_identifier = false;
+    protected string $server_identifier;
 
     /**
      * Key Exchange Algorithms
      *
      * @see self::getKexAlgorithims()
      */
-    private array|false $kex_algorithms = false;
+    private array $kex_algorithms;
 
     /**
      * Key Exchange Algorithm
      *
      * @see self::getMethodsNegotiated()
      */
-    private string|false $kex_algorithm = false;
+    private ?string $kex_algorithm;
 
     /**
      * Minimum Diffie-Hellman Group Bit Size in RFC 4419 Key Exchange Methods
@@ -270,7 +270,7 @@ class SSH2
      *
      * @see self::getServerHostKeyAlgorithms()
      */
-    private array|false $server_host_key_algorithms = false;
+    private array $server_host_key_algorithms;
 
     /**
      * Supported Private Key Algorithms
@@ -280,61 +280,60 @@ class SSH2
      * not a private key algorithm
      *
      * @see self::privatekey_login()
-     * @var array|false
      */
-    private $supported_private_key_algorithms = false;
+    private array $supported_private_key_algorithms;
 
     /**
      * Encryption Algorithms: Client to Server
      *
      * @see self::getEncryptionAlgorithmsClient2Server()
      */
-    private array|false $encryption_algorithms_client_to_server = false;
+    private array $encryption_algorithms_client_to_server;
 
     /**
      * Encryption Algorithms: Server to Client
      *
      * @see self::getEncryptionAlgorithmsServer2Client()
      */
-    private array|false $encryption_algorithms_server_to_client = false;
+    private array $encryption_algorithms_server_to_client;
 
     /**
      * MAC Algorithms: Client to Server
      *
      * @see self::getMACAlgorithmsClient2Server()
      */
-    private array|false $mac_algorithms_client_to_server = false;
+    private array $mac_algorithms_client_to_server;
 
     /**
      * MAC Algorithms: Server to Client
      *
      * @see self::getMACAlgorithmsServer2Client()
      */
-    private array|false $mac_algorithms_server_to_client = false;
+    private array $mac_algorithms_server_to_client;
 
     /**
      * Compression Algorithms: Client to Server
      *
      * @see self::getCompressionAlgorithmsClient2Server()
      */
-    private array|false $compression_algorithms_client_to_server = false;
+    private array $compression_algorithms_client_to_server;
 
     /**
      * Compression Algorithms: Server to Client
      *
      * @see self::getCompressionAlgorithmsServer2Client()
      */
-    private array|false $compression_algorithms_server_to_client = false;
+    private array $compression_algorithms_server_to_client;
 
     /**
      * Languages: Server to Client
      */
-    private array|false $languages_server_to_client = false;
+    private array $languages_server_to_client;
 
     /**
      * Languages: Client to Server
      */
-    private array|false $languages_client_to_server = false;
+    private array $languages_client_to_server;
 
     /**
      * Preferred Algorithms
@@ -371,100 +370,100 @@ class SSH2
      *
      * @see self::get_binary_packet()
      */
-    private SymmetricKey|false $decrypt = false;
+    private ?SymmetricKey $decrypt = null;
 
     /**
      * Decryption Algorithm Name
      */
-    private string|null $decryptName;
+    private string $decryptName;
 
     /**
      * Decryption Invocation Counter
      *
      * Used by GCM
      */
-    private string|null $decryptInvocationCounter;
+    private ?string $decryptInvocationCounter;
 
     /**
      * Fixed Part of Nonce
      *
      * Used by GCM
      */
-    private string|null $decryptFixedPart;
+    private ?string $decryptFixedPart;
 
     /**
      * Server to Client Length Encryption Object
      *
      * @see self::get_binary_packet()
      */
-    private SymmetricKey|false $lengthDecrypt = false;
+    private SymmetricKey $lengthDecrypt;
 
     /**
      * Client to Server Encryption Object
      *
      * @see self::send_binary_packet()
      */
-    private SymmetricKey|false $encrypt = false;
+    private ?SymmetricKey $encrypt = null;
 
     /**
      * Encryption Algorithm Name
      */
-    private string|null $encryptName;
+    private string $encryptName;
 
     /**
      * Encryption Invocation Counter
      *
      * Used by GCM
      */
-    private string|null $encryptInvocationCounter;
+    private string $encryptInvocationCounter;
 
     /**
      * Fixed Part of Nonce
      *
      * Used by GCM
      */
-    private string|null $encryptFixedPart;
+    private string $encryptFixedPart;
 
     /**
      * Client to Server Length Encryption Object
      *
      * @see self::send_binary_packet()
      */
-    private SymmetricKey|false $lengthEncrypt = false;
+    private SymmetricKey $lengthEncrypt;
 
     /**
      * Client to Server HMAC Object
      *
      * @see self::send_binary_packet()
      */
-    private Hash|\stdClass|false $hmac_create = false;
+    private Hash|\stdClass|null $hmac_create = null;
 
     /**
      * Client to Server HMAC Name
      */
-    private string|false $hmac_create_name;
+    private string $hmac_create_name;
 
     /**
      * Client to Server ETM
      */
-    private int|false $hmac_create_etm;
+    private bool $hmac_create_etm = false;
 
     /**
      * Server to Client HMAC Object
      *
      * @see self::get_binary_packet()
      */
-    private Hash|\stdClass|false $hmac_check = false;
+    private Hash|\stdClass|null $hmac_check = null;
 
     /**
      * Server to Client HMAC Name
      */
-    private string|false $hmac_check_name;
+    private string $hmac_check_name;
 
     /**
      * Server to Client ETM
      */
-    private int|false $hmac_check_etm;
+    private bool $hmac_check_etm;
 
     /**
      * Size of server to client HMAC
@@ -475,7 +474,7 @@ class SSH2
      *
      * @see self::get_binary_packet()
      */
-    private int|false $hmac_size = false;
+    private ?int $hmac_size = null;
 
     /**
      * Server Public Host Key
@@ -495,7 +494,7 @@ class SSH2
      *
      * @see self::key_exchange()
      */
-    private string|false $session_id = false;
+    private ?string $session_id = null;
 
     /**
      * Exchange hash
@@ -504,7 +503,7 @@ class SSH2
      *
      * @see self::key_exchange()
      */
-    private string|false $exchange_hash = false;
+    private string $exchange_hash;
 
     /**
      * Send Sequence Number
@@ -689,7 +688,7 @@ class SSH2
      *
      * @see self::setKeepAlive()
      */
-    private int|null $keepAlive = null;
+    private ?int $keepAlive = null;
 
     /**
      * Real-time log file pointer
@@ -730,12 +729,12 @@ class SSH2
     /**
      * Time of last read/write network activity
      */
-    private float|null $last_packet = null;
+    private ?float $last_packet = null;
 
     /**
      * Exit status returned from ssh if any
      */
-    private int|null $exit_status = null;
+    private int $exit_status;
 
     /**
      * Flag to request a PTY when using exec()
@@ -842,7 +841,7 @@ class SSH2
      * @see self::setCryptoEngine()
      * @see self::_key_exchange()
      */
-    private static int|false $crypto_engine = false;
+    private static ?int $crypto_engine = null;
 
     /**
      * A System_SSH_Agent for use in the SSH2 Agent Forwarding scenario
@@ -880,7 +879,7 @@ class SSH2
     /**
      * Binary Packet Buffer
      */
-    private object|null $binary_packet_buffer = null;
+    private ?object $binary_packet_buffer = null;
 
     /**
      * Authentication Credentials
@@ -897,7 +896,7 @@ class SSH2
      *
      * @see https://tools.ietf.org/html/rfc4252#section-5.1
      */
-    private array|null $auth_methods_to_continue = null;
+    private ?array $auth_methods_to_continue = null;
 
     /**
      * Compression method
@@ -911,17 +910,13 @@ class SSH2
 
     /**
      * Compression context
-     *
-     * @var resource|false|null
      */
-    private $compress_context;
+    private \DeflateContext $compress_context;
 
     /**
      * Decompression context
-     *
-     * @var resource|object
      */
-    private $decompress_context;
+    private \InflateContext $decompress_context;
 
     /**
      * Regenerate Compression Context
@@ -940,42 +935,31 @@ class SSH2
 
     /**
      * How many channels are currently opened
-     *
-     * @var int
      */
-    private $channelCount = 0;
+    private int $channelCount = 0;
 
     /**
      * Does the server support multiple channels? If not then error out
      * when multiple channels are attempted to be opened
-     *
-     * @var bool
      */
-    private $errorOnMultipleChannels;
+    private bool $errorOnMultipleChannels;
 
     /**
      * Bytes Transferred Since Last Key Exchange
      *
      * Includes outbound and inbound totals
-     *
-     * @var int
      */
-    private $bytesTransferredSinceLastKEX = 0;
+    private int $bytesTransferredSinceLastKEX = 0;
 
     /**
      * After how many transferred byte should phpseclib initiate a key re-exchange?
-     *
-     * @var int
      */
-    private $doKeyReexchangeAfterXBytes = 1024 * 1024 * 1024;
+    private int $doKeyReexchangeAfterXBytes = 1024 * 1024 * 1024;
 
     /**
      * Has a key re-exchange been initialized?
-     *
-     * @var bool
-     * @access private
      */
-    private $keyExchangeInProgress = false;
+    private bool $keyExchangeInProgress = false;
 
     /**
      * KEX Buffer
@@ -986,10 +970,8 @@ class SSH2
      * @see self::_get_binary_packet()
      * @see self::_key_exchange()
      * @see self::exec()
-     * @var array
-     * @access private
      */
-    private $kex_buffer = [];
+    private array $kex_buffer = [];
 
     /**
      * Strict KEX Flag
@@ -999,10 +981,8 @@ class SSH2
      *
      * @see self::_key_exchange()
      * @see self::exec()
-     * @var array
-     * @access private
      */
-    private $strict_kex_flag = false;
+    private bool $strict_kex_flag = false;
 
     /**
      * Default Constructor.
@@ -1012,8 +992,9 @@ class SSH2
      * still will be used
      *
      * @see self::login()
+     * @param string|resource $host
      */
-    public function __construct($host, int $port = 22, int $timeout = 10)
+    public function __construct(mixed $host, int $port = 22, int $timeout = 10)
     {
         self::$connections[$this->getResourceId()] = \WeakReference::create($this);
 
@@ -1097,7 +1078,7 @@ class SSH2
      *
      * This wrapper does that loop
      */
-    private static function stream_select(&$read, &$write, &$except, $seconds, $microseconds = null)
+    private static function stream_select(?array &$read, ?array &$write, ?array &$except, ?int $seconds, ?int $microseconds = null): int|false
     {
         $remaining = $seconds + $microseconds / 1000000;
         $start = microtime(true);
@@ -1121,7 +1102,7 @@ class SSH2
      * @throws UnexpectedValueException on receipt of unexpected packets
      * @throws RuntimeException on other errors
      */
-    private function connect()
+    private function connect(): void
     {
         if ($this->bitmap & self::MASK_CONSTRUCTOR) {
             return;
@@ -1273,8 +1254,6 @@ class SSH2
         }
 
         $this->bitmap |= self::MASK_CONNECTED;
-
-        return true;
     }
 
     /**
@@ -1311,12 +1290,11 @@ class SSH2
     /**
      * Key Exchange
      *
-     * @param string|bool $kexinit_payload_server optional
      * @throws UnexpectedValueException on receipt of unexpected packets
      * @throws RuntimeException on other errors
      * @throws NoSupportedAlgorithmsException when none of the algorithms phpseclib has loaded are compatible
      */
-    private function key_exchange($kexinit_payload_server = false): bool
+    private function key_exchange(?string $kexinit_payload_server = null): bool
     {
         $this->bytesTransferredSinceLastKEX = 0;
 
@@ -1396,7 +1374,7 @@ class SSH2
             0 // reserved for future extension
         );
 
-        if ($kexinit_payload_server === false && $send_kex) {
+        if (!isset($kexinit_payload_server) && $send_kex) {
             $this->send_binary_packet($kexinit_payload_client);
 
             while (true) {
@@ -1431,7 +1409,7 @@ class SSH2
             $first_kex_packet_follows
         ] = Strings::unpackSSH2('L10C', $response);
         if (in_array('kex-strict-s-v00@openssh.com', $this->kex_algorithms)) {
-            if ($this->session_id === false) {
+            if (!isset($this->session_id)) {
                 // [kex-strict-s-v00@openssh.com is] only valid in the initial SSH2_MSG_KEXINIT and MUST be ignored
                 // if [it is] present in subsequent SSH2_MSG_KEXINIT packets
                 $this->strict_kex_flag = true;
@@ -1465,25 +1443,25 @@ class SSH2
 
         // through diffie-hellman key exchange a symmetric key is obtained
         $this->kex_algorithm = self::array_intersect_first($kex_algorithms, $this->kex_algorithms);
-        if ($this->kex_algorithm === false) {
+        if (!$this->kex_algorithm) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible key exchange algorithms found');
         }
 
         $server_host_key_algorithm = self::array_intersect_first($server_host_key_algorithms, $this->server_host_key_algorithms);
-        if ($server_host_key_algorithm === false) {
+        if (!$server_host_key_algorithm) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible server host key algorithms found');
         }
 
         $mac_algorithm_out = self::array_intersect_first($c2s_mac_algorithms, $this->mac_algorithms_client_to_server);
-        if ($mac_algorithm_out === false) {
+        if (!$mac_algorithm_out) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible client to server message authentication algorithms found');
         }
 
         $mac_algorithm_in = self::array_intersect_first($s2c_mac_algorithms, $this->mac_algorithms_server_to_client);
-        if ($mac_algorithm_in === false) {
+        if (!$mac_algorithm_in) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible server to client message authentication algorithms found');
         }
@@ -1495,40 +1473,37 @@ class SSH2
         ];
 
         $compression_algorithm_in = self::array_intersect_first($s2c_compression_algorithms, $this->compression_algorithms_server_to_client);
-        if ($compression_algorithm_in === false) {
+        if (!$compression_algorithm_in) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible server to client compression algorithms found');
         }
         $this->decompress = $compression_map[$compression_algorithm_in];
 
         $compression_algorithm_out = self::array_intersect_first($c2s_compression_algorithms, $this->compression_algorithms_client_to_server);
-        if ($compression_algorithm_out === false) {
+        if (!$compression_algorithm_out) {
             $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
             throw new NoSupportedAlgorithmsException('No compatible client to server compression algorithms found');
         }
         $this->compress = $compression_map[$compression_algorithm_out];
 
-        switch ($this->kex_algorithm) {
-            case 'diffie-hellman-group15-sha512':
-            case 'diffie-hellman-group16-sha512':
-            case 'diffie-hellman-group17-sha512':
-            case 'diffie-hellman-group18-sha512':
-            case 'ecdh-sha2-nistp521':
-                $kexHash = new Hash('sha512');
-                break;
-            case 'ecdh-sha2-nistp384':
-                $kexHash = new Hash('sha384');
-                break;
-            case 'diffie-hellman-group-exchange-sha256':
-            case 'diffie-hellman-group14-sha256':
-            case 'ecdh-sha2-nistp256':
-            case 'curve25519-sha256@libssh.org':
-            case 'curve25519-sha256':
-                $kexHash = new Hash('sha256');
-                break;
-            default:
-                $kexHash = new Hash('sha1');
-        }
+        $kexHash = match ($this->kex_algorithm) {
+            'diffie-hellman-group15-sha512',
+            'diffie-hellman-group16-sha512',
+            'diffie-hellman-group17-sha512',
+            'diffie-hellman-group18-sha512',
+            'ecdh-sha2-nistp521'
+                => new Hash('sha512'),
+            'ecdh-sha2-nistp384'
+                => new Hash('sha384'),
+            'diffie-hellman-group-exchange-sha256',
+            'diffie-hellman-group14-sha256',
+            'ecdh-sha2-nistp256',
+            'curve25519-sha256@libssh.org',
+            'curve25519-sha256'
+                => new Hash('sha256'),
+            default
+                => new Hash('sha1')
+        };
 
         // Only relevant in diffie-hellman-group-exchange-sha{1,256}, otherwise empty.
 
@@ -1648,20 +1623,13 @@ class SSH2
         );
 
         $this->exchange_hash = $kexHash->hash($this->exchange_hash);
+        $this->session_id ??= $this->exchange_hash;
 
-        if ($this->session_id === false) {
-            $this->session_id = $this->exchange_hash;
-        }
+        $expected_key_format = match ($server_host_key_algorithm) {
+            'rsa-sha2-256', 'rsa-sha2-512' => 'ssh-rsa',
+            default => $server_host_key_algorithm
+        };
 
-        switch ($server_host_key_algorithm) {
-            case 'rsa-sha2-256':
-            case 'rsa-sha2-512':
-            //case 'ssh-rsa':
-                $expected_key_format = 'ssh-rsa';
-                break;
-            default:
-                $expected_key_format = $server_host_key_algorithm;
-        }
         if ($public_key_format != $expected_key_format || $this->signature_format != $server_host_key_algorithm) {
             switch (true) {
                 case $this->signature_format == $server_host_key_algorithm:
@@ -1805,7 +1773,7 @@ class SSH2
             }
             $this->hmac_create->setKey(substr($key, 0, $createKeyLength));
             $this->hmac_create_name = $mac_algorithm_out;
-            $this->hmac_create_etm = preg_match('#-etm@openssh\.com$#', $mac_algorithm_out);
+            $this->hmac_create_etm = (bool) preg_match('#-etm@openssh\.com$#', $mac_algorithm_out);
         }
 
         if (!$this->decrypt->usesNonce()) {
@@ -1826,7 +1794,7 @@ class SSH2
             }
             $this->hmac_check->setKey(substr($key, 0, $checkKeyLength));
             $this->hmac_check_name = $mac_algorithm_in;
-            $this->hmac_check_etm = preg_match('#-etm@openssh\.com$#', $mac_algorithm_in);
+            $this->hmac_check_etm = (bool) preg_match('#-etm@openssh\.com$#', $mac_algorithm_in);
         }
 
         $this->regenerate_compression_context = $this->regenerate_decompression_context = true;
@@ -1840,126 +1808,86 @@ class SSH2
      * @param string $algorithm Name of the encryption algorithm
      * @return int|null Number of bytes as an integer or null for unknown
      */
-    private function encryption_algorithm_to_key_size(string $algorithm): ?int
+    private function encryption_algorithm_to_key_size(string $algorithm): int
     {
         if ($this->bad_key_size_fix && self::bad_algorithm_candidate($algorithm)) {
             return 16;
         }
 
-        switch ($algorithm) {
-            case 'none':
-                return 0;
-            case 'aes128-gcm@openssh.com':
-            case 'aes128-cbc':
-            case 'aes128-ctr':
-            case 'arcfour':
-            case 'arcfour128':
-            case 'blowfish-cbc':
-            case 'blowfish-ctr':
-            case 'twofish128-cbc':
-            case 'twofish128-ctr':
-                return 16;
-            case '3des-cbc':
-            case '3des-ctr':
-            case 'aes192-cbc':
-            case 'aes192-ctr':
-            case 'twofish192-cbc':
-            case 'twofish192-ctr':
-                return 24;
-            case 'aes256-gcm@openssh.com':
-            case 'aes256-cbc':
-            case 'aes256-ctr':
-            case 'arcfour256':
-            case 'twofish-cbc':
-            case 'twofish256-cbc':
-            case 'twofish256-ctr':
-                return 32;
-            case 'chacha20-poly1305@openssh.com':
-                return 64;
-        }
-        return null;
+        return match ($algorithm) {
+            'none'
+                => 0,
+            'aes128-gcm@openssh.com',
+            'aes128-cbc',
+            'aes128-ctr',
+            'arcfour',
+            'arcfour128',
+            'blowfish-cbc',
+            'blowfish-ctr',
+            'twofish128-cbc',
+            'twofish128-ctr'
+                => 16,
+            '3des-cbc',
+            '3des-ctr',
+            'aes192-cbc',
+            'aes192-ctr',
+            'twofish192-cbc',
+            'twofish192-ctr'
+                => 24,
+            'aes256-gcm@openssh.com',
+            'aes256-cbc',
+            'aes256-ctr',
+            'arcfour256',
+            'twofish-cbc',
+            'twofish256-cbc',
+            'twofish256-ctr'
+                => 32,
+            'chacha20-poly1305@openssh.com'
+                => 64
+        };
     }
 
     /**
      * Maps an encryption algorithm name to an instance of a subclass of
      * \phpseclib4\Crypt\Common\SymmetricKey.
-     *
-     * @param string $algorithm Name of the encryption algorithm
-     * @return SymmetricKey|null
      */
-    private static function encryption_algorithm_to_crypt_instance(string $algorithm)
+    private static function encryption_algorithm_to_crypt_instance(string $algorithm): ?SymmetricKey
     {
-        switch ($algorithm) {
-            case '3des-cbc':
-                return new TripleDES('cbc');
-            case '3des-ctr':
-                return new TripleDES('ctr');
-            case 'aes256-cbc':
-            case 'aes192-cbc':
-            case 'aes128-cbc':
-                return new Rijndael('cbc');
-            case 'aes256-ctr':
-            case 'aes192-ctr':
-            case 'aes128-ctr':
-                return new Rijndael('ctr');
-            case 'blowfish-cbc':
-                return new Blowfish('cbc');
-            case 'blowfish-ctr':
-                return new Blowfish('ctr');
-            case 'twofish128-cbc':
-            case 'twofish192-cbc':
-            case 'twofish256-cbc':
-            case 'twofish-cbc':
-                return new Twofish('cbc');
-            case 'twofish128-ctr':
-            case 'twofish192-ctr':
-            case 'twofish256-ctr':
-                return new Twofish('ctr');
-            case 'arcfour':
-            case 'arcfour128':
-            case 'arcfour256':
-                return new RC4();
-            case 'aes128-gcm@openssh.com':
-            case 'aes256-gcm@openssh.com':
-                return new Rijndael('gcm');
-            case 'chacha20-poly1305@openssh.com':
-                return new ChaCha20();
-        }
-        return null;
+        return match ($algorithm) {
+            '3des-cbc' => new TripleDES('cbc'),
+            '3des-ctr' => new TripleDES('cbc'),
+            'aes256-cbc', 'aes192-cbc', 'aes128-cbc' => new Rijndael('cbc'),
+            'aes256-ctr', 'aes192-ctr', 'aes128-ctr' => new Rijndael('ctr'),
+            'blowfish-cbc' => new Blowfish('cbc'),
+            'blowfish-ctr' => new Blowfish('ctr'),
+            'twofish128-cbc', 'twofish192-cbc', 'twofish256-cbc', 'twofish-cbc' => new Twofish('cbc'),
+            'twofish128-ctr', 'twofish192-ctr', 'twofish256-ctr' => new Twofish('ctr'),
+            'arcfour', 'arcfour128', 'arcfour256' => new RC4(),
+            'aes128-gcm@openssh.com', 'aes256-gcm@openssh.com' => new Rijndael('gcm'),
+            'chacha20-poly1305@openssh.com' => new ChaCha20(),
+            default => null
+        };
     }
 
     /**
-     * Maps an encryption algorithm name to an instance of a subclass of
+     * Maps a hash algorithm name to an instance of a subclass of
      * \phpseclib4\Crypt\Hash.
      *
-     * @param string $algorithm Name of the encryption algorithm
      * @return array{Hash, int}|null
      */
     private static function mac_algorithm_to_hash_instance(string $algorithm): ?array
     {
-        switch ($algorithm) {
-            case 'umac-64@openssh.com':
-            case 'umac-64-etm@openssh.com':
-                return [new Hash('umac-64'), 16];
-            case 'umac-128@openssh.com':
-            case 'umac-128-etm@openssh.com':
-                return [new Hash('umac-128'), 16];
-            case 'hmac-sha2-512':
-            case 'hmac-sha2-512-etm@openssh.com':
-                return [new Hash('sha512'), 64];
-            case 'hmac-sha2-256':
-            case 'hmac-sha2-256-etm@openssh.com':
-                return [new Hash('sha256'), 32];
-            case 'hmac-sha1':
-            case 'hmac-sha1-etm@openssh.com':
-                return [new Hash('sha1'), 20];
-            case 'hmac-sha1-96':
-                return [new Hash('sha1-96'), 20];
-            case 'hmac-md5':
-                return [new Hash('md5'), 16];
-            case 'hmac-md5-96':
-                return [new Hash('md5-96'), 16];
-        }
+        return match ($algorithm) {
+            'umac-64@openssh.com', 'umac-64-etm@openssh.com' => [new Hash('umac-64'), 16],
+            'umac-128@openssh.com', 'umac-128-etm@openssh.com' => [new Hash('umac-128'), 16],
+            'hmac-sha2-512', 'hmac-sha2-512-etm@openssh.com' => [new Hash('sha512'), 64],
+            'hmac-sha2-256', 'hmac-sha2-256-etm@openssh.com' => [new Hash('sha256'), 32],
+            'hmac-sha1', 'hmac-sha1-etm@openssh.com' => [new Hash('sha1'), 20],
+            'hmac-sha1-96' => [new Hash('sha1-96'), 20],
+            'hmac-md5' => [new Hash('md5'), 16],
+            'hmac-md5-96' => [new Hash('md5-96'), 16],
+            default => null
+        };
     }
 
     /**
@@ -1969,16 +1897,12 @@ class SSH2
      * @link https://bugzilla.mindrot.org/show_bug.cgi?id=1291
      * @param string $algorithm Name of the encryption algorithm
      */
-    private static function bad_algorithm_candidate($algorithm): bool
+    private static function bad_algorithm_candidate(string $algorithm): bool
     {
-        switch ($algorithm) {
-            case 'arcfour256':
-            case 'aes192-ctr':
-            case 'aes256-ctr':
-                return true;
-        }
-
-        return false;
+        return match ($algorithm) {
+            'arcfour256', 'aes192-ctr', 'aes256-ctr' => true,
+            default => false
+        };
     }
 
     /**
@@ -1986,13 +1910,16 @@ class SSH2
      *
      * The $password parameter can be a plaintext password, a \phpseclib4\Crypt\RSA|EC|DSA object, a \phpseclib4\System\SSH\Agent object or an array
      *
-     * @param string|PrivateKey|array[]|Agent|null ...$args
      * @see self::_login()
      */
-    public function login(string $username, #[SensitiveParameter] ...$args): bool
+    public function login(string $username, #[SensitiveParameter] string|PrivateKey|array|Agent ...$args): bool
     {
+        if (!($this->bitmap & self::MASK_CONSTRUCTOR)) {
+            $this->connect();
+        }
+
         if (!$this->login_credentials_finalized) {
-            $this->auth[] = func_get_args();
+            $this->auth[] = [$username, ...$args];
         }
 
         // try logging with 'none' as an authentication method first since that's what
@@ -2014,31 +1941,12 @@ class SSH2
     /**
      * Login Helper
      *
-     * @param string|PrivateKey|array[]|Agent|null ...$args
      * @see self::_login_helper()
      */
-    protected function sublogin(string $username, #[SensitiveParameter] ...$args): bool
+    protected function sublogin(string $username, #[SensitiveParameter] string|PrivateKey|array|Agent ...$args): bool
     {
-        if (!($this->bitmap & self::MASK_CONSTRUCTOR)) {
-            $this->connect();
-        }
-
         if (empty($args)) {
             return $this->login_helper($username);
-        }
-
-        foreach ($args as $arg) {
-            switch (true) {
-                case $arg instanceof PublicKey:
-                    throw new UnexpectedValueException('A PublicKey object was passed to the login method instead of a PrivateKey object');
-                case $arg instanceof PrivateKey:
-                case $arg instanceof Agent:
-                case is_array($arg):
-                case Strings::is_stringable($arg):
-                    break;
-                default:
-                    throw new UnexpectedValueException('$password needs to either be an instance of \phpseclib4\Crypt\Common\PrivateKey, \System\SSH\Agent, an array or a string');
-            }
         }
 
         while (count($args)) {
@@ -2065,7 +1973,7 @@ class SSH2
                                     $hasArray = true;
                                     break;
                                 }
-                                if ($hasString || Strings::is_stringable($arg)) {
+                                if ($hasString || is_string($arg)) {
                                     $hasString = true;
                                     break;
                                 }
@@ -2090,7 +1998,7 @@ class SSH2
             }
 
             if (!count($newargs)) {
-                return false;
+                return $this->login_helper($username);
             }
 
             foreach ($newargs as $arg) {
@@ -2112,12 +2020,8 @@ class SSH2
      * @throws UnexpectedValueException on receipt of unexpected packets
      * @throws RuntimeException on other errors
      */
-    private function login_helper(string $username, $password = null): bool
+    private function login_helper(string $username, string|PrivateKey|array|Agent|null $password = null): bool
     {
-        if (!($this->bitmap & self::MASK_CONNECTED)) {
-            return false;
-        }
-
         if (!($this->bitmap & self::MASK_LOGIN_REQ)) {
             $packet = Strings::packSSH2('Cs', MessageType::SERVICE_REQUEST, 'ssh-userauth');
             $this->send_binary_packet($packet);
@@ -2126,7 +2030,7 @@ class SSH2
                 $response = $this->get_binary_packet_or_close(MessageType::SERVICE_ACCEPT);
             } catch (InvalidPacketLengthException $e) {
                 // the first opportunity to encounter the "bad key size" error
-                if (!$this->bad_key_size_fix && $this->decryptName != null && self::bad_algorithm_candidate($this->decryptName)) {
+                if (!$this->bad_key_size_fix && isset($this->decryptName) && self::bad_algorithm_candidate($this->decryptName)) {
                     // bad_key_size_fix is only ever re-assigned to true here
                     // retry the connection with that new setting but we'll
                     // only try it once.
@@ -2147,7 +2051,7 @@ class SSH2
         }
 
         if (strlen($this->last_interactive_response)) {
-            return !Strings::is_stringable($password) && !is_array($password) ? false : $this->keyboard_interactive_process($password);
+            return !is_string($password) && !is_array($password) ? false : $this->keyboard_interactive_process($password);
         }
 
         if ($password instanceof PrivateKey) {
@@ -2256,10 +2160,8 @@ class SSH2
      * Login via keyboard-interactive authentication
      *
      * See {@link http://tools.ietf.org/html/rfc4256 RFC4256} for details.  This is not a full-featured keyboard-interactive authenticator.
-     *
-     * @param string|array $password
      */
-    private function keyboard_interactive_login(string $username, #[SensitiveParameter] $password): bool
+    private function keyboard_interactive_login(string $username, #[SensitiveParameter] string|array $password): bool
     {
         $packet = Strings::packSSH2(
             'Cs5',
@@ -2280,7 +2182,7 @@ class SSH2
      *
      * @throws RuntimeException on connection error
      */
-    private function keyboard_interactive_process(...$responses)
+    private function keyboard_interactive_process(string|array ...$responses): bool
     {
         if (strlen($this->last_interactive_response)) {
             $response = $this->last_interactive_response;
@@ -2560,24 +2462,11 @@ class SSH2
         return $this->stdErrorLog;
     }
 
-    /**
-     * Execute Command
-     *
-     * If $callback is set to false then \phpseclib4\Net\SSH2::get_channel_packet(self::CHANNEL_EXEC) will need to be called manually.
-     * In all likelihood, this is not a feature you want to be taking advantage of.
-     *
-     * @psalm-return ($callback is callable ? bool : string|bool)
-     * @throws RuntimeException on connection error
-     */
-    public function exec(string $command, false|null|callable $callback = null): string|bool
+    protected function initExec(string $command): void
     {
         $this->curTimeout = $this->timeout;
         $this->is_timeout = false;
         $this->stdErrorLog = '';
-
-        if (!$this->isAuthenticated()) {
-            return false;
-        }
 
         //if ($this->isPTYOpen()) {
         //    throw new RuntimeException('If you want to run multiple exec()\'s you will need to disable (and re-enable if appropriate) a PTY for each one.');
@@ -2632,17 +2521,33 @@ class SSH2
         $this->channel_status[self::CHANNEL_EXEC] = MessageType::CHANNEL_REQUEST;
 
         if (!$this->get_channel_packet(self::CHANNEL_EXEC)) {
-            return false;
+            $this->disconnect_helper(DisconnectReason::BY_APPLICATION);
+            throw new RuntimeException('Unable to execute command');
         }
 
         $this->channel_status[self::CHANNEL_EXEC] = MessageType::CHANNEL_DATA;
+    }
+
+    /**
+     * Execute Command
+     *
+     * If $callback is set to false then \phpseclib4\Net\SSH2::get_channel_packet(self::CHANNEL_EXEC) will need to be called manually.
+     * In all likelihood, this is not a feature you want to be taking advantage of (SCP.php uses it)
+     *
+     * @psalm-return ($callback is callable ? bool : string|bool)
+     * @throws RuntimeException on connection error
+     */
+    public function exec(string $command, ?\Closure $callback = null): ?string
+    {
+        if (!$this->isAuthenticated()) {
+            throw new RuntimeException('Please login before attempting to call exec()');
+        }
+
+        $this->initExec($command);
 
         if ($this->request_pty === true) {
             $this->channel_id_last_interactive = self::CHANNEL_EXEC;
-            return true;
-        }
-        if ($callback === false) {
-            return true;
+            return null;
         }
 
         $output = '';
@@ -2650,14 +2555,12 @@ class SSH2
             $temp = $this->get_channel_packet(self::CHANNEL_EXEC);
             switch (true) {
                 case $temp === true:
-                    return is_callable($callback) ? true : $output;
-                case $temp === false:
-                    return false;
+                    return $callback ? null : $output;
                 default:
-                    if (is_callable($callback)) {
+                    if ($callback) {
                         if ($callback($temp) === true) {
                             $this->close_channel(self::CHANNEL_EXEC);
-                            return true;
+                            return null;
                         }
                     } else {
                         $output .= $temp;
@@ -2668,10 +2571,8 @@ class SSH2
 
     /**
      * How many channels are currently open?
-     *
-     * @return int
      */
-    public function getOpenChannelCount()
+    public function getOpenChannelCount(): int
     {
         return $this->channelCount;
     }
@@ -2729,7 +2630,7 @@ class SSH2
      * @see self::read()
      * @see self::write()
      */
-    public function openShell(): bool
+    public function openShell(): void
     {
         if (!$this->isAuthenticated()) {
             throw new InsufficientSetupException('Operation disallowed prior to login()');
@@ -2779,8 +2680,6 @@ class SSH2
         $this->channel_id_last_interactive = self::CHANNEL_SHELL;
 
         $this->bitmap |= self::MASK_SHELL;
-
-        return true;
     }
 
     /**
@@ -2813,10 +2712,8 @@ class SSH2
 
     /**
      * Return an available open channel
-     *
-     * @return int
      */
-    private function get_open_channel()
+    private function get_open_channel(): ?int
     {
         $channel = self::CHANNEL_EXEC;
         do {
@@ -2825,7 +2722,7 @@ class SSH2
             }
         } while ($channel++ < self::CHANNEL_SUBSYSTEM);
 
-        return false;
+        return null;
     }
 
     /**
@@ -2834,7 +2731,7 @@ class SSH2
     public function requestAgentForwarding(): bool
     {
         $request_channel = $this->get_open_channel();
-        if ($request_channel === false) {
+        if ($request_channel === null) {
             return false;
         }
 
@@ -2895,9 +2792,8 @@ class SSH2
         if (!$this->is_channel_status_data($channel) && empty($this->channel_buffers[$channel])) {
             if ($channel != self::CHANNEL_SHELL) {
                 throw new InsufficientSetupException('Data is not available on channel');
-            } elseif (!$this->openShell()) {
-                throw new RuntimeException('Unable to initiate an interactive shell session');
             }
+            $this->openShell();
         }
 
         if ($mode == self::READ_NEXT) {
@@ -2952,9 +2848,8 @@ class SSH2
         if (!$this->is_channel_status_data($channel)) {
             if ($channel != self::CHANNEL_SHELL) {
                 throw new InsufficientSetupException('Data is not available on channel');
-            } elseif (!$this->openShell()) {
-                throw new RuntimeException('Unable to initiate an interactive shell session');
             }
+            $this->openShell();
         }
 
         $this->curTimeout = $this->timeout;
@@ -3005,12 +2900,11 @@ class SSH2
      *
      * @see self::startSubsystem()
      */
-    public function stopSubsystem(): bool
+    public function stopSubsystem(): void
     {
         if ($this->isInteractiveChannelOpen(self::CHANNEL_SUBSYSTEM)) {
             $this->close_channel(self::CHANNEL_SUBSYSTEM);
         }
-        return true;
     }
 
     /**
@@ -3119,7 +3013,7 @@ class SSH2
                 $this->close_channel(self::CHANNEL_KEEP_ALIVE);
             }
             return true;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -3185,7 +3079,7 @@ class SSH2
 
         try {
             $this->open_channel(self::CHANNEL_KEEP_ALIVE);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return $this->reconnect();
         }
 
@@ -3219,11 +3113,11 @@ class SSH2
         $this->fsock = null;
         $this->bitmap = 0;
         $this->binary_packet_buffer = null;
-        $this->decrypt = $this->encrypt = false;
+        $this->decrypt = $this->encrypt = null;
         $this->decrypt_block_size = $this->encrypt_block_size = 8;
-        $this->hmac_check = $this->hmac_create = false;
-        $this->hmac_size = false;
-        $this->session_id = false;
+        $this->hmac_check = $this->hmac_create = null;
+        $this->hmac_size = null;
+        $this->session_id = null;
         $this->get_seq_no = $this->send_seq_no = 0;
         $this->channel_status = [];
         $this->channel_id_last_interactive = 0;
@@ -3234,7 +3128,7 @@ class SSH2
     /**
      * @return int[] second and microsecond stream timeout options based on user-requested timeout and keep-alive, or the default socket timeout by default, which mirrors PHP socket streams.
      */
-    private function get_stream_timeout()
+    private function get_stream_timeout(): array
     {
         $sec = (int) ini_get('default_socket_timeout');
         $usec = 0;
@@ -3256,11 +3150,10 @@ class SSH2
     /**
      * Retrieves the next packet with added timeout and type handling
      *
-     * @param string $message_types Message types to enforce in response, closing if not met
-     * @return string
+     * @param int $message_types Message types to enforce in response, closing if not met
      * @throws ConnectionClosedException If an error has occurred preventing read of the next packet
      */
-    private function get_binary_packet_or_close(...$message_types)
+    private function get_binary_packet_or_close(int ...$message_types): string
     {
         try {
             $packet = $this->get_binary_packet();
@@ -3270,7 +3163,7 @@ class SSH2
                     . implode(', #', $message_types) . '. Got: #' . ord($packet[0]));
             }
             return $packet;
-        } catch (TimeoutException $e) {
+        } catch (TimeoutException) {
             $this->disconnect_helper(DisconnectReason::BY_APPLICATION);
             throw new ConnectionClosedException('Connection closed due to timeout');
         }
@@ -3558,10 +3451,8 @@ class SSH2
      *
      * @see self::filter()
      * @see self::key_exchange()
-     * @return boolean
-     * @access private
      */
-    private function handleDisconnect($payload)
+    private function handleDisconnect($payload): void
     {
         Strings::shift($payload, 1);
         [$reason_code, $message] = Strings::unpackSSH2('Ns', $payload);
@@ -3583,7 +3474,7 @@ class SSH2
             return $this->handleDisconnect($payload);
         }
 
-        if ($this->session_id === false && $this->keyExchangeInProgress) {
+        if (!isset($this->session_id) && $this->keyExchangeInProgress) {
             return $payload;
         }
 
@@ -3601,7 +3492,7 @@ class SSH2
                 break;
             case MessageType::KEXINIT:
                 // this is here for server key re-exchanges after the initial key exchange
-                if (!$this->keyExchangeInProgress && $this->session_id !== false) {
+                if (!$this->keyExchangeInProgress && isset($this->session_id)) {
                     if (!$this->key_exchange($payload)) {
                         $this->disconnect_helper(DisconnectReason::KEY_EXCHANGE_FAILED);
                         throw new ConnectionClosedException('Key exchange failed');
@@ -3812,7 +3703,7 @@ class SSH2
      *        window, and where data received on that respective channel is also buffered.
      * @throws RuntimeException on connection error
      */
-    protected function get_channel_packet(int $client_channel, bool $skip_extended = false)
+    protected function get_channel_packet(int $client_channel, bool $skip_extended = false): string|bool
     {
         if (!empty($this->channel_buffers[$client_channel])) {
             switch ($this->channel_status[$client_channel] ?? null) {
@@ -3834,7 +3725,7 @@ class SSH2
         while (true) {
             try {
                 $response = $this->get_binary_packet();
-            } catch (TimeoutException $e) {
+            } catch (TimeoutException) {
                 return true;
             }
             [$type] = Strings::unpackSSH2('C', $response);
@@ -4229,10 +4120,10 @@ class SSH2
      *
      * @param resource &$realtime_log_file
      */
-    protected function append_log_helper(int $constant, string $message_number, string $message, array &$message_number_log, array &$message_log, int &$log_size, &$realtime_log_file, bool &$realtime_log_wrap, int &$realtime_log_size): void
+    protected function append_log_helper(int $constant, string $message_number, string $message, array &$message_number_log, array &$message_log, ?int &$log_size, mixed &$realtime_log_file, ?bool &$realtime_log_wrap, ?int &$realtime_log_size): void
     {
         // remove the byte identifying the message type from all but the first two messages (ie. the identification strings)
-        if (!in_array(substr($message_number, 0, 4), ['<- (', '-> (']) && strlen($message_number) > 2) {
+        if (!in_array(substr($message_number, 0, 4), ['<- (', '-> (']) && strlen($message_number) > 2 && substr($message_number, 3, 8) != 'SSH_FXP_') {
             Strings::shift($message);
         }
 
@@ -4364,7 +4255,7 @@ class SSH2
      * and for SFTP channels are presumably closed when the client disconnects.  This functions is intended
      * for SCP more than anything.
      */
-    protected function close_channel($client_channel): void
+    protected function close_channel(int $client_channel): void
     {
         // see http://tools.ietf.org/html/rfc4254#section-5.3
 
@@ -4418,7 +4309,7 @@ class SSH2
             $data = Strings::packSSH2('CNss', MessageType::DISCONNECT, $reason, '', '');
             try {
                 $this->send_binary_packet($data);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         }
 
@@ -4431,10 +4322,8 @@ class SSH2
      * Returns a log of the packets that have been sent and received.
      *
      * Returns a string if NET_SSH2_LOGGING == self::LOG_COMPLEX, an array if NET_SSH2_LOGGING == self::LOG_SIMPLE and false if !defined('NET_SSH2_LOGGING')
-     *
-     * @return array|false|string
      */
-    public function getLog()
+    public function getLog(): array|string|null
     {
         if (!defined('NET_SSH2_LOGGING')) {
             return false;
@@ -4447,7 +4336,7 @@ class SSH2
                 $log = $this->format_log($this->message_log, $this->message_number_log);
                 return PHP_SAPI == 'cli' ? $log : '<pre>' . $log . '</pre>';
             default:
-                return false;
+                return null;
         }
     }
 
@@ -4497,54 +4386,20 @@ class SSH2
         }
     }
 
-    /**
-     * Returns the first value of the intersection of two arrays or false if
-     * the intersection is empty. The order is defined by the first parameter.
-     *
-     * @return mixed False if intersection is empty, else intersected value.
-     */
-    private static function array_intersect_first(array $array1, array $array2)
+    private static function array_intersect_first(array $array1, array $array2): ?string
     {
         foreach ($array1 as $value) {
             if (in_array($value, $array2)) {
                 return $value;
             }
         }
-        return false;
-    }
-
-    /**
-     * Returns all errors / debug messages on the SSH layer
-     *
-     * If you are looking for messages from the SFTP layer, please see SFTP::getSFTPErrors()
-     *
-     * @return string[]
-     */
-    public function getErrors(): array
-    {
-        return $this->errors;
-    }
-
-    /**
-     * Returns the last error received on the SSH layer
-     *
-     * If you are looking for messages from the SFTP layer, please see SFTP::getLastSFTPError()
-     */
-    public function getLastError(): string
-    {
-        $count = count($this->errors);
-
-        if ($count > 0) {
-            return $this->errors[$count - 1];
-        }
+        return null;
     }
 
     /**
      * Return the server identification.
-     *
-     * @return string|false
      */
-    public function getServerIdentification()
+    public function getServerIdentification(): string
     {
         $this->connect();
 
@@ -4961,11 +4816,10 @@ class SSH2
      * Caching this the first time you connect to a server and checking the result on subsequent connections
      * is recommended.  Returns false if the server signature is not signed correctly with the public host key.
      *
-     * @return string|false
      * @throws RuntimeException on badly formatted keys
      * @throws NoSupportedAlgorithmsException when the key isn't in a supported format
      */
-    public function getServerPublicHostKey()
+    public function getServerPublicHostKey(): ?string
     {
         if (!($this->bitmap & self::MASK_CONSTRUCTOR)) {
             $this->connect();
@@ -4977,7 +4831,7 @@ class SSH2
         if ($this->signature_validated) {
             return $this->bitmap ?
                 $this->signature_format . ' ' . $server_public_host_key :
-                false;
+                null;
         }
 
         $this->signature_validated = true;
@@ -4989,19 +4843,12 @@ class SSH2
             case 'ecdsa-sha2-nistp521':
                 $key = EC::loadFormat('OpenSSH', $server_public_host_key)
                     ->withSignatureFormat('SSH2');
-                switch ($this->signature_format) {
-                    case 'ssh-ed25519':
-                        $hash = 'sha512';
-                        break;
-                    case 'ecdsa-sha2-nistp256':
-                        $hash = 'sha256';
-                        break;
-                    case 'ecdsa-sha2-nistp384':
-                        $hash = 'sha384';
-                        break;
-                    case 'ecdsa-sha2-nistp521':
-                        $hash = 'sha512';
-                }
+                $hash = match ($this->signature_format) {
+                    'ssh-ed25519' => 'sha512',
+                    'ecdsa-sha2-nistp256' => 'sha256',
+                    'ecdsa-sha2-nistp384' => 'sha384',
+                    'ecdsa-sha2-nistp521' => 'sha512'
+                };
                 $key = $key->withHash($hash);
                 break;
             case 'ssh-dss':
@@ -5019,17 +4866,11 @@ class SSH2
 
                 $key = RSA::loadFormat('OpenSSH', $server_public_host_key)
                     ->withPadding(RSA::SIGNATURE_PKCS1);
-                switch ($this->signature_format) {
-                    case 'rsa-sha2-512':
-                        $hash = 'sha512';
-                        break;
-                    case 'rsa-sha2-256':
-                        $hash = 'sha256';
-                        break;
-                    //case 'ssh-rsa':
-                    default:
-                        $hash = 'sha1';
-                }
+                $hash = match ($this->signature_format) {
+                    'rsa-sha2-512' => 'sha512',
+                    'rsa-sha2-256' => 'sha256',
+                    default => 'sha1'
+                };
                 $key = $key->withHash($hash);
                 break;
             default:
@@ -5045,14 +4886,12 @@ class SSH2
     }
 
     /**
-     * Returns the exit status of an SSH command or false.
-     *
-     * @return false|int
+     * Returns the exit status of an SSH command or false
      */
-    public function getExitStatus()
+    public function getExitStatus(): ?int
     {
-        if (is_null($this->exit_status)) {
-            return false;
+        if (!isset($this->exit_status)) {
+            return null;
         }
         return $this->exit_status;
     }
@@ -5104,7 +4943,7 @@ class SSH2
      * @return string
      */
     #[\ReturnTypeWillChange]
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getResourceId();
     }
@@ -5122,7 +4961,7 @@ class SSH2
         return '{' . spl_object_hash($this) . '}';
     }
 
-    public static function getConnectionByResourceId(string $id): SSH2|null
+    public static function getConnectionByResourceId(string $id): ?SSH2
     {
         if (array_key_exists($id, self::$connections)) {
             /**
@@ -5196,7 +5035,7 @@ class SSH2
     /**
      * How many bytes until the next key re-exchange?
      */
-    public function bytesUntilKeyReexchange(int $bytes)
+    public function bytesUntilKeyReexchange(int $bytes): void
     {
         $this->doKeyReexchangeAfterXBytes = $bytes;
     }

--- a/tests/Functional/Net/SCPSSH2UserStoryTest.php
+++ b/tests/Functional/Net/SCPSSH2UserStoryTest.php
@@ -44,10 +44,7 @@ class SCPSSH2UserStoryTest extends PhpseclibFunctionalTestCase
     /** @depends testConstructor */
     public function testPutGetString($scp)
     {
-        $this->assertTrue(
-            $scp->put(self::$remoteFile, self::$exampleData),
-            'Failed asserting that data could successfully be put() into file.'
-        );
+        $scp->put(self::$remoteFile, self::$exampleData);
         $content = $scp->get(self::$remoteFile);
         $this->assertSame(
             strlen($content),
@@ -66,10 +63,7 @@ class SCPSSH2UserStoryTest extends PhpseclibFunctionalTestCase
     public function testGetFile($scp)
     {
         $localFilename = $this->createTempFile();
-        $this->assertTrue(
-            $scp->get(self::$remoteFile, $localFilename),
-            'Failed asserting that get() into file was successful.'
-        );
+        $scp->get(self::$remoteFile, $localFilename);
         $this->assertContains(
             filesize($localFilename),
             array(self::$exampleDataLength, self::$exampleDataLength + 1),
@@ -90,21 +84,16 @@ class SCPSSH2UserStoryTest extends PhpseclibFunctionalTestCase
     public function testGetBadFilePutGet($scp)
     {
         $scp->exec('rm ' . self::$remoteFile);
-        $this->assertFalse(
-            $scp->get(self::$remoteFile),
-            'Failed asserting that get() on a non-existant file failed'
-        );
-        $this->assertCount(1, $scp->getSCPErrors());
-        $this->assertTrue(
-            $scp->put(self::$remoteFile, self::$exampleData),
-            'Failed asserting that put() succeeded'
-        );
+        try {
+            $scp->get(self::$remoteFile);
+            $this->assertTrue(
+                false,
+                'Failed asserting that get() on a non-existant file failed'
+            );
+        } catch (\Exception) {
+        }
+        $scp->put(self::$remoteFile, self::$exampleData);
         $content = $scp->get(self::$remoteFile);
-        $this->assertSame(
-            strlen($content),
-            self::$exampleDataLength,
-            'Failed asserting that string length matches expected length.'
-        );
         $this->assertSame(
             $content,
             self::$exampleData,

--- a/tests/Functional/Net/SFTPLargeFileTest.php
+++ b/tests/Functional/Net/SFTPLargeFileTest.php
@@ -33,10 +33,7 @@ class SFTPLargeFileTest extends SFTPTestCase
         $tmp_filename = $this->createTempFile(128, 1024 * 1024);
         $filename = 'file-large-from-local.txt';
 
-        $this->assertTrue(
-            $this->sftp->put($filename, $tmp_filename, SFTP::SOURCE_LOCAL_FILE),
-            'Failed asserting that local file could be successfully put().'
-        );
+        $this->sftp->put($filename, $tmp_filename, SFTP::SOURCE_LOCAL_FILE);
 
         $this->assertSame(
             128 * 1024 * 1024,

--- a/tests/Functional/Net/SFTPTestCase.php
+++ b/tests/Functional/Net/SFTPTestCase.php
@@ -34,8 +34,8 @@ abstract class SFTPTestCase extends PhpseclibFunctionalTestCase
             $this->getEnv('SSH_USERNAME'),
             $this->getEnv('SSH_PASSWORD')
         ));
-        $this->assertTrue($this->sftp->mkdir($this->scratchDir));
-        $this->assertTrue($this->sftp->chdir($this->scratchDir));
+        $this->sftp->mkdir($this->scratchDir);
+        $this->sftp->chdir($this->scratchDir);
     }
 
     public function tearDown(): void

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -82,17 +82,16 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         $dirname = self::$scratchDir;
 
-        $this->assertTrue(
-            $sftp->mkdir($dirname),
-            "Failed asserting that a new scratch directory $dirname could " .
-            'be created.'
-        );
-
-        $this->assertFalse(
-            $sftp->mkdir($dirname),
-            "Failed asserting that a new scratch directory $dirname could " .
-            'not be created (because it already exists).'
-        );
+        $sftp->mkdir($dirname);
+        try {
+            $sftp->mkdir($dirname);
+            $this->assertTrue(
+                false,
+                "Failed asserting that a new scratch directory $dirname could " .
+                'not be created (because it already exists).'
+            );
+        } catch (\Exception) {
+        }
 
         return $sftp;
     }
@@ -102,14 +101,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testChDirScratch(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->chdir(self::$scratchDir),
-            sprintf(
-                'Failed asserting that working directory could be changed ' .
-                'to scratch directory %s.',
-                self::$scratchDir
-            )
-        );
+        $sftp->chdir(self::$scratchDir);
 
         $pwd = $sftp->pwd();
 
@@ -144,25 +136,12 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         return $sftp;
     }
 
-    public static function demoCallback($length)
-    {
-        $r = substr(self::$buffer, 0, $length);
-        self::$buffer = substr(self::$buffer, $length);
-        if (strlen($r)) {
-            return $r;
-        }
-        return null;
-    }
-
     /**
      * @depends testStatOnDir
      */
     public function testPutSizeGetFile(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->put('file1.txt', self::$exampleData),
-            'Failed asserting that example data could be successfully put().'
-        );
+        $sftp->put('file1.txt', self::$exampleData);
 
         $this->assertSame(
             self::$exampleDataLength,
@@ -176,10 +155,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
             'Failed asserting that get() returns expected example data.'
         );
 
-        $this->assertTrue(
-            $sftp->put('file1.txt', 'xxx', SFTP::RESUME),
-            'Failed asserting that an upload could be successfully resumed'
-        );
+        $sftp->put('file1.txt', 'xxx', SFTP::RESUME);
 
         $this->assertSame(
             self::$exampleDataLength + 3,
@@ -202,10 +178,15 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     public function testPutSizeGetFileCallback(SFTP $sftp)
     {
         self::$buffer = self::$exampleData;
-        $this->assertTrue(
-            $sftp->put('file1.txt', [__CLASS__, 'demoCallback'], $sftp::SOURCE_CALLBACK),
-            'Failed asserting that example data could be successfully put().'
-        );
+        $closure = function ($length) {
+            $r = substr(self::$buffer, 0, $length);
+            self::$buffer = substr(self::$buffer, $length);
+            if (strlen($r)) {
+                return $r;
+            }
+            return null;
+        };
+        $sftp->put('file1.txt', $closure, $sftp::SOURCE_CALLBACK);
 
         $this->assertSame(
             self::$exampleDataLength,
@@ -227,10 +208,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testTouch(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->touch('file2.txt'),
-            'Failed asserting that touch() successfully ran.'
-        );
+        $sftp->touch('file2.txt');
 
         $this->assertTrue(
             $sftp->file_exists('file2.txt'),
@@ -245,15 +223,9 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testTruncate(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->touch('file3.txt'),
-            'Failed asserting that touch() successfully ran.'
-        );
+        $sftp->touch('file3.txt');
 
-        $this->assertTrue(
-            $sftp->truncate('file3.txt', 1024 * 1024),
-            'Failed asserting that touch() successfully ran.'
-        );
+        $sftp->truncate('file3.txt', 1024 * 1024);
 
         $this->assertSame(
             1024 * 1024,
@@ -270,10 +242,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testChModOnFile(SFTP $sftp)
     {
-        $this->assertNotFalse(
-            $sftp->chmod(0o755, 'file1.txt'),
-            'Failed asserting that chmod() was successful.'
-        );
+        $sftp->chmod('file1.txt', 0o755);
 
         return $sftp;
     }
@@ -283,10 +252,14 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testChDirOnFile(SFTP $sftp)
     {
-        $this->assertFalse(
-            $sftp->chdir('file1.txt'),
-            'Failed to assert that the cwd cannot be changed to a file'
-        );
+        try {
+            $sftp->chdir('file1.txt');
+            $this->assertTrue(
+                false,
+                'Failed to assert that the cwd cannot be changed to a file'
+            );
+        } catch (\Exception) {
+        }
 
         return $sftp;
     }
@@ -342,11 +315,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testSortOrder(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->mkdir('temp'),
-            "Failed asserting that a new scratch directory temp could " .
-            'be created.'
-        );
+        $sftp->mkdir('temp');
 
         $sftp->setListOrder('filename', SORT_DESC);
 
@@ -415,10 +384,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testSymlink(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->symlink('file3.txt', 'symlink'),
-            'Failed asserting that a symlink could be created'
-        );
+        $sftp->symlink('file3.txt', 'symlink');
 
         return $sftp;
     }
@@ -503,18 +469,18 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         // Name used for both directory and file.
         $name = 'stattestdir';
-        $this->assertTrue($sftp->mkdir($name));
+        $sftp->mkdir($name);
         $this->assertTrue($sftp->is_dir($name));
-        $this->assertTrue($sftp->chdir($name));
+        $sftp->chdir($name);
         $this->assertStringEndsWith(self::$scratchDir . '/' . $name, $sftp->pwd());
         $this->assertFalse($sftp->file_exists($name));
-        $this->assertTrue($sftp->touch($name));
+        $sftp->touch($name);
         $this->assertTrue($sftp->is_file($name));
-        $this->assertTrue($sftp->chdir('..'));
+        $sftp->chdir('..');
         $this->assertStringEndsWith(self::$scratchDir, $sftp->pwd());
         $this->assertTrue($sftp->is_dir($name));
         $this->assertTrue($sftp->is_file("$name/$name"));
-        $this->assertTrue($sftp->delete($name, true));
+        $sftp->delete($name, true);
 
         return $sftp;
     }
@@ -524,10 +490,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testChDirUpHome(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->chdir('../'),
-            'Failed asserting that directory could be changed one level up.'
-        );
+        $sftp->chdir('../');
 
         $this->assertEquals(
             $this->getEnv('SSH_HOME'),
@@ -568,8 +531,8 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     {
         $filesize = (4 * 1024 + 16) * 1024 * 1024;
         $filename = 'file-large-from-truncate-4112MiB.txt';
-        $this->assertTrue($sftp->touch($filename));
-        $this->assertTrue($sftp->truncate($filename, $filesize));
+        $sftp->touch($filename);
+        $sftp->truncate($filename, $filesize);
         $this->assertSame($filesize, $sftp->filesize($filename));
 
         return $sftp;
@@ -580,11 +543,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testRmDirScratch(SFTP $sftp)
     {
-        $this->assertFalse(
-            $sftp->rmdir(self::$scratchDir),
-            'Failed asserting that non-empty scratch directory could ' .
-            'not be deleted using rmdir().'
-        );
+        $sftp->rmdir(self::$scratchDir);
 
         return $sftp;
     }
@@ -594,11 +553,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testDeleteRecursiveScratch(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->delete(self::$scratchDir),
-            'Failed asserting that non-empty scratch directory could ' .
-            'be deleted using recursive delete().'
-        );
+        $sftp->delete(self::$scratchDir);
 
         return $sftp;
     }
@@ -608,11 +563,7 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testRmDirScratchNonexistent(SFTP $sftp)
     {
-        $this->assertFalse(
-            $sftp->rmdir(self::$scratchDir),
-            'Failed asserting that nonexistent scratch directory could ' .
-            'not be deleted using rmdir().'
-        );
+        $sftp->rmdir(self::$scratchDir);
 
         return $sftp;
     }
@@ -623,30 +574,30 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testDeleteEmptyDir(SFTP $sftp)
     {
-        $this->assertTrue(
-            $sftp->mkdir(self::$scratchDir),
-            'Failed asserting that scratch directory could ' .
-            'be created.'
-        );
+        $sftp->mkdir(self::$scratchDir);
         $this->assertIsArray(
             $sftp->stat(self::$scratchDir),
             'Failed asserting that stat on an existent empty directory returns an array'
         );
-        $this->assertTrue(
-            $sftp->delete(self::$scratchDir),
-            'Failed asserting that empty scratch directory could ' .
-            'be deleted using recursive delete().'
-        );
-        $this->assertFalse(
-            $sftp->stat(self::$scratchDir),
-            'Failed asserting that stat on a deleted directory returns false'
-        );
+        $sftp->delete(self::$scratchDir);
+        try {
+            $sftp->stat(self::$scratchDir);
+            $this->assertTrue(
+                false,
+                'Failed asserting that stat on a deleted directory returns false'
+            );
+        } catch (\Exception) {
+        }
 
-        $this->assertFalse(
-            $sftp->delete(self::$scratchDir),
-            'Failed asserting that non-existent directory could not ' .
-            'be deleted using recursive delete().'
-        );
+        try {
+            $sftp->delete(self::$scratchDir);
+            $this->assertTrue(
+                false,
+                'Failed asserting that non-existent directory could not ' .
+                'be deleted using recursive delete().'
+            );
+        } catch (\Exception) {
+        }
 
         return $sftp;
     }
@@ -657,12 +608,12 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testStatVsLstat(SFTP $sftp)
     {
-        $this->assertTrue($sftp->mkdir(self::$scratchDir));
-        $this->assertTrue($sftp->chdir(self::$scratchDir));
-        $this->assertTrue($sftp->put('text.txt', 'zzzzz'));
-        $this->assertTrue($sftp->symlink('text.txt', 'link.txt'));
-        $this->assertTrue($sftp->mkdir('subdir'));
-        $this->assertTrue($sftp->symlink('subdir', 'linkdir'));
+        $sftp->mkdir(self::$scratchDir);
+        $sftp->chdir(self::$scratchDir);
+        $sftp->put('text.txt', 'zzzzz');
+        $sftp->symlink('text.txt', 'link.txt');
+        $sftp->mkdir('subdir');
+        $sftp->symlink('subdir', 'linkdir');
 
         $sftp->clearStatCache();
 
@@ -764,13 +715,13 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
      */
     public function testRawlistDisabledStatCache(SFTP $sftp)
     {
-        $this->assertTrue($sftp->mkdir(self::$scratchDir));
-        $this->assertTrue($sftp->chdir(self::$scratchDir));
-        $this->assertTrue($sftp->put('text.txt', 'zzzzz'));
-        $this->assertTrue($sftp->mkdir('subdir'));
-        $this->assertTrue($sftp->chdir('subdir'));
-        $this->assertTrue($sftp->put('leaf.txt', 'yyyyy'));
-        $this->assertTrue($sftp->chdir('../../'));
+        $sftp->mkdir(self::$scratchDir);
+        $sftp->chdir(self::$scratchDir);
+        $sftp->put('text.txt', 'zzzzz');
+        $sftp->mkdir('subdir');
+        $sftp->chdir('subdir');
+        $sftp->put('leaf.txt', 'yyyyy');
+        $sftp->chdir('../../');
 
         $list_cache_enabled = $sftp->rawlist('.', true);
 
@@ -814,8 +765,8 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
     public function testChownChgrp(SFTP $sftp)
     {
         $stat = $sftp->stat(self::$scratchDir);
-        $this->assertTrue($sftp->chown(self::$scratchDir, $stat['uid']));
-        $this->assertTrue($sftp->chgrp(self::$scratchDir, $stat['gid']));
+        $sftp->chown(self::$scratchDir, $stat['uid']);
+        $sftp->chgrp(self::$scratchDir, $stat['gid']);
 
         $sftp->clearStatCache();
         $stat2 = $sftp->stat(self::$scratchDir);

--- a/tests/Functional/Net/SSH2Test.php
+++ b/tests/Functional/Net/SSH2Test.php
@@ -162,7 +162,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
             ->expects($this->atLeastOnce())
             ->method('callbackMethod')
             ->will($this->returnValue(true));
-        $ssh->exec('pwd', [$callbackObject, 'callbackMethod']);
+        $ssh->exec('pwd', \Closure::fromCallable([$callbackObject, 'callbackMethod']));
 
         $this->assertFalse(
             $ssh->isPTYOpen(),
@@ -313,10 +313,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
 
         $ssh->enablePTY();
 
-        $this->assertTrue(
-            $ssh->exec('bash'),
-            'Failed asserting exec command succeeded.'
-        );
+        $ssh->exec('bash');
 
         $this->assertTrue(
             $ssh->isShellOpen(),
@@ -360,10 +357,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
     {
         $ssh = $this->getSSH2Login();
 
-        $this->assertTrue(
-            $ssh->openShell(),
-            'SSH2 shell initialization failed.'
-        );
+        $ssh->openShell();
 
         $this->assertTrue(
             $ssh->isShellOpen(),
@@ -428,10 +422,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
     {
         $ssh = $this->getSSH2Login();
 
-        $this->assertTrue(
-            $ssh->openShell(),
-            'SSH2 shell initialization failed.'
-        );
+        $ssh->openShell();
 
         $this->assertEquals(
             SSH2::CHANNEL_SHELL,
@@ -468,10 +459,7 @@ class SSH2Test extends PhpseclibFunctionalTestCase
 
         $ssh->enablePTY();
 
-        $this->assertTrue(
-            $ssh->exec('bash'),
-            'Failed asserting that pty exec succeeds'
-        );
+        $ssh->exec('bash');
 
         $this->assertTrue(
             $ssh->isShellOpen(),

--- a/tests/Unit/Net/SSH2UnitTest.php
+++ b/tests/Unit/Net/SSH2UnitTest.php
@@ -100,7 +100,7 @@ class SSH2UnitTest extends PhpseclibTestCase
     {
         $ssh = $this->createSSHMock();
 
-        $this->assertFalse($ssh->getExitStatus());
+        $this->assertNull($ssh->getExitStatus());
     }
 
     /**
@@ -201,8 +201,7 @@ class SSH2UnitTest extends PhpseclibTestCase
             ->method('isAuthenticated')
             ->willReturn(true);
         $ssh->expects($this->once())
-            ->method('openShell')
-            ->willReturn(true);
+            ->method('openShell');
         $ssh->expects($this->once())
             ->method('send_channel_packet')
             ->with(SSH2::CHANNEL_SHELL, 'hello');
@@ -223,7 +222,7 @@ class SSH2UnitTest extends PhpseclibTestCase
         $this->expectException(InsufficientSetupException::class);
         $this->expectExceptionMessage('Operation disallowed prior to login()');
 
-        $this->assertFalse($ssh->openShell());
+        $ssh->openShell();
     }
 
     public function testGetTimeout(): void
@@ -299,8 +298,9 @@ class SSH2UnitTest extends PhpseclibTestCase
         $ssh->expects($this->once())
             ->method('get_channel_packet')
             ->with(-1)
-            ->willReturnCallback(function () use ($ssh): void {
+            ->willReturnCallback(function () use ($ssh): string|bool {
                 self::setVar($ssh, 'window_size_client_to_server', [1 => 0x7FFFFFFF]);
+                return true;
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')
@@ -326,8 +326,9 @@ class SSH2UnitTest extends PhpseclibTestCase
         $ssh->expects($this->once())
             ->method('get_channel_packet')
             ->with(-1)
-            ->willReturnCallback(function () use ($ssh): void {
+            ->willReturnCallback(function () use ($ssh): string|bool {
                 self::setVar($ssh, 'window_size_client_to_server', [1 => 0x7FFFFFFF]);
+                return true;
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')
@@ -357,8 +358,9 @@ class SSH2UnitTest extends PhpseclibTestCase
         $ssh->expects($this->once())
             ->method('get_channel_packet')
             ->with(-1)
-            ->willReturnCallback(function () use ($ssh): void {
+            ->willReturnCallback(function () use ($ssh): string|bool {
                 self::setVar($ssh, 'is_timeout', true);
+                return true;
             });
         $ssh->expects($this->once())
             ->method('send_binary_packet')


### PR DESCRIPTION
In phpseclib v3, if `$sftp->put('path/to/filename.ext', 'zzz')` failed due to permission being denied it'd return false. Now it'll throw an exception. As will most SSH2 / SFTP methods upon failure. This mirrors a trend that has been seen in PHP for several years now. For example:

- in PHP 8.0.0 PDO [switched](https://www.php.net/manual/en/pdo.error-handling.php) from using PDO::ERRMODE_SILENT as the default error handling mode to PDO::ERRMODE_EXCEPTION.
- in PHP 8.1.0 MySQLi's default error mode was [set to exceptions](https://www.php.net/releases/8.1/en.php)

That said, there are still situations phpseclib v4 (SFTP, in particular) does not throw exceptions. https://terrafrost.com/phpseclib/v4/docs/ssh2/diagnosis#sftpgeterrors elaborates, however, to expand on what that URL says...

In phpseclib v3, SSH2 had `getErrors()` and `getLastError()`. SFTP had `getSFTPErrors()` and `getLastSFTPError()`. In v4 all of those methods have been removed (since exceptions are now thrown, instead) and `SFTP::getErrors()` has been added. https://terrafrost.com/phpseclib/v4/docs/ssh2/diagnosis#sftpgeterrors gives an example of what `SFTP::getErrors()` would return under a very specific scenario:

```
Array
(
    [0] => REMOVE /home/test/A (FAILURE): Failure
    [1] => REMOVE /home/test/A/B (PERMISSION_DENIED): Permission denied
    [2] => OPENDIR /home/test/A/C (PERMISSION_DENIED): Permission denied
    [3] => RMDIR /home/test/A/C (FAILURE): Failure
    [4] => RMDIR /home/test/A (FAILURE): Failure
)
```

Here's what `SFTP::getSFTPErrors()` would have looked like in phpseclib v3 under the exact same scenario:

```
Array
(
    [0] => NET_SFTP_STATUS_FAILURE: Failure
    [1] => NET_SFTP_STATUS_PERMISSION_DENIED: Permission denied
    [2] => NET_SFTP_STATUS_PERMISSION_DENIED: Permission denied
    [3] => NET_SFTP_STATUS_FAILURE: Failure
    [4] => NET_SFTP_STATUS_FAILURE: Failure
)
```
So for this specific scenario, phpseclib v4's output is _significantly_ more useful. Like phpseclib v3's output omits any context what-so-ever.

As an added bonus to all of this, consider this bit of code wherein you're logging into an SFTP server with a bad password:

```php
$sftp = new SFTP('...');
$sftp->login('username', 'badpassword');
foreach ($files as $file) {
    $sftp->put(basename($file), $file, SFTP::SOURCE_LOCAL_FILE);
}
```
In phpseclib v3 each `$sftp->put()` command would silently fail and you'd be none the wiser to the fact that none of the files actually uploaded. Sure, you could check to see if `$sftp->put()` was returning true or false, but, then again, you could have also checked to see if `$sftp->login()` returned true or false and thrown an Exception on failure. Like maybe you were just writing something quick and dirty and were confident it'd work and just didn't think to check the return value because you didn't think you needed to. In phpseclib v3 that can leave you puzzling over what happened. In phpseclib v4 there's going to be no doubt as to what happened. An exception will be thrown and you're not going to miss it.

Another change of note is that the parameters for `chmod` have been switched up. In v3 it's `chmod($mode, $filename, $recursive = false)`. In v4 it's `chmod($filename, $mode, $recursive = false)`. `$filename` precedes `$mode` in both `chown` and `chgrp` so making it the same for `chmod` only makes since. This change also makes v4's `chmod` consistent with [PHP's chmod](https://www.php.net/chmod). Presumably v1 - v3's behavior was inspired by [PHP's ftp_chmod](https://www.php.net/ftp-chmod), wherein `$filename` _follows_ `$mode`, however, because PHP's ftp extension does not offer any chown or chgrp functions, I guess I wouldn't have had the ftp extension to rely on for precedent.

This work has been commissioned by the Sovereign Tech Fund:

<a target="_blank" href="https://www.sovereign.tech/tech/phpseclib">
        <img src="https://phpseclib.com/img/sponsors/sovereign-tech-agency.webp" alt="Sovereign Tech Agency" width="200">
</a>