### PR TITLE
X509: name the BIMI mark attributes

### DIFF
--- a/phpseclib/File/ASN1/OIDs/X509.php
+++ b/phpseclib/File/ASN1/OIDs/X509.php
@@ -64,6 +64,26 @@ abstract class X509
         'jurisdictionOfIncorporationCountryName' => '1.3.6.1.4.1.311.60.2.1.3',
         'jurisdictionOfIncorporationStateOrProvinceName' => '1.3.6.1.4.1.311.60.2.1.2',
         'jurisdictionLocalityName' => '1.3.6.1.4.1.311.60.2.1.1',
+        // Mark Certificate attributes, from the BIMI Group's Verified Mark Certificate
+        // Requirements. the trademark attributes below succeed 1.3.6.1.4.1.311.60.2.1.4
+        // through .7 of the arc above.
+        // https://bimigroup.org/resources/VMC_Requirements_v1_4.pdf
+        'trademarkOfficeName' => '1.3.6.1.4.1.53087.1.2',
+        'trademarkCountryOrRegionName' => '1.3.6.1.4.1.53087.1.3',
+        'trademarkRegistration' => '1.3.6.1.4.1.53087.1.4',
+        'legalEntityIdentifier' => '1.3.6.1.4.1.53087.1.5',
+        'wordMark' => '1.3.6.1.4.1.53087.1.6',
+        'markType' => '1.3.6.1.4.1.53087.1.13',
+        // used in place of the trademark attributes when the mark is established by
+        // statute rather than by registration
+        'statuteCountryName' => '1.3.6.1.4.1.53087.3.2',
+        'statuteStateOrProvinceName' => '1.3.6.1.4.1.53087.3.3',
+        'statuteLocalityName' => '1.3.6.1.4.1.53087.3.4',
+        'statuteCitation' => '1.3.6.1.4.1.53087.3.5',
+        'statuteURL' => '1.3.6.1.4.1.53087.3.6',
+        // not a DN attribute but a certificate policy, asserted by every VMC in
+        // certificatePolicies alongside the issuing CA's own policy
+        'certificateGeneralPolicyIdentifier' => '1.3.6.1.4.1.53087.1.1',
         'id-at-businessCategory' => '2.5.4.15',
         'id-domainComponent' => '0.9.2342.19200300.100.1.25',
         // from RFC3039

--- a/phpseclib/File/Common/Traits/Extension.php
+++ b/phpseclib/File/Common/Traits/Extension.php
@@ -332,6 +332,8 @@ trait Extension
             'id-ce-policyMappings' => false,
             'id-ce-issuerAltName' => false,
             'id-ce-subjectDirectoryAttributes' => false,
+            // "This extension MUST NOT be marked critical" - RFC 9399, section 4.1
+            'id-pe-logotype' => false,
             'id-ce-cRLDistributionPoints' => false,
             'id-ce-freshestCRL' => false,
             'id-pe-authorityInfoAccess' => false,

--- a/tests/Unit/File/X509/LogotypeTest.php
+++ b/tests/Unit/File/X509/LogotypeTest.php
@@ -43,7 +43,11 @@ class LogotypeTest extends PhpseclibTestCase
 
     /**
      * the extension is wired up in the Extension trait, so it has to survive a
-     * trip through an actual certificate - not just through the map
+     * trip through an actual certificate - not just through the map.
+     *
+     * the criticality argument is deliberately omitted so that the default from
+     * getExtensionCriticalValue() is what gets exercised - RFC 9399, section 4.1
+     * says the extension MUST NOT be marked critical
      */
     public function testExtensionInCertificate(): void
     {
@@ -54,19 +58,21 @@ class LogotypeTest extends PhpseclibTestCase
         $cert->makeCA();
         $cert->setExtension(
             'id-pe-logotype',
-            ['subjectLogo' => ['direct' => ['image' => [['imageDetails' => self::DETAILS]]]]],
-            false
+            ['subjectLogo' => ['direct' => ['image' => [['imageDetails' => self::DETAILS]]]]]
         );
         $key->sign($cert);
 
         $value = null;
+        $critical = null;
         foreach (X509::load("$cert")['tbsCertificate']['extensions'] as $extension) {
             if ("$extension[extnId]" === 'id-pe-logotype') {
                 $value = $extension['extnValue'];
+                $critical = $extension['critical'];
             }
         }
 
         $this->assertNotNull($value);
+        $this->assertFalse($critical->value);
         $this->assertSame(['subjectLogo'], $value->keys());
         $this->assertSame('direct', $value['subjectLogo']->index);
         $this->assertSame(

--- a/tests/Unit/File/X509/LogotypeTest.php
+++ b/tests/Unit/File/X509/LogotypeTest.php
@@ -332,4 +332,62 @@ class LogotypeTest extends PhpseclibTestCase
             );
         }
     }
+
+    /**
+     * the BIMI mark attributes in these certificates' subject DNs, which without
+     * their OIDs registered come out as bare numbers. only the four below appear
+     * in real certificates I could find - wordMark, legalEntityIdentifier and the
+     * statute* attributes are specified but do not seem to be issued anywhere.
+     */
+    public function testMarkAttributesInSubjectDN(): void
+    {
+        $expected = [
+            'vmc-ebay.pem' => [
+                'markType = Registered Mark',
+                'trademarkCountryOrRegionName = US',
+                'trademarkRegistration = 4408423',
+            ],
+            'vmc-badoo.pem' => [
+                'trademarkOfficeName = Intellectual Property Office',
+                'trademarkCountryOrRegionName = GB',
+                'trademarkRegistration = UK00004062752',
+            ],
+        ];
+
+        foreach ($expected as $file => $attributes) {
+            $dn = X509::load(file_get_contents(__DIR__ . '/' . $file))
+                ->getSubjectDN(X509::DN_STRING);
+
+            foreach ($attributes as $attribute) {
+                $this->assertStringContainsString($attribute, $dn, $file);
+            }
+
+            $this->assertStringNotContainsString('1.3.6.1.4.1.53087', $dn, $file);
+        }
+    }
+
+    /**
+     * the VMC policy identifier, which every Verified Mark Certificate asserts
+     * next to the issuing CA's own policy. it is a certificate policy rather
+     * than a DN attribute, hence certificatePolicies instead of the subject DN
+     */
+    public function testPolicyIdentifierInCertificatePolicies(): void
+    {
+        foreach (['vmc-ebay.pem', 'vmc-badoo.pem', 'vmc-rabobank.pem'] as $file) {
+            $cert = X509::load(file_get_contents(__DIR__ . '/' . $file));
+
+            $policies = [];
+            foreach ($cert['tbsCertificate']['extensions'] as $extension) {
+                if ("$extension[extnId]" !== 'id-ce-certificatePolicies') {
+                    continue;
+                }
+
+                foreach ($extension['extnValue'] as $policy) {
+                    $policies[] = "$policy[policyIdentifier]";
+                }
+            }
+
+            $this->assertContains('certificateGeneralPolicyIdentifier', $policies, $file);
+        }
+    }
 }


### PR DESCRIPTION
As offered in #2160, and split into two commits since they come from two different specs.

### The mark attributes

The subject DN of a Verified Mark Certificate carries the trademark registration that backs the logo. Without their OIDs registered those attributes come out as bare numbers — on the `vmc-ebay.pem` fixture already in the suite:

```
before:  1.3.6.1.4.1.53087.1.13 = Registered Mark
         1.3.6.1.4.1.53087.1.3  = US
         1.3.6.1.4.1.53087.1.4  = 4408423

after:   markType                     = Registered Mark
         trademarkCountryOrRegionName = US
         trademarkRegistration        = 4408423
```

Eleven attributes, from the [VMC Requirements v1.4](https://bimigroup.org/resources/VMC_Requirements_v1_4.pdf). Six for registered marks — `trademarkOfficeName`, `trademarkCountryOrRegionName`, `trademarkRegistration`, `legalEntityIdentifier`, `wordMark`, `markType` — and five `statute*` ones that take their place when a mark rests on a statute rather than a registration.

I put them next to the `jurisdiction*` entries on purpose: the first four succeed `1.3.6.1.4.1.311.60.2.1.4` through `.7`, and you already carry `.1` through `.3` of that arc.

I left out the twelfth OID I mentioned, `1.3.6.1.4.1.53087.1.1`. It is a certificate policy identifier rather than a DN attribute, and the spec only ever calls it the "Certificate General Policy Identifier" — no short name. Naming it felt like your call rather than mine, so say the word and I will add it under whatever you prefer.

### Criticality

Just the explicit entry, as you asked. It changes no behaviour, since `getExtensionCriticalValue()` already returns `false` for anything unlisted — it records the intent. What the commit does add is coverage: `testExtensionInCertificate` previously passed `false` explicitly, so the default was never exercised. It now omits the argument and asserts the result, which means the test would catch a future change to that default.

### Testing

Full `tests/Unit` on PHP 8.5: no failures, deprecation and notice counts unchanged. phpcs clean, and psalm clean at `errorLevel="6"` this time — sorry about the annotation you had to add last round.

Removing the OID block turns `testMarkAttributesInSubjectDN` red with the bare numbers in the failure message. Removing the criticality entry changes nothing, as expected — worth saying plainly rather than implying the entry is load-bearing.

### One gap, stated rather than hidden

Only four of the eleven appear in certificates I could actually find: `markType`, `trademarkOfficeName`, `trademarkCountryOrRegionName` and `trademarkRegistration`. Those are the ones under test.

`wordMark` and `legalEntityIdentifier` are optional and nobody seems to fill them in. The five `statute*` attributes I went looking for properly — 44 domains, including government agencies, postal services, public broadcasters, central banks, and the bodies behind statute-protected emblems. Eight had BIMI records; every certificate I could retrieve was a `Registered Mark` with no `statute*` attributes, the IOC included, which uses a USPTO registration rather than the protected Olympic symbol. The only plausible candidate was `studentaid.gov`, whose BIMI record points at a PEM that does not download.

So government marks look specified but not yet issued anywhere reachable. The OIDs are still right to have — I just cannot show them working on real data.
