### PR TITLE
BigInteger PHP engine: don't return the divisor as the common residue (3.0 backport)

### DIFF
--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -533,7 +533,11 @@ abstract class PHP extends Engine
             $quotient = new static();
             $remainder = new static();
             $quotient->value = $q;
-            if ($this->is_negative) {
+            // The common residue is the first positive modulo, so it is only the
+            // negative remainders that need the divisor added. A remainder of 0 is
+            // already the residue; adding the divisor would return the modulus
+            // itself, which is never a valid residue.
+            if ($this->is_negative && $r) {
                 $r = $y->value[0] - $r;
             }
             $remainder->value = [$r];
@@ -667,8 +671,9 @@ abstract class PHP extends Engine
 
         $quotient->is_negative = $x_sign != $y_sign;
 
-        // calculate the "common residue", if appropriate
-        if ($x_sign) {
+        // calculate the "common residue", if appropriate. A remainder of 0 is
+        // already the residue -- see divideHelper's single-digit branch.
+        if ($x_sign && count($x->value)) {
             $y->rshift($shift);
             $x = $y->subtract($x);
         }

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -122,6 +122,28 @@ abstract class TestCase extends PhpseclibTestCase
         $this->assertSame('1', (string) $r);
     }
 
+    public function testDivideNegativeExact()
+    {
+        // The second element of divide() is the "common residue" -- the first
+        // positive modulo -- so only a negative remainder gets the divisor added.
+        // When the division is exact the remainder is already 0, and adding the
+        // divisor returned the modulus itself, which is never a valid residue.
+        // The GMP and BCMath engines returned 0 here; the PHP engines did not.
+        foreach (array(array('-256', '256'), array('-7', '7'), array('-256', '2'), array('-7', '1')) as $pair) {
+            list($a, $b) = $pair;
+            list(, $r) = $this->getInstance($a)->divide($this->getInstance($b));
+            $this->assertSame('0', (string) $r, "$a / $b should leave no remainder");
+            $this->assertNotSame($b, (string) $r, "$a / $b returned the divisor as the residue");
+        }
+
+        // Same again with a divisor too large for the single-digit branch of
+        // divideHelper(), so the general long-division path is covered too.
+        list($q, $r) = $this->getInstance('-340282366920938463463374607431768211456')
+            ->divide($this->getInstance('18446744073709551616'));
+        $this->assertSame('-18446744073709551616', (string) $q);
+        $this->assertSame('0', (string) $r);
+    }
+
     public function testModPow()
     {
         $a = $this->getInstance('10');


### PR DESCRIPTION
Backport of the divide() common-residue fix from #2165 to 3.0, as requested there.

For an exact negative division the remainder is already 0, but divideHelper still
added the divisor to it, returning the modulus itself, which is never a valid
common residue. Both the single-digit and long-division branches did this. Guard
on a non-zero remainder so the PHP engine matches GMP and BCMath.

The toString `??` fix from #2165 is not included here: 3.0 predates that
modernization and uses `isset(...) ? ... : ''`, so it does not have that bug.

Verified against the GMP engine across every sign/size combination (0 disagreements
after the fix, and it reproduces without it). Added testDivideNegativeExact covering
both branches.
