### PR TITLE
Feature: SFTP Hardlink

### DIFF
--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3825,9 +3825,12 @@ class SFTP extends SSH2
             return false;
         }
 
-        // don't move the stat cache entry over since this operation could very well change the
-        // atime and mtime attributes
+        // this operation will change the ctime and link-count attributes
+        // which could be cached depending on sftp version
         $this->remove_from_stat_cache($oldpath);
+
+        // hardlink creation should fail if $newpath exists;
+        // removing it from the cache anyway, just to be sure
         $this->remove_from_stat_cache($newpath);
 
         return true;

--- a/phpseclib/Net/SFTP.php
+++ b/phpseclib/Net/SFTP.php
@@ -3789,4 +3789,47 @@ class SFTP extends SSH2
             Strings::unpackSSH2('QQQQQQQQQQQ', $response)
         );
     }
+
+    public function hardlink($oldpath, $newpath)
+    {
+        if (!$this->precheck()) {
+            return false;
+        }
+
+        if (!isset($this->extensions['hardlink@openssh.com']) || $this->extensions['hardlink@openssh.com'] !== '1') {
+            throw new \RuntimeException(
+                "Extension 'hardlink@openssh.com' is not supported by the server. " .
+                "Call getSupportedVersions() to see a list of supported extension"
+            );
+        }
+
+        $oldpath = $this->realpath($oldpath);
+        $newpath = $this->realpath($newpath);
+        if ($oldpath === false || $newpath === false) {
+            return false;
+        }
+
+        $packet = Strings::packSSH2('sss', 'hardlink@openssh.com', $oldpath, $newpath);
+        $this->send_sftp_packet(NET_SFTP_EXTENDED, $packet);
+
+        $response = $this->get_sftp_packet();
+        if ($this->packet_type !== NET_SFTP_STATUS) {
+            throw new \UnexpectedValueException('Expected NET_SFTP_STATUS. '
+                . 'Got packet type: ' . $this->packet_type);
+        }
+
+        // if $status isn't SSH_FX_OK it's probably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
+        list($status) = Strings::unpackSSH2('N', $response);
+        if ($status !== NET_SFTP_STATUS_OK) {
+            $this->logError($response, $status);
+            return false;
+        }
+
+        // don't move the stat cache entry over since this operation could very well change the
+        // atime and mtime attributes
+        $this->remove_from_stat_cache($oldpath);
+        $this->remove_from_stat_cache($newpath);
+
+        return true;
+    }
 }

--- a/tests/Functional/Net/SFTPUserStoryTest.php
+++ b/tests/Functional/Net/SFTPUserStoryTest.php
@@ -790,4 +790,25 @@ class SFTPUserStoryTest extends PhpseclibFunctionalTestCase
         $sftp->posix_rename('test1.txt', 'test2.txt');
         $this->assertSame('aaaaa', $sftp->get('test2.txt'));
     }
+
+    /** @depends testSymlink */
+    public function testHardlink($sftp)
+    {
+        $sftp->put('test3.txt', 'abcdefg');
+
+        $this->assertTrue(
+            $sftp->hardlink('test3.txt', 'hardlink'),
+            'Failed asserting that a hardlink could be created'
+        );
+        $this->assertSame(
+            'abcdefg',
+            $sftp->get('hardlink'),
+            'Failed asserting that a hardlink is the same as the original file'
+        );
+        $this->assertSame(
+            $sftp->stat('test3.txt'),
+            $sftp->stat('hardlink'),
+            'Failed asserting that hardlink stat is the same as original file stat'
+        );
+    }
 }


### PR DESCRIPTION
I would like to add this method to enable creating hardlinks via SFTP.

My use case is a remote storage server where I found it is possible to create hardlinks via SFTP extensions command, while ```ln``` command is missing and ```cp -l``` fails for non-admin accounts.

In the past I had a similar task in a Node backend and used [ext_openssh_hardlink](https://github.com/mscdex/ssh2/blob/318d447ce3aca26e1ac73b63767b82a29b02467b/lib/protocol/SFTP.js#L1426) from the [ssh2](https://www.npmjs.com/package/ssh2) node.js library, which is why I knew it is possible.
