### PR TITLE
BigInteger PHP engine: don't return the divisor as the common residue

### DIFF
--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -499,7 +499,11 @@ abstract class PHP extends Engine
             $quotient = new static();
             $remainder = new static();
             $quotient->value = $q;
-            if ($this->is_negative) {
+            // The common residue is the first positive modulo, so it is only the
+            // negative remainders that need the divisor added. A remainder of 0 is
+            // already the residue; adding the divisor would return the modulus
+            // itself, which is never a valid residue.
+            if ($this->is_negative && $r) {
                 $r = $y->value[0] - $r;
             }
             $remainder->value = [$r];
@@ -633,8 +637,9 @@ abstract class PHP extends Engine
 
         $quotient->is_negative = $x_sign != $y_sign;
 
-        // calculate the "common residue", if appropriate
-        if ($x_sign) {
+        // calculate the "common residue", if appropriate. A remainder of 0 is
+        // already the residue -- see divideHelper's single-digit branch.
+        if ($x_sign && count($x->value)) {
             $y->rshift($shift);
             $x = $y->subtract($x);
         }

--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -158,7 +158,7 @@ abstract class PHP extends Engine
         while (count($temp->value)) {
             [$temp, $mod] = $temp->divide($divisor);
             $result = str_pad(
-                (string) $mod->value[0] ?? '',
+                (string) ($mod->value[0] ?? ''),
                 static::MAX10LEN,
                 '0',
                 STR_PAD_LEFT

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -124,6 +124,27 @@ abstract class TestCase extends PhpseclibTestCase
         $this->assertSame('1', (string) $r);
     }
 
+    public function testDivideNegativeExact(): void
+    {
+        // The second element of divide() is the "common residue" -- the first
+        // positive modulo -- so only a negative remainder gets the divisor added.
+        // When the division is exact the remainder is already 0, and adding the
+        // divisor returned the modulus itself, which is never a valid residue.
+        // The GMP and BCMath engines returned 0 here; the PHP engines did not.
+        foreach ([['-256', '256'], ['-7', '7'], ['-256', '2'], ['-7', '1']] as [$a, $b]) {
+            [$q, $r] = $this->getInstance($a)->divide($this->getInstance($b));
+            $this->assertSame('0', (string) $r, "$a / $b should leave no remainder");
+            $this->assertNotSame($b, (string) $r, "$a / $b returned the divisor as the residue");
+        }
+
+        // Same again with a divisor too large for the single-digit branch of
+        // divideHelper(), so the general long-division path is covered too.
+        [$q, $r] = $this->getInstance('-340282366920938463463374607431768211456')
+            ->divide($this->getInstance('18446744073709551616'));
+        $this->assertSame('-18446744073709551616', (string) $q);
+        $this->assertSame('0', (string) $r);
+    }
+
     public function testModPow(): void
     {
         $a = $this->getInstance('10');

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -132,7 +132,7 @@ abstract class TestCase extends PhpseclibTestCase
         // divisor returned the modulus itself, which is never a valid residue.
         // The GMP and BCMath engines returned 0 here; the PHP engines did not.
         foreach ([['-256', '256'], ['-7', '7'], ['-256', '2'], ['-7', '1']] as [$a, $b]) {
-            [$q, $r] = $this->getInstance($a)->divide($this->getInstance($b));
+            [, $r] = $this->getInstance($a)->divide($this->getInstance($b));
             $this->assertSame('0', (string) $r, "$a / $b should leave no remainder");
             $this->assertNotSame($b, (string) $r, "$a / $b returned the divisor as the residue");
         }


### PR DESCRIPTION
Two fixes to the `PHP` BigInteger engine, one commit each.

I judged neither of these to be a vulnerability, so they are here rather than at the Tidelift contact: both are wrong-result/notice bugs in a public math API, neither is reachable with attacker-controlled input in the protocol code as far as I can see, and the engines used in almost every production install (GMP, BCMath) are unaffected by the first and not affected at all by the second. Happy to move the discussion if you read it differently.

### 1. `divide()` hands back the divisor as the common residue

```php
BigInteger::setEngine('PHP64');
[$q, $r] = (new BigInteger('-256'))->divide(new BigInteger('256'));
// $q = -1, $r = 256      expected 0
```

The docblock defines the second element as the common residue — the first positive modulo — so it is only a *negative* remainder that has the divisor added. When the division is exact the remainder is already `0`, and adding the divisor returns the modulus itself, which is never a valid residue.

GMP and BCMath return `0`, so the same call gives a different answer depending on which extension happens to be installed, and the `PHP` engines are the fallback when neither is.

Both branches of `divideHelper()` are affected:

* the single-digit divisor path, `$r = $y->value[0] - $r`
* the long-division path, `if ($x_sign) { $y->rshift($shift); $x = $y->subtract($x); }`

The equal-magnitude case returns early with a zero remainder, which is probably why exact division has looked correct. `testDivide()` covers exact division only with a positive dividend, so it passes either way.

I checked a cross-engine sweep of 1278 operations over `add`, `subtract`, `multiply` and `divide`: 32 results differed between BCMath and the two PHP engines before this change and none after, and BCMath matched the documented rule in all 32.

**This applies to 3.0 as well.** Both code paths are identical there (`PHP.php` lines 536-538 and 670-674 on the 3.0 branch); I have only prepared the master patch, so say the word if you would like the backport.

### 2. `toString()` raises "Undefined array key 0"

```php
(string) $mod->value[0] ?? ''
```

The cast binds tighter than `??`, so this is `((string) $mod->value[0]) ?? ''`: the array access is evaluated first, and a cast cannot produce `null`, so the coalesce is unreachable. Every intermediate modulus of `0` therefore raises a warning. 3.0 has this as `isset($mod->value[0]) ? $mod->value[0] : ''` and does not warn, so it looks like it came in with the `??` modernisation.

The returned string is correct either way. It matters because an error handler that promotes warnings — Symfony, Laravel, PHPUnit in strict mode — turns a plain string cast into a thrown `ErrorException`:

```php
BigInteger::setEngine('PHP32');
(string) new BigInteger('10000000');   // ErrorException: Undefined array key 0
```

Reproduces on `PHP32` for values divisible by `10^7` and on `PHP64` for `10^13`.

### Tests

The new case lives in the shared `TestCase`, so every engine is held to it. Reverting either `divideHelper()` branch fails it for `PHP32` and `PHP64` and leaves BCMath passing, which is the intended asymmetry — BCMath was never wrong here.

`BCMathTest`, `BCMath64Test`, `PHP64Test` and `PHP32Test` are green at 48 tests / 117 assertions.

One thing I could not check: the GMP engine. The static PHP builds available to me abort with SIGILL inside libgmp on this machine, so GMP's behaviour here is inferred from BCMath agreeing with the documented rule rather than measured. Worth a second pair of eyes on `GMPTest` before merging.
