### PR TITLE
4.0: ASN1: fix tag matching for tagged CHOICE children

### DIFF
--- a/phpseclib/File/ASN1.php
+++ b/phpseclib/File/ASN1.php
@@ -548,7 +548,7 @@ abstract class ASN1
     {
         foreach ($mapping['children'] as $key => $option) {
             switch (true) {
-                case isset($option['constant']) && $option['constant'] == $decoded['constant']:
+                case isset($option['constant']) && isset($decoded['constant']) && $option['constant'] == $decoded['constant']:
                 case !isset($option['constant']) && $option['type'] == $decoded['type']:
                     return new Choice($key, self::map($decoded, $option, $rules[$key] ?? []));
             }

--- a/phpseclib/File/ASN1/Constructed.php
+++ b/phpseclib/File/ASN1/Constructed.php
@@ -522,6 +522,13 @@ class Constructed implements \ArrayAccess, \Countable, \Iterator, BaseType
                 // Can only match if no constant expected and type matches or is generic.
                 $maymatch = !isset($child['constant']) && array_search($child['type'], [$temp['type'], ASN1::TYPE_ANY, ASN1::TYPE_CHOICE]) !== false;
             }
+        } elseif (isset($child['constant'])) {
+            // a CHOICE that is itself tagged is identified by that tag. its alternatives
+            // can't be used to tell it apart from a sibling with the same CHOICE definition
+            // (eg. issuerLogo [1] / subjectLogo [2] in RFC 9399's LogotypeExtn).
+            $maymatch = isset($temp['constant']) &&
+                $child['constant'] == $temp['constant'] &&
+                $tempClass == ASN1::CLASS_CONTEXT_SPECIFIC;
         }
 
         if ($maymatch) {

--- a/tests/Unit/File/ASN1Test.php
+++ b/tests/Unit/File/ASN1Test.php
@@ -533,4 +533,90 @@ cKVMm1WnOQd4aQgCvzv2r7/gsdX++496vRpBMTfwa1qLBjG6
         $arr2 = ['cRLSign', 'keyCertSign'];
         $this->assertSame($arr, $arr2);
     }
+
+    /**
+     * a CHOICE that is itself tagged is identified by its own context tag - not by
+     * its alternatives. sibling children whose CHOICE definitions are identical
+     * (eg. issuerLogo [1] / subjectLogo [2] in RFC 9399's LogotypeExtn) can only be
+     * told apart that way. previously the tag was ignored and the first child won.
+     */
+    public function testTaggedChoiceUsesItsOwnTag(): void
+    {
+        $inner = [
+            'type' => ASN1::TYPE_CHOICE,
+            'children' => [
+                'alpha' => [
+                    'constant' => 0,
+                    'optional' => true,
+                    'implicit' => true,
+                    'type' => ASN1::TYPE_SEQUENCE,
+                    'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                ],
+                'beta' => [
+                    'constant' => 1,
+                    'optional' => true,
+                    'implicit' => true,
+                    'type' => ASN1::TYPE_SEQUENCE,
+                    'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                ],
+            ],
+        ];
+        $map = [
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => [
+                'first' => ['constant' => 1, 'optional' => true, 'explicit' => true] + $inner,
+                'second' => ['constant' => 2, 'optional' => true, 'explicit' => true] + $inner,
+            ],
+        ];
+
+        // SEQUENCE { [2] EXPLICIT { [0] IMPLICIT SEQUENCE { INTEGER 5 } } }
+        $result = ASN1::map(ASN1::decodeBER("\x30\x07\xa2\x05\xa0\x03\x02\x01\x05"), $map);
+
+        $this->assertSame(['second'], $result->keys());
+        $this->assertSame('alpha', $result['second']->index);
+        $this->assertSame('5', (string) $result['second']['alpha']['n']);
+
+        // ...and the [1] sibling still resolves to itself
+        $result = ASN1::map(ASN1::decodeBER("\x30\x07\xa1\x05\xa0\x03\x02\x01\x05"), $map);
+
+        $this->assertSame(['first'], $result->keys());
+    }
+
+    /**
+     * this would previously yield a PHP Warning, as the CHOICE alternatives were
+     * compared against a context tag that isn't there
+     */
+    public function testTaggedChoiceWithUntaggedAlternative(): void
+    {
+        $map = [
+            'type' => ASN1::TYPE_SEQUENCE,
+            'children' => [
+                'only' => [
+                    'constant' => 2,
+                    'optional' => true,
+                    'explicit' => true,
+                    'type' => ASN1::TYPE_CHOICE,
+                    'children' => [
+                        // the tagged alternative comes first on purpose
+                        'tagged' => [
+                            'constant' => 1,
+                            'optional' => true,
+                            'implicit' => true,
+                            'type' => ASN1::TYPE_SEQUENCE,
+                            'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                        ],
+                        'untagged' => [
+                            'type' => ASN1::TYPE_SEQUENCE,
+                            'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // SEQUENCE { [2] EXPLICIT { SEQUENCE { INTEGER 5 } } }
+        $result = ASN1::map(ASN1::decodeBER("\x30\x07\xa2\x05\x30\x03\x02\x01\x05"), $map);
+
+        $this->assertSame('untagged', $result['only']->index);
+    }
 }


### PR DESCRIPTION
The 4.0 counterpart to #2158. The rewritten engine has the same omission, so the 3.0 fix won't carry over by merging — the code it touches no longer exists here.

### The bug

`Constructed::setSeqInnerLoop()` decides whether a `SEQUENCE` / `SET` child matches the element in hand, but skips that check for any child whose own type is `TYPE_CHOICE`:

```php
$maymatch = true;
if ($child['type'] != ASN1::TYPE_CHOICE) {
    // ... constant / class checks ...
}
```

That is right for an *untagged* CHOICE child, where the alternatives carry the tags. It is wrong for `[n] EXPLICIT SomeChoice`, because there the child's own tag is the only thing that distinguishes it from its siblings. Where two siblings share the same CHOICE definition, the first one declared always wins — silently, since the submapping succeeds.

### Minimal reproduction

```php
$inner = [
    'type' => ASN1::TYPE_CHOICE,
    'children' => [
        'alpha' => ['constant' => 0, 'optional' => true, 'implicit' => true,
                    'type' => ASN1::TYPE_SEQUENCE, 'children' => ['n' => ['type' => ASN1::TYPE_INTEGER]]],
    ],
];
$map = [
    'type' => ASN1::TYPE_SEQUENCE,
    'children' => [
        'first'  => ['constant' => 1, 'optional' => true, 'explicit' => true] + $inner,
        'second' => ['constant' => 2, 'optional' => true, 'explicit' => true] + $inner,
    ],
];

// SEQUENCE { [2] EXPLICIT { [0] IMPLICIT SEQUENCE { INTEGER 5 } } }
var_dump(ASN1::map(ASN1::decodeBER("\x30\x07\xa2\x05\xa0\x03\x02\x01\x05"), $map)->keys());
```

Before: `['first']`. After: `['second']`.

### Why it matters in practice

RFC 9399 (formerly RFC 3709) defines the logotype extension as four siblings that are all `EXPLICIT LogotypeInfo`:

```
LogotypeExtn ::= SEQUENCE {
    communityLogos  [0] EXPLICIT SEQUENCE OF LogotypeInfo OPTIONAL,
    issuerLogo      [1] EXPLICIT LogotypeInfo OPTIONAL,
    subjectLogo     [2] EXPLICIT LogotypeInfo OPTIONAL,
    otherLogos      [3] EXPLICIT SEQUENCE OF OtherLogotypeInfo OPTIONAL }
```

`issuerLogo` and `subjectLogo` are structurally identical, so only the tag tells them apart. Registering a mapping for `id-pe-logotype` and loading real-world BIMI Verified Mark Certificates (Entrust and DigiCert issued) reports every one of them as `issuerLogo`, with no error, when `openssl asn1parse` shows the logo in `subjectLogo` `[2]`. For BIMI that inverts the meaning of the certificate, since the spec requires the mark in `subjectLogo`.

The same omission also let `ASN1::mapChoice()` compare an option's `constant` against `$decoded['constant']` when the decoded value carries no context tag at all, raising `Undefined array key "constant"` on PHP 8.

### Changes

- `phpseclib/File/ASN1/Constructed.php`: in `setSeqInnerLoop()`, match a tagged CHOICE child on its own context tag.
- `phpseclib/File/ASN1.php`: guard the `$decoded['constant']` lookup in `mapChoice()`.
- `tests/Unit/File/ASN1Test.php`: two regression tests — sibling disambiguation in both directions, and the untagged-alternative case that used to warn.

### Testing

Full `tests/Unit` suite on PHP 8.5: 3093 tests, 3834 assertions, no failures. Without the source change, `testTaggedChoiceUsesItsOwnTag` fails (`first` instead of `second`) and `testTaggedChoiceWithUntaggedAlternative` warns. `phpcs --standard=build/php_codesniffer.xml` is clean on all three changed files.
