### PR TITLE
chore: define default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lafourchette/thefork-gg-business-and-operations

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpseclib/phpseclib",
+    "name": "lafourchette/phpseclib",
     "type": "library",
     "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
     "keywords": [


### PR DESCRIPTION
Define a default owner (line starting with `*` in `CODEOWNERS`).