### PR TITLE
ASN1: fix tag matching for tagged CHOICE children

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -540,7 +540,7 @@ abstract class ASN1
             case $mapping['type'] == self::TYPE_CHOICE:
                 foreach ($mapping['children'] as $key => $option) {
                     switch (true) {
-                        case isset($option['constant']) && $option['constant'] == $decoded['constant']:
+                        case isset($option['constant']) && isset($decoded['constant']) && $option['constant'] == $decoded['constant']:
                         case !isset($option['constant']) && $option['type'] == $decoded['type']:
                             $value = self::asn1map($decoded, $option, $special);
                             break;
@@ -624,6 +624,13 @@ abstract class ASN1
                                 // Can only match if no constant expected and type matches or is generic.
                                 $maymatch = !isset($child['constant']) && array_search($child['type'], [$temp['type'], self::TYPE_ANY, self::TYPE_CHOICE]) !== false;
                             }
+                        } elseif (isset($child['constant'])) {
+                            // a CHOICE that is itself tagged is identified by that tag. its alternatives
+                            // can't be used to tell it apart from a sibling with the same CHOICE definition
+                            // (eg. issuerLogo [1] / subjectLogo [2] in RFC 9399's LogotypeExtn).
+                            $maymatch = isset($temp['constant']) &&
+                                $child['constant'] == $temp['constant'] &&
+                                $temp['type'] == self::CLASS_CONTEXT_SPECIFIC;
                         }
                     }
 
@@ -696,6 +703,11 @@ abstract class ASN1
                                 // Can only match if no constant expected and type matches or is generic.
                                 $maymatch = !isset($child['constant']) && array_search($child['type'], [$temp['type'], self::TYPE_ANY, self::TYPE_CHOICE]) !== false;
                             }
+                        } elseif (isset($child['constant'])) {
+                            // see the comment in the TYPE_SEQUENCE case
+                            $maymatch = isset($temp['constant']) &&
+                                $child['constant'] == $temp['constant'] &&
+                                $tempClass == self::CLASS_CONTEXT_SPECIFIC;
                         }
 
                         if ($maymatch) {

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -498,4 +498,93 @@ class ASN1Test extends PhpseclibTestCase
         $key = ASN1::asn1map($decoded[0], \phpseclib3\File\ASN1\Maps\DSAPublicKey::MAP);
         $this->assertFalse($key);
     }
+
+    /**
+     * a CHOICE that is itself tagged is identified by its own context tag - not by
+     * its alternatives. sibling children whose CHOICE definitions are identical
+     * (eg. issuerLogo [1] / subjectLogo [2] in RFC 9399's LogotypeExtn) can only be
+     * told apart that way. previously the tag was ignored and the first child won.
+     */
+    public function testTaggedChoiceUsesItsOwnTag()
+    {
+        $inner = [
+            'type' => ASN1::TYPE_CHOICE,
+            'children' => [
+                'alpha' => [
+                    'constant' => 0,
+                    'optional' => true,
+                    'implicit' => true,
+                    'type' => ASN1::TYPE_SEQUENCE,
+                    'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                ],
+                'beta' => [
+                    'constant' => 1,
+                    'optional' => true,
+                    'implicit' => true,
+                    'type' => ASN1::TYPE_SEQUENCE,
+                    'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                ],
+            ],
+        ];
+        $map = [
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => [
+                'first' => ['constant' => 1, 'optional' => true, 'explicit' => true] + $inner,
+                'second' => ['constant' => 2, 'optional' => true, 'explicit' => true] + $inner,
+            ],
+        ];
+
+        // SEQUENCE { [2] EXPLICIT { [0] IMPLICIT SEQUENCE { INTEGER 5 } } }
+        $decoded = ASN1::decodeBER("\x30\x07\xa2\x05\xa0\x03\x02\x01\x05");
+        $result = ASN1::asn1map($decoded[0], $map);
+
+        $this->assertSame(['second'], array_keys($result));
+        $this->assertSame(['alpha'], array_keys($result['second']));
+        $this->assertSame('5', (string) $result['second']['alpha']['n']);
+
+        // ...and the [1] sibling still resolves to itself
+        $decoded = ASN1::decodeBER("\x30\x07\xa1\x05\xa0\x03\x02\x01\x05");
+        $result = ASN1::asn1map($decoded[0], $map);
+
+        $this->assertSame(['first'], array_keys($result));
+    }
+
+    /**
+     * on older versions of \phpseclib3\File\ASN1 this would yield a PHP Warning, as the
+     * CHOICE alternatives were compared against a context tag that isn't there
+     */
+    public function testTaggedChoiceWithUntaggedAlternative()
+    {
+        $map = [
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => [
+                'only' => [
+                    'constant' => 2,
+                    'optional' => true,
+                    'explicit' => true,
+                    'type' => ASN1::TYPE_CHOICE,
+                    'children' => [
+                        // the tagged alternative comes first on purpose
+                        'tagged' => [
+                            'constant' => 1,
+                            'optional' => true,
+                            'implicit' => true,
+                            'type' => ASN1::TYPE_SEQUENCE,
+                            'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                        ],
+                        'untagged' => [
+                            'type' => ASN1::TYPE_SEQUENCE,
+                            'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // SEQUENCE { [2] EXPLICIT { SEQUENCE { INTEGER 5 } } }
+        $decoded = ASN1::decodeBER("\x30\x07\xa2\x05\x30\x03\x02\x01\x05");
+        $result = ASN1::asn1map($decoded[0], $map);
+
+        $this->assertSame(['untagged'], array_keys($result['only']));
+    }
 }


### PR DESCRIPTION
`asn1map()` skips the context tag check for any `SEQUENCE` / `SET` child whose own type is `TYPE_CHOICE`:

```php
if ($child['type'] != self::TYPE_CHOICE) {
    // ... constant / class checks ...
}
```

That is right for an *untagged* CHOICE child, where the alternatives carry the tags. It is wrong for `[n] EXPLICIT SomeChoice`, because there the child's own tag is the only thing that distinguishes it from its siblings. Where two siblings share the same CHOICE definition, the first one declared always wins — silently, since the submapping succeeds.

### Minimal reproduction

```php
$inner = [
    'type' => ASN1::TYPE_CHOICE,
    'children' => [
        'alpha' => ['constant' => 0, 'optional' => true, 'implicit' => true,
                    'type' => ASN1::TYPE_SEQUENCE, 'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]]],
    ],
];
$map = [
    'type' => ASN1::TYPE_SEQUENCE,
    'children' => [
        'first'  => ['constant' => 1, 'optional' => true, 'explicit' => true] + $inner,
        'second' => ['constant' => 2, 'optional' => true, 'explicit' => true] + $inner,
    ],
];

// SEQUENCE { [2] EXPLICIT { [0] IMPLICIT SEQUENCE { INTEGER 5 } } }
$decoded = ASN1::decodeBER("\x30\x07\xa2\x05\xa0\x03\x02\x01\x05");
var_dump(array_keys(ASN1::asn1map($decoded[0], $map)));
```

Before: `['first']`. After: `['second']`.

### Why it matters in practice

RFC 9399 (formerly RFC 3709) defines the logotype extension as four siblings that are all `EXPLICIT LogotypeInfo`:

```
LogotypeExtn ::= SEQUENCE {
    communityLogos  [0] EXPLICIT SEQUENCE OF LogotypeInfo OPTIONAL,
    issuerLogo      [1] EXPLICIT LogotypeInfo OPTIONAL,
    subjectLogo     [2] EXPLICIT LogotypeInfo OPTIONAL,
    otherLogos      [3] EXPLICIT SEQUENCE OF OtherLogotypeInfo OPTIONAL }
```

`issuerLogo` and `subjectLogo` are structurally identical, so only the tag tells them apart. I registered a mapping for `id-pe-logotype` via `X509::registerExtension()` and loaded six real-world BIMI Verified Mark Certificates (Entrust and DigiCert issued). All six carry their logo in `subjectLogo` `[2]` — confirmed with `openssl asn1parse` — and all six were reported as `issuerLogo`, with no error. For BIMI that inverts the meaning of the certificate, since the spec requires the mark in `subjectLogo`.

The same omission also let the CHOICE branch compare an option's `constant` against `$decoded['constant']` when the decoded value carries no context tag at all, raising `Undefined array key "constant"` on PHP 8.

### Changes

- `phpseclib/File/ASN1.php`: check the child's own context tag when a tagged child is a CHOICE, in both the `TYPE_SEQUENCE` and `TYPE_SET` child loops; guard the `$decoded['constant']` lookup in the CHOICE branch.
- `tests/Unit/File/ASN1Test.php`: two regression tests — sibling disambiguation in both directions, and the untagged-alternative case that used to warn.

### Testing

Full 3.0 suite on PHP 8.5: 3651 tests, no failures, deprecation counts unchanged versus the unpatched branch. Without the fix, exactly the two new tests fail. `phpcs --standard=build/php_codesniffer.xml` is clean on both changed files.

### Note on 4.0 / master

The rewritten engine has the same omission at `Constructed::setSeqInnerLoop()` and `ASN1::mapChoice()`, so this change won't carry over by merging. I have the equivalent fix and can open a separate PR for it if you'd like — the full master suite (3224 tests) passes with it.
