### PR TITLE
BigInteger PHP engine common-residue fix (4.0, merge of #2167)

### DIFF
--- a/phpseclib/Math/BigInteger/Engines/PHP.php
+++ b/phpseclib/Math/BigInteger/Engines/PHP.php
@@ -533,7 +533,11 @@ abstract class PHP extends Engine
             $quotient = new static();
             $remainder = new static();
             $quotient->value = $q;
-            if ($this->is_negative) {
+            // The common residue is the first positive modulo, so it is only the
+            // negative remainders that need the divisor added. A remainder of 0 is
+            // already the residue; adding the divisor would return the modulus
+            // itself, which is never a valid residue.
+            if ($this->is_negative && $r) {
                 $r = $y->value[0] - $r;
             }
             $remainder->value = [$r];
@@ -667,8 +671,9 @@ abstract class PHP extends Engine
 
         $quotient->is_negative = $x_sign != $y_sign;
 
-        // calculate the "common residue", if appropriate
-        if ($x_sign) {
+        // calculate the "common residue", if appropriate. A remainder of 0 is
+        // already the residue -- see divideHelper's single-digit branch.
+        if ($x_sign && count($x->value)) {
             $y->rshift($shift);
             $x = $y->subtract($x);
         }

--- a/tests/Unit/Math/BigInteger/TestCase.php
+++ b/tests/Unit/Math/BigInteger/TestCase.php
@@ -122,6 +122,28 @@ abstract class TestCase extends PhpseclibTestCase
         $this->assertSame('1', (string) $r);
     }
 
+    public function testDivideNegativeExact()
+    {
+        // The second element of divide() is the "common residue" -- the first
+        // positive modulo -- so only a negative remainder gets the divisor added.
+        // When the division is exact the remainder is already 0, and adding the
+        // divisor returned the modulus itself, which is never a valid residue.
+        // The GMP and BCMath engines returned 0 here; the PHP engines did not.
+        foreach (array(array('-256', '256'), array('-7', '7'), array('-256', '2'), array('-7', '1')) as $pair) {
+            list($a, $b) = $pair;
+            list(, $r) = $this->getInstance($a)->divide($this->getInstance($b));
+            $this->assertSame('0', (string) $r, "$a / $b should leave no remainder");
+            $this->assertNotSame($b, (string) $r, "$a / $b returned the divisor as the residue");
+        }
+
+        // Same again with a divisor too large for the single-digit branch of
+        // divideHelper(), so the general long-division path is covered too.
+        list($q, $r) = $this->getInstance('-340282366920938463463374607431768211456')
+            ->divide($this->getInstance('18446744073709551616'));
+        $this->assertSame('-18446744073709551616', (string) $q);
+        $this->assertSame('0', (string) $r);
+    }
+
     public function testModPow()
     {
         $a = $this->getInstance('10');


### PR DESCRIPTION
Forward-merge of #2167 (the 3.0 fix) into 4.0, as requested in #2165.

The divideHelper change merged cleanly; the only conflict was the new test, resolved
in favour of 4.0's destructuring style. This branch also carries the toString
`??`-precedence fix, which 4.0 needs (unlike 3.0), so the PHP.php change here matches
#2165 exactly.

Verified against the GMP engine across every sign/size combination (0 disagreements),
and toString is clean on zero, small and multi-limb values.
