### PR TITLE
Don't delegate PSS signing to openssl_sign()

### DIFF
--- a/phpseclib/Crypt/RSA.php
+++ b/phpseclib/Crypt/RSA.php
@@ -974,6 +974,13 @@ abstract class RSA extends AsymmetricKey
                         break;
                     case $this->getSaltLength() !== $this->hLen:
                         $error = 'Engine OpenSSL is forced but can\'t be used because the salt length doesn\'t match the hash length';
+                        break;
+                    case 'openssl_sign' && $this->getLength() < 8 * (2 * $this->getSaltLength() + 2):
+                        $error = 'Engine OpenSSL is forced but can\'t be used for PSS signing because the key is too small for OpenSSL to use the configured salt length';
+                        break;
+                    case 'openssl_sign' && OPENSSL_VERSION_NUMBER < 0x30100000:
+                        $error = 'Engine OpenSSL is forced but can\'t be used for PSS signing because OpenSSL < 3.1.0 defaults to the maximum salt length instead of the hash length';
+                        break;
                 }
             }
             /*

--- a/tests/Unit/Crypt/RSA/ModeTest.php
+++ b/tests/Unit/Crypt/RSA/ModeTest.php
@@ -145,6 +145,68 @@ p0GbMJDyR4e9T04ZZwIDAQAB
         RSA::forceEngine();
     }
 
+    public function testPSSSignAndVerifyAcrossEngines()
+    {
+        $privatekey = RSA::createKey(1024)
+            ->withHash('sha256')
+            ->withMGFHash('sha256')
+            ->withPadding(RSA::SIGNATURE_PSS);
+        $publickey = $privatekey->getPublicKey();
+
+        $message = 'zzzz';
+        $signature = $privatekey->sign($message);
+
+        RSA::forceEngine('PHP');
+        try {
+            $this->assertTrue($publickey->verify($message, $signature));
+        } finally {
+            RSA::forceEngine();
+        }
+    }
+
+    public function testPSSSignWithForcedOpenSSLEngineFailsOnSmallKey()
+    {
+        if (!defined('OPENSSL_PKCS1_PSS_PADDING')) {
+            $this->markTestSkipped('OPENSSL_PKCS1_PSS_PADDING is not defined (requires PHP >= 8.5)');
+        }
+
+        $privatekey = RSA::createKey(512)
+            ->withHash('sha256')
+            ->withMGFHash('sha256')
+            ->withPadding(RSA::SIGNATURE_PSS);
+
+        RSA::forceEngine('OpenSSL');
+        try {
+            $this->expectException(BadConfigurationException::class);
+            $privatekey->sign('zzzz');
+        } finally {
+            RSA::forceEngine();
+        }
+    }
+
+    public function testPSSSignWithForcedOpenSSLEngineFailsOnOldOpenSSL()
+    {
+        if (!defined('OPENSSL_PKCS1_PSS_PADDING')) {
+            $this->markTestSkipped('OPENSSL_PKCS1_PSS_PADDING is not defined (requires PHP >= 8.5)');
+        }
+        if (OPENSSL_VERSION_NUMBER >= 0x30100000) {
+            $this->markTestSkipped('OpenSSL >= 3.1.0 defaults to a spec-compliant PSS salt length for this key size');
+        }
+
+        $privatekey = RSA::createKey(1024)
+            ->withHash('sha256')
+            ->withMGFHash('sha256')
+            ->withPadding(RSA::SIGNATURE_PSS);
+
+        RSA::forceEngine('OpenSSL');
+        try {
+            $this->expectException(BadConfigurationException::class);
+            $privatekey->sign('zzzz');
+        } finally {
+            RSA::forceEngine();
+        }
+    }
+
     public function testSmallModulo()
     {
         $this->expectException('LengthException');


### PR DESCRIPTION
Fixes #2152.

## Changes

* `phpseclib/Crypt/RSA.php`: in `handleOpenSSL()`, reject delegating PSS signing to `openssl_sign()` in two cases:
   * the installed OpenSSL is older than 3.1.0.
   * the key is too small to fit the configured salt length.